### PR TITLE
CRUST-bench integration + parallel execution + type-safe plans

### DIFF
--- a/ir/src/id.rs
+++ b/ir/src/id.rs
@@ -34,48 +34,84 @@ impl Id {
         // The highest ID allocated so far. Each new_array() call starts
         // allocating IDs at HIGHEST_ID + 1.
         static HIGHEST_ID: AtomicU64 = AtomicU64::new(0);
-        // prev is the ID number immediately before the ID we are currently
-        // trying to construct.
-        let mut prev = HIGHEST_ID.fetch_add(LEN.try_into().expect("LEN > u64::MAX"), Relaxed);
-        [(); LEN].map(|_| {
-            let Some(num) = prev.checked_add(1).and_then(NonZeroU64::new) else {
-                // We don't have any way to continue execution on overflow. If
-                // we try to panic, this tool invocation will fail, but the
-                // panic will be caught and we'll just run into this again.
-                // Fortunately, it's basically impossible for this to overflow,
-                // so we won't hit this case in any useful harvest_translate
-                // execution.
-                eprintln!("IR ID allocation overflow, cannot continue");
-                abort();
-            };
-            prev = num.get();
-            Id(num)
-        })
+        new_array_testable(&HIGHEST_ID)
     }
+}
+
+// `Id::new_array`, but with an injected AtomicU64. This allows `tests::new` to
+// use its own AtomicU64, which prevents other tests that are run in parallel
+// from interfering with it.
+fn new_array_testable<const LEN: usize>(highest_id: &AtomicU64) -> [Id; LEN] {
+    // prev is the ID number immediately before the ID we are currently trying
+    // to construct.
+    let mut prev = highest_id.fetch_add(LEN.try_into().expect("LEN > u64::MAX"), Relaxed);
+    [(); LEN].map(|_| {
+        let Some(num) = prev.checked_add(1).and_then(NonZeroU64::new) else {
+            // We don't have any way to continue execution on overflow. If we
+            // try to panic, this tool invocation will fail, but the panic will
+            // be caught and we'll just run into this again. Fortunately, it's
+            // basically impossible for this to overflow, so we won't hit this
+            // case in any useful harvest_translate execution.
+            eprintln!("IR ID allocation overflow, cannot continue");
+            abort();
+        };
+        prev = num.get();
+        Id(num)
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::thread::spawn;
+    use std::collections::HashSet;
+    use std::thread::{scope, spawn};
 
-    /// Verifies that new() and new_array() work properly.
+    // Verifies that Id::new and Id::new_array return unique IDs (to verify they
+    // correctly use new_array_testable).
     #[test]
     fn new() {
+        let one_at_a_time = spawn(|| (0..100).map(|_| Id::new()).collect());
+        let all_at_once = Id::new_array::<100>();
+        let mut ids: Vec<_> = one_at_a_time.join().unwrap();
+        ids.extend(all_at_once);
+        let deduplicated: HashSet<Id> = ids.iter().copied().collect();
+        assert_eq!(ids.len(), deduplicated.len(), "duplicate ID");
+    }
+
+    // Verifies that new_array_testable works as designed. The contract of Id is
+    // simply that each generated ID is unique, but if we simply generate N
+    // random u64s (for a reasonably-sized N) then uniqueness is likely to
+    // happen by accident. Instead, this specifically tests that the IDs are
+    // sequential and start at 1 to verify the implementation is behaving as
+    // intended.
+    #[test]
+    fn new_implementation() {
+        let highest_id = &AtomicU64::new(0);
         // Generate IDs from three unsynchronized threads, hoping they run at
         // the same time. Each thread uses a different strategy, but each thread
         // generates exactly 1000 IDs.
-        let one_at_a_time = spawn(|| (0..1000).map(|_| Id::new()).collect());
-        let chunks = spawn(|| (0..10).map(|_| Id::new_array::<100>()).flatten().collect());
-        let all_at_once = Id::new_array::<1000>().into();
-        let chunks: Vec<_> = chunks.join().unwrap();
-        let one_at_a_time: Vec<_> = one_at_a_time.join().unwrap();
-        // The contract of Id is that each ID is unique, but that's easy to
-        // achieve by generating 3000 random u64s. This loop instead verifies
-        // the internal implementation by verifying that the IDs generated are
-        // exactly 1..=3000.
+        let id_vecs: [Vec<Id>; 3] = scope(|s| {
+            let one_at_a_time = s.spawn(|| {
+                (0..1000)
+                    .map(|_| new_array_testable::<1>(highest_id)[0])
+                    .collect()
+            });
+            let chunks = s.spawn(|| {
+                (0..10)
+                    .map(|_| new_array_testable::<100>(highest_id))
+                    .flatten()
+                    .collect()
+            });
+            let all_at_once = new_array_testable::<1000>(highest_id).into();
+            [
+                all_at_once,
+                chunks.join().unwrap(),
+                one_at_a_time.join().unwrap(),
+            ]
+        });
+        // This loop verifies the IDs generated are exactly 1..=3000.
         let mut found = [false; 3000];
-        for Id(n) in [all_at_once, chunks, one_at_a_time].iter().flatten() {
+        for Id(n) in id_vecs.iter().flatten() {
             let entry = found.get_mut(n.get() as usize - 1).expect("too-large ID");
             assert!(!*entry, "duplicate ID {}", n);
             *entry = true;


### PR DESCRIPTION
## Summary

Integrates CRUST-bench into harvest-tools alongside the existing HARVEST Test-Corpus pipeline.

**CRUST Results: 85/96 projects pass (88.5%)**, 0 build failures.
4 projects skipped due to dataset bugs (issues filed on CRUST-bench repo: [#37](https://github.com/anirudhkhatry/CRUST-bench/issues/37), [#39](https://github.com/anirudhkhatry/CRUST-bench/issues/39), [#40](https://github.com/anirudhkhatry/CRUST-bench/issues/40), [#41](https://github.com/anirudhkhatry/CRUST-bench/issues/41)).

### Key Changes

**CRUST-bench Integration**
- `Dataset` enum (`TestCorpus` / `Crust`) with auto-detection from target name
- `CrustProject` newtype: skip list enforced at construction, paths resolved once
- Scaffold setup: moves `src/interfaces/*.rs` → `src/` (matches CRUST-bench methodology)
- CRUST prompt: fill `unimplemented!()` bodies, 60s test timeout, re-read C on failure
- `cargo test` validation with 60s timeout matching official methodology

**Type-Safe Execution Plans**
- `TranslatePlan` / `VerifyPlan` / `TestPlan` enums — each variant carries only valid parameters
- `limit` only on `Crust`, `verify` only on `TestCorpus` (compile-time enforcement)

**Parallel Execution**
- `--parallel N` + `--limit N` for CRUST translation
- Semaphore-gated `thread::scope`, threads return `CaseResult` values

**Infrastructure**
- `IsolatedWorkDir`: RAII temp dir for translate/verify (no config names leak to agent)
- Symlink-safe `copy_dir_all` / `copy_dir_filtered`
- `OPENSSL_DIR` in test runner, `.vsync` cleanup, translation logs preserved

### CLI
```bash
harvest-tools --agent kiro run CRUST/amp           # single project
harvest-tools --agent kiro run CRUST --parallel 4  # all projects
harvest-tools --agent kiro run CRUST --parallel 3 --limit 40
```