### PR TITLE
Support OpenRouter in raw_source_to_cargo_llm

### DIFF
--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -10,7 +10,7 @@ config = { default-features = false, features = ["toml"], version = "0.15.18" }
 directories = "6.0.0"
 env_logger = "0.11.8"
 harvest_ir = { workspace = true }
-llm = { default-features = false, features = ["ollama", "openai", "rustls-tls" ], version = "1.3.4" }
+llm = { default-features = false, features = ["ollama", "openai", "openrouter", "rustls-tls" ], version = "1.3.4" }
 log = "0.4.28"
 serde = "1.0.228"
 serde_json = "1.0.145"


### PR DESCRIPTION
Adds support for OpenRouter to the LLM tool.

Closes #42