### PR TITLE
Make Tool::might_write return a HashSet.

### DIFF
--- a/ir/src/edit.rs
+++ b/ir/src/edit.rs
@@ -1,5 +1,6 @@
 use crate::{Id, Representation};
-use std::{collections::HashMap, sync::Arc};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 /// A tool for making changes to (a subset of) the IR. When an `Edit` is
 /// created, it is given a limited set of representations which it can modify
@@ -24,7 +25,7 @@ pub struct Edit {
 
 impl Edit {
     /// Creates a new Edit, limited to changing the given set of IDs.
-    pub fn new(might_change: &[Id]) -> Edit {
+    pub fn new(might_change: &HashSet<Id>) -> Edit {
         Edit {
             writable: might_change.iter().map(|&id| (id, None)).collect(),
         }
@@ -98,7 +99,7 @@ mod tests {
         }
 
         let [a, b, c] = Id::new_array();
-        let mut edit = Edit::new(&[a, b]);
+        let mut edit = Edit::new(&[a, b].into());
         let d = edit.add_representation(new_representation());
         let e = edit.new_id();
         assert_eq!(

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -98,7 +98,7 @@ mod tests {
             representations: initial_ir.clone().into_iter().collect(),
         };
         let [(a, a_repr), (b, b_repr), (c, _)] = initial_ir;
-        let mut edit = Edit::new(&[b, c]);
+        let mut edit = Edit::new(&[b, c].into());
         edit.write_id(c, new_representation());
         let c_repr = edit.writable[&c].clone().unwrap();
         let d = edit.add_representation(new_representation());

--- a/translate/src/tools/load_raw_source.rs
+++ b/translate/src/tools/load_raw_source.rs
@@ -2,7 +2,7 @@
 
 use crate::tools::{Context, Tool};
 use harvest_ir::{HarvestIR, Id, Representation, fs::RawDir};
-use std::{fs::read_dir, path::PathBuf};
+use std::{collections::HashSet, fs::read_dir, path::PathBuf};
 
 pub struct Args {
     /// The path to the source code project's root directory.
@@ -24,8 +24,8 @@ impl LoadRawSource {
 impl Tool for LoadRawSource {
     // LoadRawSource will create a new representation, not modify an existing
     // one.
-    fn might_write(&mut self, _ir: &HarvestIR) -> Option<Vec<Id>> {
-        Some(vec![])
+    fn might_write(&mut self, _ir: &HarvestIR) -> Option<HashSet<Id>> {
+        Some([].into())
     }
 
     fn run(&mut self, context: Context) -> Result<(), Box<dyn std::error::Error>> {

--- a/translate/src/tools/mod.rs
+++ b/translate/src/tools/mod.rs
@@ -5,7 +5,8 @@ use crate::cli::unknown_field_warning;
 use harvest_ir::{Edit, HarvestIR, Id};
 use serde::Deserialize;
 use serde_json::Value;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
@@ -60,7 +61,7 @@ pub trait Tool: Send {
     /// 1. The tool requires input data that `ir` does not have.
     /// 2. The tool creates data that already exists in `ir` so there is nothing
     ///    to do.
-    fn might_write(&mut self, ir: &HarvestIR) -> Option<Vec<Id>>;
+    fn might_write(&mut self, ir: &HarvestIR) -> Option<HashSet<Id>>;
 
     /// Runs the tool logic. IR access and edits are made using `context`.
     ///

--- a/translate/src/tools/raw_source_to_cargo_llm.rs
+++ b/translate/src/tools/raw_source_to_cargo_llm.rs
@@ -8,7 +8,9 @@ use llm::builder::{LLMBackend, LLMBuilder};
 use llm::chat::{ChatMessage, StructuredOutputFormat};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::str::FromStr;
 
 /// Structured output JSON schema for Ollama.
 const STRUCTURED_OUTPUT_SCHEMA: &str =
@@ -19,9 +21,9 @@ const SYSTEM_PROMPT: &str = include_str!("raw_source_to_cargo_llm/system_prompt.
 pub struct RawSourceToCargoLlm;
 
 impl Tool for RawSourceToCargoLlm {
-    fn might_write(&mut self, ir: &HarvestIR) -> Option<Vec<Id>> {
+    fn might_write(&mut self, ir: &HarvestIR) -> Option<HashSet<Id>> {
         // We need a raw_source to be available, but we won't write any existing IDs.
-        raw_source(ir).map(|_| vec![])
+        raw_source(ir).map(|_| [].into())
     }
 
     fn run(&mut self, context: Context) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
The order of IDs returned by Tool::might_write does not matter, and duplicate IDs should not exist. Therefore a HashSet is conceptually a better fit for the return type than a Vec.