### PR TITLE
Add a scheduler that uses `Tool`.

### DIFF
--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+thiserror = "2.0.16"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/ir/src/edit.rs
+++ b/ir/src/edit.rs
@@ -1,0 +1,125 @@
+use crate::{Id, Representation};
+use std::{collections::HashMap, sync::Arc};
+
+/// A tool for making changes to (a subset of) the IR. When an `Edit` is
+/// created, it is given a limited set of representations which it can modify
+/// (by ID). An `Edit` can replace those representations as well as create new
+/// representations.
+///
+/// The general pattern for a tool to edit an existing ID's Representation is:
+///
+/// 1. Read the Representation out of `context.ir_snapshot`.
+/// 2. Clone the Representation to get an owned copy.
+/// 3. Edit the copied Representation.
+/// 4. Store the edited Representation into `context.ir_edit` using `write_id`.
+pub struct Edit {
+    // Contains every ID this tool can write. IDs that contain Some() will be
+    // written, and IDs that contain None will not be touched.
+    //
+    // Arc<> is used to avoid needing to copy the Representation into HarvestIR
+    // when this edit is merged into the main IR; it is not expected for there
+    // to be other references to these representations.
+    pub(crate) writable: HashMap<Id, Option<Arc<Representation>>>,
+}
+
+impl Edit {
+    /// Creates a new Edit, limited to changing the given set of IDs.
+    pub fn new(might_change: &[Id]) -> Edit {
+        Edit {
+            writable: might_change.iter().map(|&id| (id, None)).collect(),
+        }
+    }
+
+    /// Adds a representation with a new ID and returns the new ID.
+    pub fn add_representation(&mut self, representation: Representation) -> Id {
+        let id = Id::new();
+        self.writable.insert(id, Some(representation.into()));
+        id
+    }
+
+    /// Returns the set of IDs that this `Edit` changes.
+    pub fn changed_ids(&self) -> Vec<Id> {
+        self.writable
+            .iter()
+            .filter(|(_, r)| r.is_some())
+            .map(|(&id, _)| id)
+            .collect()
+    }
+
+    /// Creates a new ID and gives this tool write access to it.
+    pub fn new_id(&mut self) -> Id {
+        let id = Id::new();
+        self.writable.insert(id, None);
+        id
+    }
+
+    /// Writes `representation` to the given `id`. Errors if this tool cannot
+    /// write `id`.
+    pub fn try_write_id(
+        &mut self,
+        id: Id,
+        representation: Representation,
+    ) -> Result<(), NotWritable> {
+        self.writable
+            .get_mut(&id)
+            .map(|v| *v = Some(representation.into()))
+            .ok_or(NotWritable)
+    }
+
+    /// Writes `representation` to the given `id`. Panics if this tool cannot
+    /// write `id`.
+    #[track_caller]
+    pub fn write_id(&mut self, id: Id, representation: Representation) {
+        if self.try_write_id(id, representation).is_err() {
+            panic!("cannot write this id");
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+#[error("cannot write this id")]
+pub struct NotWritable;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::new_representation;
+    use std::panic::catch_unwind;
+
+    #[test]
+    fn edit() {
+        // Checks whether left and right contain the same elements.
+        fn set_equal(left: &[Id], right: &[Id]) -> bool {
+            let mut left: Vec<_> = left.iter().collect();
+            let mut right: Vec<_> = right.iter().collect();
+            left.sort_unstable();
+            right.sort_unstable();
+            left == right
+        }
+
+        let [a, b, c] = Id::new_array();
+        let mut edit = Edit::new(&[a, b]);
+        let d = edit.add_representation(new_representation());
+        let e = edit.new_id();
+        assert_eq!(
+            edit.try_write_id(a, new_representation()),
+            Ok(()),
+            "failed to set writable ID"
+        );
+        assert_eq!(
+            edit.try_write_id(c, new_representation()),
+            Err(NotWritable),
+            "set unwritable ID"
+        );
+        edit.write_id(d, new_representation());
+        edit.write_id(e, new_representation());
+        assert!(
+            set_equal(&edit.changed_ids(), &[a, d, e]),
+            "changed IDs incorrect"
+        );
+        assert!(
+            catch_unwind(move || edit.write_id(c, new_representation())).is_err(),
+            "set unwritable ID"
+        );
+    }
+}

--- a/ir/src/id.rs
+++ b/ir/src/id.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 // practice, we run on 64-bit systems, so that matches usize anyway). NonZeroU64
 // is used to make Option<Id> smaller, because it's easy and doesn't have a
 // downside.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Id(NonZeroU64);
 
 impl Id {

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,14 +1,17 @@
+pub mod edit;
 mod id;
 pub mod raw_source;
 
+pub use edit::Edit;
 pub use id::Id;
-use std::{collections::BTreeMap, fmt::Display, path::Path};
+use std::{collections::BTreeMap, fmt::Display, ops::Deref, sync::Arc};
 
 /// Harvest Intermediate Representation
 ///
 /// The Harvest IR is a collection of [Representation]s of a
 /// program. Transformations of the IR may add or modify
 /// representations.
+#[derive(Clone, Default)]
 pub struct HarvestIR {
     // The IR is composed of a set of [Representation]s identified by
     // some [Id] that is unique to that [Resentation] (at least for a
@@ -16,7 +19,7 @@ pub struct HarvestIR {
     // useful ordering for [Id]s, but for now using an ordered map at
     // least gives us a stable ordering when iterating, e.g. to print
     // the IR.
-    representations: BTreeMap<Id, Representation>,
+    representations: BTreeMap<Id, Arc<Representation>>,
 }
 
 /// An abstract representation of a program
@@ -27,39 +30,60 @@ pub enum Representation {
 }
 
 impl HarvestIR {
-    /// Lift a source code project into a [HarvestIR].
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - the [Path] to the source code project's root directory.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use harvest_ir::HarvestIR;
-    /// # fn main() -> std::io::Result<()> {
-    /// # let dir = tempdir::TempDir::new("harvest_test")?;
-    /// # let path = dir.path();
-    /// let harvest_ir = HarvestIR::from_raw_source(path)?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn from_raw_source<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
-        let dir = std::fs::read_dir(path)?;
-        let root_dir = raw_source::RawDir::populate_from(dir)?;
-        Ok(HarvestIR {
-            representations: [(Id::new(), Representation::RawSource(root_dir))].into(),
-        })
+    pub fn apply_edit(&mut self, edit: Edit) {
+        for (id, representation) in edit.writable {
+            if let Some(representation) = representation {
+                self.representations.insert(id, representation);
+            }
+        }
     }
 }
 
 impl Display for HarvestIR {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for r in self.representations.values() {
-            match r {
+            match r.deref() {
                 Representation::RawSource(r) => r.display(0, f)?,
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raw_source::RawDir;
+    use std::fs::read_dir;
+    use tempdir::TempDir;
+
+    /// Returns a new Representation (for code that needs a Representation but
+    /// doesn't care what it is).
+    pub(crate) fn new_representation() -> Representation {
+        Representation::RawSource(
+            RawDir::populate_from(read_dir(TempDir::new("harvest_test").unwrap().path()).unwrap())
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn apply_edit() {
+        let initial_ir = Id::new_array::<3>().map(|i| (i, new_representation().into()));
+        let mut ir = HarvestIR {
+            representations: initial_ir.clone().into_iter().collect(),
+        };
+        let [(a, a_repr), (b, b_repr), (c, _)] = initial_ir;
+        let mut edit = Edit::new(&[b, c]);
+        edit.write_id(c, new_representation());
+        let c_repr = edit.writable[&c].clone().unwrap();
+        let d = edit.add_representation(new_representation());
+        let d_repr = edit.writable[&d].clone().unwrap();
+        edit.new_id();
+        ir.apply_edit(edit);
+        assert_eq!(ir.representations.len(), 4);
+        assert!(Arc::ptr_eq(&a_repr, &ir.representations[&a]));
+        assert!(Arc::ptr_eq(&b_repr, &ir.representations[&b]));
+        assert!(Arc::ptr_eq(&c_repr, &ir.representations[&c]));
+        assert!(Arc::ptr_eq(&d_repr, &ir.representations[&d]));
     }
 }

--- a/translate/src/main.rs
+++ b/translate/src/main.rs
@@ -1,13 +1,19 @@
 mod cli;
-mod tool;
+mod scheduler;
+mod tools;
 
 use clap::Parser as _;
 use cli::Args;
-use harvest_ir::HarvestIR;
+use scheduler::Scheduler;
+use tools::{ToolInvocation, load_raw_source};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    let harvest_ir = HarvestIR::from_raw_source(args.in_performer)?;
-    println!("{harvest_ir}");
+    let mut scheduler = Scheduler::default();
+    scheduler.queue_invocation(ToolInvocation::LoadRawSource(load_raw_source::Args {
+        directory: args.in_performer,
+    }));
+    scheduler.main_loop();
+    println!("{}", scheduler.ir_snapshot());
     Ok(())
 }

--- a/translate/src/scheduler.rs
+++ b/translate/src/scheduler.rs
@@ -1,0 +1,60 @@
+//! # harvest_translate scheduler
+//!
+//! The scheduler is responsible for determining which tools to invoke and also
+//! for invoking them. It is effectively the main loop of harvest_translate.
+
+use crate::tools::{Context, ToolInvocation};
+use harvest_ir::HarvestIR;
+use std::sync::Arc;
+
+#[derive(Default)]
+pub struct Scheduler {
+    ir: Arc<HarvestIR>,
+    queued_invocations: Vec<ToolInvocation>,
+}
+
+impl Scheduler {
+    /// Returns the current IR snapshot.
+    pub fn ir_snapshot(&self) -> Arc<HarvestIR> {
+        self.ir.clone()
+    }
+
+    /// The scheduler main loop -- invokes tools until done.
+    pub fn main_loop(&mut self) {
+        // TODO: This is just a temporary implementation to make the
+        // LoadRawSource invocation run; this all needs to be restructured to
+        // fit the design doc.
+        for invocation in &self.queued_invocations {
+            let mut tool = invocation.create_tool();
+            // TODO: Diagnostics for tools that are not runnable (which is not
+            // necessarily an error).
+            let Some(ids) = tool.might_write(&self.ir) else {
+                continue;
+            };
+            // TODO: Track which IDs are in use and allow tools to write IDs.
+            // This implementation is conservative which is correct but too
+            // limited (tools can only add new IDs).
+            if !ids.is_empty() {
+                continue;
+            };
+            // TODO: Catch panics and handle errors appropriately.
+            let mut ir_edit = harvest_ir::Edit::new(&ids);
+            tool.run(Context {
+                ir_edit: &mut ir_edit,
+                ir_snapshot: self.ir.clone(),
+            })
+            .expect("tool invocation failed");
+            // TODO: Verify that ir_edit doesn't touch any IDs that might_write
+            // did not return (it's theoretically possible -- though not
+            // sensible -- for tools to replace ir_edit entirely).
+            Arc::make_mut(&mut self.ir).apply_edit(ir_edit);
+        }
+    }
+
+    /// Add a tool invocation to the scheduler's queue. Note that scheduling a
+    /// tool invocation does not guarantee the tool will run, as a tool may
+    /// indicate that it is not runnable.
+    pub fn queue_invocation(&mut self, invocation: ToolInvocation) {
+        self.queued_invocations.push(invocation);
+    }
+}

--- a/translate/src/tools/load_raw_source.rs
+++ b/translate/src/tools/load_raw_source.rs
@@ -1,0 +1,37 @@
+//! Lifts a source code project into a RawSource representation.
+
+use crate::tools::{Context, Tool};
+use harvest_ir::{HarvestIR, Id, Representation, raw_source::RawDir};
+use std::{fs::read_dir, path::PathBuf};
+
+pub struct Args {
+    /// The path to the source code project's root directory.
+    pub directory: PathBuf,
+}
+
+pub struct LoadRawSource {
+    directory: Option<PathBuf>,
+}
+
+impl LoadRawSource {
+    pub fn new(args: &Args) -> LoadRawSource {
+        LoadRawSource {
+            directory: Some(args.directory.clone()),
+        }
+    }
+}
+
+impl Tool for LoadRawSource {
+    // LoadRawSource will create a new representation, not modify an existing
+    // one.
+    fn might_write(&mut self, _ir: &HarvestIR) -> Option<Vec<Id>> {
+        Some(vec![])
+    }
+
+    fn run(&mut self, context: Context) -> Result<(), Box<dyn std::error::Error>> {
+        let dir = read_dir(self.directory.take().ok_or("already run")?)?;
+        let representation = Representation::RawSource(RawDir::populate_from(dir)?);
+        context.ir_edit.add_representation(representation);
+        Ok(())
+    }
+}


### PR DESCRIPTION
This adds the interfaces (`harvest_ir::Edit`, `tool::Context`) that tools use to read and write the IR. It adds a scheduler that is capable of invoking tools.

I refactored the "load source code" step to fit into the tool framework and made `main()` queue it so it runs.