### PR TITLE
Implement configuration using the `config` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ resolver = "3"
 
 [workspace.dependencies]
 harvest_ir = { path = "ir" }
+tempfile = "3.23.0"

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -1,0 +1,24 @@
+# Configuration
+
+## Configuration file
+
+`harvest-translate` reads configuration values from a config file in TOML
+format. The location is OS-dependent; to print the location, run:
+
+```
+cargo run -p harvest_translate -- --print-config-path
+```
+
+You can see an example of the syntax at `translate/default_config.toml`.
+
+## Configuration flag
+
+Additionally, configuration values can be specified on the command line using
+`--config`. For example, to set the LLM server address for the
+raw_source_to_cargo_llm tool, run:
+
+```
+cargo run -p harvest_translate --release -- --config tools.raw_source_to_cargo_llm.address=127.0.0.1
+```
+
+The `--config` flag overrides configuration from the configuration file.

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 thiserror = "2.0.16"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = { workspace = true }

--- a/ir/src/fs.rs
+++ b/ir/src/fs.rs
@@ -50,7 +50,7 @@ impl RawDir {
     /// # #[cfg(miri)] fn main() {}
     /// # #[cfg(not(miri))]
     /// # fn main() -> std::io::Result<()> {
-    /// # let dir = tempdir::TempDir::new("harvest_test")?;
+    /// # let dir = tempfile::tempdir().unwrap();
     /// # let path = dir.path();
     /// let raw_dir = RawDir::populate_from(std::fs::read_dir(path)?)?;
     /// # Ok(())

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -5,8 +5,11 @@ edition = "2024"
 
 [dependencies]
 clap = { features = ["derive"], version = "4.5.45" }
+config = { default-features = false, features = ["toml"], version = "0.15.18" }
+directories = "6.0.0"
 harvest_ir = { workspace = true }
 llm = { default-features = false, features = ["ollama"], version = "1.3.4" }
 serde = "1.0.228"
 serde_json = "1.0.145"
+tempfile = { workspace = true }
 tokio = { features = ["net", "rt"], version = "1.47.1" }

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -1,0 +1,6 @@
+# The default configurations options for harvest_translate.
+
+[tools.raw_source_to_cargo_llm]
+address = "[::1]:11434"
+backend = "ollama"
+model = "codellama:7b"

--- a/translate/src/cli.rs
+++ b/translate/src/cli.rs
@@ -1,16 +1,192 @@
+use crate::tools;
 use clap::Parser;
-use std::path::PathBuf;
+use config::FileFormat::Toml;
+use directories::ProjectDirs;
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 
 #[derive(Debug, Parser)]
 pub struct Args {
-    // Currently, this is the only input format supported, so --in_performer is
-    // required. However, in the future, we'll want to be able to take a
-    // different input format that conveys more information (such as the version
-    // control history, code review comments, etc). When that format has been
-    // defined, we'll add a separate flag to specify it, and change the
-    // requirement to "pass either --in_performer or the other input flag".
+    /// Set a configuration value; format $NAME=$VALUE.
+    #[arg(long, short)]
+    pub config: Vec<String>,
+
     /// Path to the C code to translate. This path should be a directory in the
     /// project structure defined by the TRACTOR_Performers library.
     #[arg(long)]
+    pub in_performer: Option<PathBuf>,
+
+    /// Prints out the location of the config file.
+    #[arg(long)]
+    pub print_config_path: bool,
+}
+
+/// Configuration for this harvest-translate run. The sources of these configuration values (from
+/// highest-precedence to lowest-precedence) are:
+///
+/// 1. Configurations passed using the `--config` command line flag.
+/// 2. A user-specific configuration directory (e.g. `$HOME/.config/harvest/config.toml').
+/// 3. Defaults specified in the code (using `#[serde(default)]`).
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    // Currently, this is the only input format supported, so in_performer is required. However, in
+    // the future, we'll want to be able to take a different input format that conveys more
+    // information (such as the version control history, code review comments, etc). When that
+    // format has been defined, we'll add a separate config option to specify it, and change the
+    // requirement to "specify either in_performer or the other input option".
+    /// Path to the C code to translate. This path should be a directory in the
+    /// project structure defined by the TRACTOR_Performers library.
     pub in_performer: PathBuf,
+
+    /// Sub-configuration for each tool.
+    pub tools: tools::Config,
+
+    // serde will place any unrecognized fields here. This will be passed to unknown_field_warning
+    // after parsing to emit warnings on unrecognized config entries (we don't error on unknown
+    // fields because that can be annoying to work with if you are switching back and forth between
+    // commits that have different config options).
+    #[serde(flatten)]
+    unknown: HashMap<String, Value>,
+}
+
+/// Returns the configuration.
+pub fn get_config() -> Arc<Config> {
+    CONFIG
+        .get()
+        .expect("configuration not initialized yet")
+        .clone()
+}
+
+/// Performs parsing and validation of the config; to be called by main() before executing any code
+/// that tries to retrieve the config.
+///
+/// Returns true if a command line flag that calls for an early exit (such as --print_config_path)
+/// was provided.
+pub fn initialize() -> bool {
+    let args: Arc<_> = Args::parse().into();
+    ARGS.set(args.clone()).expect("cli already initialized");
+    let dirs = ProjectDirs::from("", "", "harvest").expect("no home directory");
+    if args.print_config_path {
+        println!("Config file location: {:?}", config_file(dirs.config_dir()));
+        return true;
+    }
+    let config = load_config(&args, dirs.config_dir());
+    unknown_field_warning("", &config.unknown);
+    config.tools.validate();
+    CONFIG.set(config.into()).expect("cli already initialized");
+    false
+}
+
+/// Prints out a warning message for every field in `unknown`.
+///
+/// This is intended for use by config validation routines. `prefix` should be the path to this
+/// entry (e.g. `tools::Config` should call this with a `prefix` of `tools`).
+pub fn unknown_field_warning(prefix: &str, unknown: &HashMap<String, Value>) {
+    let mut entries: Vec<_> = unknown.keys().collect();
+    entries.sort_unstable();
+    entries.into_iter().for_each(|name| match prefix {
+        "" => eprintln!("Warning: unknown config key {name}"),
+        p => eprintln!("Warning: unknown config key {p}.{name}"),
+    });
+}
+
+static ARGS: OnceLock<Arc<Args>> = OnceLock::new();
+static CONFIG: OnceLock<Arc<Config>> = OnceLock::new();
+
+fn load_config(args: &Args, config_dir: &Path) -> Config {
+    let mut settings = config::Config::builder()
+        .add_source(config::File::from_str(
+            include_str!("../default_config.toml"),
+            Toml,
+        ))
+        .add_source(config::File::from(config_file(config_dir)).required(false));
+    for config_arg in &args.config {
+        let Some((name, value)) = config_arg.split_once('=') else {
+            panic!("failed to parse config value {config_arg:?}; no '=' found");
+        };
+        settings = settings
+            .set_override(name, value)
+            .expect("settings override failed");
+    }
+    // If --in_performer was passed, we need to set an override so that deserializing the config
+    // does not error. However, the config crate does not support providing a Path in an override.
+    // We could convert to a string and back, but that can be lossy. Instead, this just sets a
+    // blank value and then corrects it after deserialization.
+    if args.in_performer.is_some() {
+        settings = settings
+            .set_override("in_performer", " ")
+            .expect("settings override failed");
+    }
+    let mut config: Config = settings
+        .build()
+        .expect("failed to build settings")
+        .try_deserialize()
+        .expect("config deserialization failed");
+    if let Some(ref performer) = args.in_performer {
+        config.in_performer = performer.clone();
+    }
+    config
+}
+
+/// Returns the config file path, given the config directory.
+fn config_file(config_dir: &Path) -> PathBuf {
+    [config_dir, "translate.toml".as_ref()].iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(miri))]
+    #[test]
+    fn load_config_test() {
+        use super::*;
+        use crate::test_util::tempdir;
+        use std::{fs, io::Write as _};
+        let config_dir = tempdir().unwrap();
+
+        assert_eq!(
+            load_config(
+                &Args::parse_from(["", "--in-performer=a"]),
+                config_dir.path(),
+            )
+            .in_performer,
+            AsRef::<Path>::as_ref("a")
+        );
+
+        fs::File::create(config_file(config_dir.path()))
+            .unwrap()
+            .write(
+                br#"
+                    in_performer = "b"
+                    [tools.raw_source_to_cargo_llm]
+                    address = "127.0.0.1"
+                    model = "gpt-oss"
+                "#,
+            )
+            .unwrap();
+        assert_eq!(
+            load_config(&Args::parse_from([""]), config_dir.path()).in_performer,
+            AsRef::<Path>::as_ref("b")
+        );
+        // Verify the --config flag overrides the user's config file.
+        assert_eq!(
+            load_config(
+                &Args::parse_from(["", "--config", "in_performer=c"]),
+                config_dir.path()
+            )
+            .in_performer,
+            AsRef::<Path>::as_ref("c")
+        );
+        // Verify --in-performer overrides all the configuration options.
+        assert_eq!(
+            load_config(
+                &Args::parse_from(["", "--config", "in_performer=d", "--in-performer=d"]),
+                config_dir.path()
+            )
+            .in_performer,
+            AsRef::<Path>::as_ref("d")
+        );
+    }
 }

--- a/translate/src/main.rs
+++ b/translate/src/main.rs
@@ -2,16 +2,20 @@ mod cli;
 mod scheduler;
 mod tools;
 
-use clap::Parser as _;
-use cli::Args;
+#[cfg(test)]
+mod test_util;
+
+use cli::get_config;
 use scheduler::Scheduler;
 use tools::{ToolInvocation, load_raw_source};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args = Args::parse();
+    if cli::initialize() {
+        return Ok(()); // An early-exit argument was passed.
+    }
     let mut scheduler = Scheduler::default();
     scheduler.queue_invocation(ToolInvocation::LoadRawSource(load_raw_source::Args {
-        directory: args.in_performer,
+        directory: get_config().in_performer.clone(),
     }));
     scheduler.queue_invocation(ToolInvocation::RawSourceToCargoLlm);
     scheduler.main_loop();

--- a/translate/src/test_util.rs
+++ b/translate/src/test_util.rs
@@ -1,0 +1,15 @@
+//! Place to put utilities that are only used by tests.
+
+/// Returns a new temporary directory. Unlike the defaults in the `tempdir` and `tempfile` crates,
+/// this directory is not world-accessible by default.
+#[cfg(not(miri))]
+pub fn tempdir() -> std::io::Result<tempfile::TempDir> {
+    use std::fs::Permissions;
+    let mut builder = tempfile::Builder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(Permissions::from_mode(0o700));
+    }
+    builder.tempdir()
+}

--- a/translate/src/tools/mod.rs
+++ b/translate/src/tools/mod.rs
@@ -1,8 +1,26 @@
 pub mod load_raw_source;
 pub mod raw_source_to_cargo_llm;
 
+use crate::cli::unknown_field_warning;
 use harvest_ir::{Edit, HarvestIR, Id};
-use std::sync::Arc;
+use serde::Deserialize;
+use serde_json::Value;
+use std::{collections::HashMap, sync::Arc};
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    raw_source_to_cargo_llm: raw_source_to_cargo_llm::Config,
+
+    #[serde(flatten)]
+    unknown: HashMap<String, Value>,
+}
+
+impl Config {
+    pub fn validate(&self) {
+        unknown_field_warning("tools", &self.unknown);
+        self.raw_source_to_cargo_llm.validate();
+    }
+}
 
 /// A tool invocation that the scheduler could choose to perform.
 pub enum ToolInvocation {


### PR DESCRIPTION
This loads configuration from three places, in increasing order of precedence:

1. A default configuration file.
2. A per-user config file (the location depends on the OS and can be printed using --print-config-path).
3. A new `--config` command line argument.

I've realized that the configuration and command line interface have a lot of overlap and probably belong together. Calling the module `config` seems sensible because I expect the configuration to be larger than the CLI, but there are too many `config`s in the code, so I kept the module name (`cli`) as-is.

I migrated from `tempdir` to `tempfile`; `tempdir` is deprecated in favor of `tempfile` and `tempfile` allows us to set the permissions on the temporary directory.

Closes #14 