### PR TITLE
Add a rust-toolchain.toml file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89.0"
+components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
So we're all using the same Rust toolchain