### PR TITLE
Rename `harvest_ir::raw_source` to `harvest_ir::fs`.

### DIFF
--- a/ir/src/fs.rs
+++ b/ir/src/fs.rs
@@ -1,3 +1,6 @@
+//! Type representing a filesystem. Example use cases: representing a C source project, a Cargo
+//! project, etc.
+
 use std::{collections::BTreeMap, ffi::OsString, fs::ReadDir};
 
 /// A representation of a file-system directory entry.
@@ -36,7 +39,7 @@ impl RawDir {
     /// # Examples
     ///
     /// ```
-    /// # use harvest_ir::raw_source::RawDir;
+    /// # use harvest_ir::fs::RawDir;
     /// # fn main() -> std::io::Result<()> {
     /// # let dir = tempdir::TempDir::new("harvest_test")?;
     /// # let path = dir.path();

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod edit;
+pub mod fs;
 mod id;
-pub mod raw_source;
 
 pub use edit::Edit;
 pub use id::Id;
@@ -26,7 +26,7 @@ pub struct HarvestIR {
 pub enum Representation {
     /// An verbatim copy of the original source code project's
     /// directories and files.
-    RawSource(raw_source::RawDir),
+    RawSource(fs::RawDir),
 }
 
 impl HarvestIR {
@@ -53,7 +53,7 @@ impl Display for HarvestIR {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::raw_source::RawDir;
+    use crate::fs::RawDir;
     use std::fs::read_dir;
     use tempdir::TempDir;
 

--- a/translate/src/tools/load_raw_source.rs
+++ b/translate/src/tools/load_raw_source.rs
@@ -1,7 +1,7 @@
 //! Lifts a source code project into a RawSource representation.
 
 use crate::tools::{Context, Tool};
-use harvest_ir::{HarvestIR, Id, Representation, raw_source::RawDir};
+use harvest_ir::{HarvestIR, Id, Representation, fs::RawDir};
 use std::{fs::read_dir, path::PathBuf};
 
 pub struct Args {


### PR DESCRIPTION
I want to use these types to represent an output Cargo project, not just the input project. Therefore, I'm renaming this to `fs` to separate it from `Representation::RawSource`.

Makes progress on #16.