### PR TITLE
Reduce the size of `id::tests::new_implementation` on Miri.

### DIFF
--- a/ir/src/id.rs
+++ b/ir/src/id.rs
@@ -86,6 +86,8 @@ mod tests {
     // intended.
     #[test]
     fn new_implementation() {
+        // Use a smaller test size in Miri to keep the test fast and a larger test size for native
+        // execution to make the test more effective.
         #[cfg(not(miri))]
         const CHUNK_SIZE: usize = 100;
         #[cfg(miri)]


### PR DESCRIPTION
This change reduces the number of IDs that the new_implementation tests allocates in Miri by a factor of 10 (with no change for non-Miri runs).

This reduces the runtime for `make -j16 test` on my system from 7.5 seconds to 4.7 seconds. Not much but I run that command a lot so it'll add up.