### PR TITLE
check formatting and clippy in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,5 +6,34 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.8.0
+
       - name: Test
         run: make test
+  
+  rustfmt:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v5
+
+        - name: Rust Cache
+          uses: Swatinem/rust-cache@v2.8.0
+
+        - name: Rust rustfmt
+          run: cargo fmt --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.8.0
+
+      - name: Run cargo check
+        run: RUSTFLAGS="-Dwarnings" cargo check
+
+      - name: Run clippy
+        run: cargo clippy


### PR DESCRIPTION
I extended the CI to check that the code:
1. Has been `cargo fmt`'d
2. Builds with no warnings
3. Has no clippy warnings
4. Uses `rust cache`, a popular github action that lets us run many cargo commands without rebuilding the project every time.