### PR TITLE
Make `ToolInvocation` a trait instead of an `enum`

### DIFF
--- a/translate/src/main.rs
+++ b/translate/src/main.rs
@@ -7,7 +7,7 @@ mod test_util;
 
 use cli::get_config;
 use scheduler::Scheduler;
-use tools::{ToolInvocation, load_raw_source};
+use tools::{load_raw_source, raw_source_to_cargo_llm};
 
 fn main() {
     if let Err(e) = run() {
@@ -22,10 +22,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(()); // An early-exit argument was passed.
     }
     let mut scheduler = Scheduler::default();
-    scheduler.queue_invocation(ToolInvocation::LoadRawSource(load_raw_source::Args {
+    scheduler.queue_invocation(load_raw_source::Invocation {
         directory: get_config().in_performer.clone(),
-    }));
-    scheduler.queue_invocation(ToolInvocation::RawSourceToCargoLlm);
+    });
+    scheduler.queue_invocation(raw_source_to_cargo_llm::Invocation);
     scheduler.main_loop()?;
     let ir = scheduler.ir_snapshot();
     log::info!("{}", ir);

--- a/translate/src/scheduler.rs
+++ b/translate/src/scheduler.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 #[derive(Default)]
 pub struct Scheduler {
     ir: Arc<HarvestIR>,
-    queued_invocations: Vec<ToolInvocation>,
+    queued_invocations: Vec<Box<dyn ToolInvocation>>,
 }
 
 impl Scheduler {
@@ -59,7 +59,7 @@ impl Scheduler {
     /// Add a tool invocation to the scheduler's queue. Note that scheduling a
     /// tool invocation does not guarantee the tool will run, as a tool may
     /// indicate that it is not runnable.
-    pub fn queue_invocation(&mut self, invocation: ToolInvocation) {
-        self.queued_invocations.push(invocation);
+    pub fn queue_invocation<T: ToolInvocation + 'static>(&mut self, invocation: T) {
+        self.queued_invocations.push(Box::new(invocation));
     }
 }

--- a/translate/src/tools/load_raw_source.rs
+++ b/translate/src/tools/load_raw_source.rs
@@ -4,9 +4,22 @@ use crate::tools::{Context, Tool};
 use harvest_ir::{HarvestIR, Id, Representation, fs::RawDir};
 use std::{collections::HashSet, fs::read_dir, path::PathBuf};
 
-pub struct Args {
-    /// The path to the source code project's root directory.
+use super::ToolInvocation;
+
+pub struct Invocation {
     pub directory: PathBuf,
+}
+
+impl ToolInvocation for Invocation {
+    fn create_tool(&self) -> Box<dyn Tool> {
+        Box::new(LoadRawSource::new(self.directory.clone()))
+    }
+}
+
+impl std::fmt::Display for Invocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "LoadRawSource({})", self.directory.display())
+    }
 }
 
 pub struct LoadRawSource {
@@ -14,9 +27,9 @@ pub struct LoadRawSource {
 }
 
 impl LoadRawSource {
-    pub fn new(args: &Args) -> LoadRawSource {
+    pub fn new(directory: PathBuf) -> LoadRawSource {
         LoadRawSource {
-            directory: Some(args.directory.clone()),
+            directory: Some(directory),
         }
     }
 }

--- a/translate/src/tools/mod.rs
+++ b/translate/src/tools/mod.rs
@@ -27,27 +27,8 @@ impl Config {
 }
 
 /// A tool invocation that the scheduler could choose to perform.
-pub enum ToolInvocation {
-    LoadRawSource(load_raw_source::Args),
-    RawSourceToCargoLlm,
-}
-
-impl ToolInvocation {
-    pub fn create_tool(&self) -> Box<dyn Tool> {
-        match self {
-            Self::LoadRawSource(args) => Box::new(load_raw_source::LoadRawSource::new(args)),
-            Self::RawSourceToCargoLlm => Box::new(raw_source_to_cargo_llm::RawSourceToCargoLlm),
-        }
-    }
-}
-
-impl Display for ToolInvocation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        match self {
-            Self::RawSourceToCargoLlm => f.write_str("RawSourceToCargoLlm"),
-            Self::LoadRawSource(args) => write!(f, "LoadRawSource({})", args.directory.display()),
-        }
-    }
+pub trait ToolInvocation: Display {
+    fn create_tool(&self) -> Box<dyn Tool>;
 }
 
 /// Trait implemented by each tool. Used by the scheduler to decide what tools

--- a/translate/src/tools/raw_source_to_cargo_llm.rs
+++ b/translate/src/tools/raw_source_to_cargo_llm.rs
@@ -12,11 +12,27 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use super::ToolInvocation;
+
 /// Structured output JSON schema for Ollama.
 const STRUCTURED_OUTPUT_SCHEMA: &str =
     include_str!("raw_source_to_cargo_llm/structured_schema.json");
 
 const SYSTEM_PROMPT: &str = include_str!("raw_source_to_cargo_llm/system_prompt.txt");
+
+pub struct Invocation;
+
+impl ToolInvocation for Invocation {
+    fn create_tool(&self) -> Box<dyn Tool> {
+        Box::new(RawSourceToCargoLlm)
+    }
+}
+
+impl std::fmt::Display for Invocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RawSourceToCargoLlm")
+    }
+}
 
 pub struct RawSourceToCargoLlm;
 


### PR DESCRIPTION
This allows `Tool`s to be developed entirely out-of-tree, in separate crates since, previously, the `ToolInvocation` enum needed to be extended to actually be able to use any new tool.

In order for `ToolInvocation` to be `dyn` safe (so it can be stored in a `Vec<Box<dyn ToolInvocation>>` in the scheduler), instance types can't be associated with their `Tool` (e.g. with an associated type) and `create_tool` method needs to return a boxed trait object. But that's not particular hard to implement. 