### PR TITLE
Introduce `harvest_ir::edit::Organizer`.

### DIFF
--- a/ir/src/edit.rs
+++ b/ir/src/edit.rs
@@ -1,6 +1,89 @@
-use crate::{Id, Representation};
+//! A system for organizing concurrent mutations to a [`HarvestIR`].
+
+use crate::{HarvestIR, Id, Representation};
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+
+/// A tool for organizing concurrent modifications to a `HarvestIR`. This owns the `HarvestIR`,
+/// providing read-only access via `snapshot` and an interface to create and apply `Edits` that
+/// mutate the IR. `Organizer` does not allow two `Edit`s that can modify the same representation
+/// to exist simultaneously.
+#[derive(Default)]
+pub struct Organizer {
+    ir: Arc<HarvestIR>,
+    shared: Arc<Shared>,
+}
+
+impl Organizer {
+    /// Constructs a new Organizer with the provided `HarvestIR`.
+    pub fn with_harvest_ir(ir: HarvestIR) -> Organizer {
+        Organizer {
+            ir: ir.into(),
+            shared: Default::default(),
+        }
+    }
+
+    /// Applies the edit in `Edit` to the IR. This will update the IR and mark the edit's IDs as
+    /// unused.
+    pub fn apply_edit(&mut self, mut edit: Edit) -> Result<(), WrongOrganizer> {
+        // Note: we just drop `edit` to mark the IDs as no longer in use.
+        if !Arc::ptr_eq(&self.shared, &edit.shared) {
+            return Err(WrongOrganizer);
+        }
+        let ir = Arc::make_mut(&mut self.ir);
+        for (&id, ref mut representation) in &mut edit.writable {
+            if let Some(representation) = representation.take() {
+                ir.representations.insert(id, representation);
+            }
+        }
+        Ok(())
+    }
+
+    /// Creates a new `Edit` that can edit the given list of IDs. All IDs in `might_write` must be
+    /// part of the current IR.
+    ///
+    /// The IDs in `might_write` will be marked as in use, and will only be freed when either the
+    /// edit is applied (via [`apply_edit`]) or dropped.
+    pub fn new_edit(&mut self, might_write: &HashSet<Id>) -> Result<Edit, NewEditError> {
+        // An unknown ID generally represents a bug in the calling code, whereas IdInUse can be a
+        // normal situation. Therefore, prioritize returning UnknownId so that IdInUse doesn't hide
+        // bugs.
+        if might_write.iter().any(|&id| !self.ir.contains_id(id)) {
+            return Err(NewEditError::UnknownId);
+        }
+        let mut in_use = self.shared.in_use.lock().expect("in_use poisoned");
+        if might_write.iter().any(|id| in_use.contains(id)) {
+            return Err(NewEditError::IdInUse);
+        }
+        might_write.iter().for_each(|&id| {
+            in_use.insert(id);
+        });
+        Ok(Edit {
+            shared: self.shared.clone(),
+            writable: might_write.iter().map(|&id| (id, None)).collect(),
+        })
+    }
+
+    /// Returns the current value of the IR.
+    pub fn snapshot(&self) -> Arc<HarvestIR> {
+        self.ir.clone()
+    }
+}
+
+/// Error type returned by `Organizer::apply_edit`.
+#[derive(Debug, Error, Hash, PartialEq)]
+#[error("edit is for a different Organizer")]
+pub struct WrongOrganizer;
+
+/// Error type returned by `Organizer::new_edit`.
+#[derive(Debug, Error, Hash, PartialEq)]
+pub enum NewEditError {
+    #[error("one of the IDs is currently in use.")]
+    IdInUse,
+    #[error("an ID is not in this HarvestIR")]
+    UnknownId,
+}
 
 /// A tool for making changes to (a subset of) the IR. When an `Edit` is
 /// created, it is given a limited set of representations which it can modify
@@ -14,37 +97,23 @@ use std::sync::Arc;
 /// 3. Edit the copied Representation.
 /// 4. Store the edited Representation into `context.ir_edit` using `write_id`.
 pub struct Edit {
+    shared: Arc<Shared>,
+
     // Contains every ID this tool can write. IDs that contain Some() will be
     // written, and IDs that contain None will not be touched.
     //
     // Arc<> is used to avoid needing to copy the Representation into HarvestIR
     // when this edit is merged into the main IR; it is not expected for there
     // to be other references to these representations.
-    pub(crate) writable: HashMap<Id, Option<Arc<Representation>>>,
+    writable: HashMap<Id, Option<Arc<Representation>>>,
 }
 
 impl Edit {
-    /// Creates a new Edit, limited to changing the given set of IDs.
-    pub fn new(might_change: &HashSet<Id>) -> Edit {
-        Edit {
-            writable: might_change.iter().map(|&id| (id, None)).collect(),
-        }
-    }
-
     /// Adds a representation with a new ID and returns the new ID.
     pub fn add_representation(&mut self, representation: Representation) -> Id {
         let id = Id::new();
         self.writable.insert(id, Some(representation.into()));
         id
-    }
-
-    /// Returns the set of IDs that this `Edit` changes.
-    pub fn changed_ids(&self) -> Vec<Id> {
-        self.writable
-            .iter()
-            .filter(|(_, r)| r.is_some())
-            .map(|(&id, _)| id)
-            .collect()
     }
 
     /// Creates a new ID and gives this tool write access to it.
@@ -77,9 +146,25 @@ impl Edit {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+impl Drop for Edit {
+    fn drop(&mut self) {
+        // Mark this Edit's IDs as no longer in use.
+        let mut in_use = self.shared.in_use.lock().expect("in_use poisoned");
+        self.writable.iter().for_each(|(id, _)| {
+            in_use.remove(id);
+        });
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Error)]
 #[error("cannot write this id")]
 pub struct NotWritable;
+
+/// State shared between the `Organizer` and the `Edit`s it creates.
+#[derive(Default)]
+struct Shared {
+    in_use: Mutex<HashSet<Id>>,
+}
 
 #[cfg(test)]
 mod tests {
@@ -88,18 +173,84 @@ mod tests {
     use std::panic::catch_unwind;
 
     #[test]
-    fn edit() {
-        // Checks whether left and right contain the same elements.
-        fn set_equal(left: &[Id], right: &[Id]) -> bool {
-            let mut left: Vec<_> = left.iter().collect();
-            let mut right: Vec<_> = right.iter().collect();
-            left.sort_unstable();
-            right.sort_unstable();
-            left == right
-        }
+    fn organizer() {
+        let mut organizer = Organizer::default();
 
+        // Apply an edit to add two new reprs to the IR.
+        let mut edit = organizer
+            .new_edit(&[].into())
+            .expect("no-ID new_edit failed");
+        let [a, b, c] = [
+            edit.add_representation(new_representation()),
+            edit.add_representation(new_representation()),
+            edit.new_id(),
+        ];
+        assert_eq!(organizer.apply_edit(edit), Ok(()));
+        // a and b should be applied but c should not.
+        assert_eq!(
+            HashSet::from_iter(organizer.snapshot().representations.keys()),
+            HashSet::from([&a, &b]),
+            "apply_edit set incorrect representations"
+        );
+
+        // Nested change creation: create two Edits. Apply the second one, then drop the first.
+        let mut edit1 = organizer.new_edit(&[a].into()).expect("new_edit failed");
+        let mut edit2 = organizer.new_edit(&[b].into()).expect("new_edit failed");
+        assert_eq!(
+            *organizer.shared.in_use.lock().expect("in_use poisoned"),
+            HashSet::from([a, b])
+        );
+        let [_, _] = [(); 2].map(|_| edit1.add_representation(new_representation()));
+        let [f, g] = [(); 2].map(|_| edit2.add_representation(new_representation()));
+        assert_eq!(organizer.apply_edit(edit2), Ok(()), "apply_edit failed");
+        assert_eq!(
+            *organizer.shared.in_use.lock().expect("in_use poisoned"),
+            HashSet::from([a])
+        );
+        // a, b, f, and g should be set but d and e should not.
+        drop(edit1);
+        assert_eq!(
+            *organizer.shared.in_use.lock().expect("in_use poisoned"),
+            HashSet::from([])
+        );
+        assert_eq!(
+            HashSet::from_iter(organizer.snapshot().representations.keys().copied()),
+            HashSet::from([a, b, f, g])
+        );
+
+        // Swap Edits between Organizer instances.
+        assert_eq!(
+            organizer.apply_edit(
+                Organizer::default()
+                    .new_edit(&[].into())
+                    .expect("new_edit failed")
+            ),
+            Err(WrongOrganizer),
+            "apply_edit accepted Edit from another Organizer"
+        );
+
+        // new_edit error cases.
+        let edit = organizer.new_edit(&[f].into()).expect("new_edit failed");
+        assert_eq!(
+            organizer.new_edit(&[c, f].into()).err(),
+            Some(NewEditError::UnknownId),
+            "with both an unknown ID and an in use ID, new_edit should return an UnknownId error"
+        );
+        assert_eq!(
+            organizer.new_edit(&[f, g].into()).err(),
+            Some(NewEditError::IdInUse),
+            "new_edit accepted in use ID"
+        );
+        drop(edit);
+    }
+
+    #[test]
+    fn edit() {
         let [a, b, c] = Id::new_array();
-        let mut edit = Edit::new(&[a, b].into());
+        let mut organizer = Organizer::with_harvest_ir(HarvestIR {
+            representations: [a, b].map(|id| (id, new_representation().into())).into(),
+        });
+        let mut edit = organizer.new_edit(&[a, b].into()).unwrap();
         let d = edit.add_representation(new_representation());
         let e = edit.new_id();
         assert_eq!(
@@ -114,8 +265,14 @@ mod tests {
         );
         edit.write_id(d, new_representation());
         edit.write_id(e, new_representation());
-        assert!(
-            set_equal(&edit.changed_ids(), &[a, d, e]),
+        assert_eq!(
+            HashSet::from_iter(
+                edit.writable
+                    .iter()
+                    .filter(|(_, r)| r.is_some())
+                    .map(|(&i, _)| i)
+            ),
+            HashSet::from([a, d, e]),
             "changed IDs incorrect"
         );
         assert!(

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -53,12 +53,10 @@ impl Representation {
 }
 
 impl HarvestIR {
-    pub fn apply_edit(&mut self, edit: Edit) {
-        for (id, representation) in edit.writable {
-            if let Some(representation) = representation {
-                self.representations.insert(id, representation);
-            }
-        }
+    /// Returns `true` if this `HarvestIR` contains a representation under ID `id`, `false`
+    /// otherwise.
+    pub fn contains_id(&self, id: Id) -> bool {
+        self.representations.contains_key(&id)
     }
 
     /// Returns an iterator over the IDs and representations in this IR.
@@ -107,26 +105,5 @@ mod tests {
     /// doesn't care what it is).
     pub(crate) fn new_representation() -> Representation {
         Representation::RawSource(RawDir::default())
-    }
-
-    #[test]
-    fn apply_edit() {
-        let initial_ir = Id::new_array::<3>().map(|i| (i, new_representation().into()));
-        let mut ir = HarvestIR {
-            representations: initial_ir.clone().into_iter().collect(),
-        };
-        let [(a, a_repr), (b, b_repr), (c, _)] = initial_ir;
-        let mut edit = Edit::new(&[b, c].into());
-        edit.write_id(c, new_representation());
-        let c_repr = edit.writable[&c].clone().unwrap();
-        let d = edit.add_representation(new_representation());
-        let d_repr = edit.writable[&d].clone().unwrap();
-        edit.new_id();
-        ir.apply_edit(edit);
-        assert_eq!(ir.representations.len(), 4);
-        assert!(Arc::ptr_eq(&a_repr, &ir.representations[&a]));
-        assert!(Arc::ptr_eq(&b_repr, &ir.representations[&b]));
-        assert!(Arc::ptr_eq(&c_repr, &ir.representations[&c]));
-        assert!(Arc::ptr_eq(&d_repr, &ir.representations[&d]));
     }
 }

--- a/translate/src/scheduler.rs
+++ b/translate/src/scheduler.rs
@@ -4,54 +4,50 @@
 //! for invoking them. It is effectively the main loop of harvest_translate.
 
 use crate::tools::{Context, ToolInvocation};
-use harvest_ir::HarvestIR;
-use std::sync::Arc;
+use harvest_ir::edit;
 
 #[derive(Default)]
 pub struct Scheduler {
-    ir: Arc<HarvestIR>,
     queued_invocations: Vec<ToolInvocation>,
 }
 
 impl Scheduler {
-    /// Returns the current IR snapshot.
-    pub fn ir_snapshot(&self) -> Arc<HarvestIR> {
-        self.ir.clone()
-    }
-
     /// The scheduler main loop -- invokes tools until done.
-    pub fn main_loop(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn main_loop(
+        &mut self,
+        ir: &mut edit::Organizer,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         // TODO: This is just a temporary implementation to make the
         // LoadRawSource invocation run; this all needs to be restructured to
         // fit the design doc.
         for invocation in &self.queued_invocations {
             log::debug!("Attempting to invoke {invocation}");
             let mut tool = invocation.create_tool();
+            let snapshot = ir.snapshot();
             // TODO: Diagnostics for tools that are not runnable (which is not
             // necessarily an error).
-            let Some(ids) = tool.might_write(&self.ir) else {
-                continue;
-            };
-            // TODO: Track which IDs are in use and allow tools to write IDs.
-            // This implementation is conservative which is correct but too
-            // limited (tools can only add new IDs).
-            if !ids.is_empty() {
+            let Some(ids) = tool.might_write(&snapshot) else {
                 continue;
             };
             // TODO: Catch panics and handle errors appropriately.
-            let mut ir_edit = harvest_ir::Edit::new(&ids);
+            let mut ir_edit = match ir.new_edit(&ids) {
+                Ok(edit) => edit,
+                Err(error) => {
+                    log::error!("Tool::might_write ID error: {error}");
+                    continue;
+                }
+            };
             tool.run(Context {
                 ir_edit: &mut ir_edit,
-                ir_snapshot: self.ir.clone(),
+                ir_snapshot: snapshot,
             })
             .map_err(|e| {
                 log::debug!("Invoking {invocation} failed: {e}");
                 e
             })?;
-            // TODO: Verify that ir_edit doesn't touch any IDs that might_write
-            // did not return (it's theoretically possible -- though not
-            // sensible -- for tools to replace ir_edit entirely).
-            Arc::make_mut(&mut self.ir).apply_edit(ir_edit);
+            if let Err(error) = ir.apply_edit(ir_edit) {
+                log::error!("Failed to apply edit: {error}");
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Currently, there are a couple of things about managing IR edits that are messy:

1. `Edit::new` is public, so tools can create `Edit`s and swap them around.
2. Tools can return IDs that are not part of the IR from `Tool::might_write`, which is a logic error.

In both cases, `harvest_translate` *should* be able to catch the error and emit a diagnostic, but when I went to implement it there's just no sensible place for that logic.

Instead, this introduces a new component whose main purpose is to create and apply `Edit`s, `edit::Organizer`. Because it is in the `harvest_ir` crate, `Edit::new` can be removed, so tools can no longer create `Edit`s at will. It also provides a good place to verify that `Tool::might_write` only returned IDs that are in the IR.

I also moved the IR storage out of the scheduler, it doesn't really belong there.