### PR TITLE
Enable clippy::self_named_module_files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ resolver = "3"
 [workspace.dependencies]
 harvest_ir = { path = "ir" }
 tempfile = "3.23.0"
+
+[workspace.lints.clippy]
+self_named_module_files = "warn"

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -8,3 +8,6 @@ thiserror = "2.0.16"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -16,3 +16,6 @@ serde = "1.0.228"
 serde_json = "1.0.145"
 tempfile = { workspace = true }
 tokio = { features = ["net", "rt"], version = "1.47.1" }
+
+[lints]
+workspace = true

--- a/translate/src/tools/raw_source_to_cargo_llm/mod.rs
+++ b/translate/src/tools/raw_source_to_cargo_llm/mod.rs
@@ -13,10 +13,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 /// Structured output JSON schema for Ollama.
-const STRUCTURED_OUTPUT_SCHEMA: &str =
-    include_str!("raw_source_to_cargo_llm/structured_schema.json");
+const STRUCTURED_OUTPUT_SCHEMA: &str = include_str!("structured_schema.json");
 
-const SYSTEM_PROMPT: &str = include_str!("raw_source_to_cargo_llm/system_prompt.txt");
+const SYSTEM_PROMPT: &str = include_str!("system_prompt.txt");
 
 pub struct RawSourceToCargoLlm;
 


### PR DESCRIPTION
We should be consistent about using self-named modules files versus `mod.rs`. The current contributors have a preference for `mod.rs`, so this uses clippy to enforce that preference for consistency.