### PR TITLE
Add simple `materialize(path)` method to representations

### DIFF
--- a/ir/src/fs.rs
+++ b/ir/src/fs.rs
@@ -187,6 +187,24 @@ impl RawDir {
         };
         Ok(out)
     }
+
+    /// Materializes the [RawDir] to the file system.
+    ///
+    /// `path` is a path to an empty or non-existent directory noting
+    /// where the file system should be materialized to.
+    pub fn materialize<P: AsRef<Path>>(&self, base_path: P) -> std::io::Result<()> {
+        let base_path = base_path.as_ref();
+        for (file_path, contents) in self.files_recursive().iter() {
+            let dir_path = if let Some(parent) = file_path.parent() {
+                base_path.join(parent)
+            } else {
+                base_path.into()
+            };
+            std::fs::create_dir(dir_path)?;
+            std::fs::write(base_path.join(file_path), contents)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Eq, Hash, PartialEq, thiserror::Error)]

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -4,7 +4,7 @@ mod id;
 
 pub use edit::Edit;
 pub use id::Id;
-use std::{collections::BTreeMap, fmt::Display, ops::Deref, sync::Arc};
+use std::{collections::BTreeMap, fmt::Display, ops::Deref, path::Path, sync::Arc};
 
 /// Harvest Intermediate Representation
 ///
@@ -30,6 +30,21 @@ pub enum Representation {
     /// An verbatim copy of the original source code project's
     /// directories and files.
     RawSource(fs::RawDir),
+}
+
+impl Representation {
+    /// Materialize the [Representation] to a directory at the
+    /// provided `path`.
+    ///
+    /// Materializing stores an on-disk version of the
+    /// [Representation]. The format is specific to each
+    /// [Representation] variant.
+    pub fn materialize<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
+        match self {
+            Representation::CargoPackage(raw_dir) => raw_dir.materialize(path),
+            Representation::RawSource(raw_dir) => raw_dir.materialize(path),
+        }
+    }
 }
 
 impl HarvestIR {

--- a/translate/src/main.rs
+++ b/translate/src/main.rs
@@ -19,6 +19,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }));
     scheduler.queue_invocation(ToolInvocation::RawSourceToCargoLlm);
     scheduler.main_loop();
-    println!("{}", scheduler.ir_snapshot());
+    let ir = scheduler.ir_snapshot();
+    println!("{}", ir);
+
+    for (_, representation) in ir.iter() {
+        if let repr @ harvest_ir::Representation::CargoPackage(_) = representation {
+            repr.materialize(get_config().output.clone())?;
+            break;
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
Materialize the first found `CargoPackage` representation found at the end of the pipeline.