### PR TITLE
Run tests in Miri.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,4 @@ test:
 	RUSTFLAGS="-D warnings" cargo test
 	RUSTFLAGS="-D warnings" cargo clippy
 	cargo fmt --check
+	cd nightly && cargo miri test --manifest-path=../Cargo.toml

--- a/ir/src/fs.rs
+++ b/ir/src/fs.rs
@@ -47,6 +47,8 @@ impl RawDir {
     ///
     /// ```
     /// # use harvest_ir::fs::RawDir;
+    /// # #[cfg(miri)] fn main() {}
+    /// # #[cfg(not(miri))]
     /// # fn main() -> std::io::Result<()> {
     /// # let dir = tempdir::TempDir::new("harvest_test")?;
     /// # let path = dir.path();

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -69,16 +69,11 @@ impl Display for HarvestIR {
 mod tests {
     use super::*;
     use crate::fs::RawDir;
-    use std::fs::read_dir;
-    use tempdir::TempDir;
 
     /// Returns a new Representation (for code that needs a Representation but
     /// doesn't care what it is).
     pub(crate) fn new_representation() -> Representation {
-        Representation::RawSource(
-            RawDir::populate_from(read_dir(TempDir::new("harvest_test").unwrap().path()).unwrap())
-                .unwrap(),
-        )
+        Representation::RawSource(RawDir::default())
     }
 
     #[test]

--- a/nightly/rust-toolchain.toml
+++ b/nightly/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-10-10"
+components = ["miri", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
Question: Do we want to keep our tests runnable under Miri?

When I implemented the ID allocation, I ran its test under Miri, because Miri has features for detecting atomics-related bugs. I'd like to retain the ability to run our tests under Miri, but there are some drawbacks:

1. By default, Miri disallows filesystem access, which some of our tests use. This can be disabled with the -Zmiri-disable-isolation flag.
2. The additional complexity of having a nightly toolchain + running Miri in CI to verify it still works.