### PR TITLE
Add rust-analyzer to toolchain for IDEs

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.90.0"
-components = [ "clippy", "rustfmt" ]
+components = [ "clippy", "rustfmt", "rust-analyzer" ]


### PR DESCRIPTION
I need it for my setup, but this basically ensures that the available `rust-analyzer` LSP server is from the same version as the compiler toolchain from rustup.