### PR TITLE
Initial diagnostics framework.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,5 @@ test:
 	RUSTFLAGS="-D warnings" cargo test
 	RUSTFLAGS="-D warnings" cargo clippy
 	cargo fmt --check
-	cd nightly && cargo miri test --manifest-path=../Cargo.toml
+	cd nightly && \
+		RUSTFLAGS="-D warnings" cargo miri test --manifest-path=../Cargo.toml

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -20,7 +20,7 @@ use crate::logger::TeeLogger;
 use crate::stats::{ProgramEvalStats, SummaryStats, TestResult};
 use clap::Parser;
 use harvest_ir::HarvestIR;
-use harvest_translate::transpile;
+use harvest_translate::{transpile, util::set_user_only_umask};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -286,6 +286,7 @@ fn benchmark_single_program(
 }
 
 fn main() -> HarvestResult<()> {
+    set_user_only_umask();
     let args = Args::parse();
 
     // Validate input directory exists

--- a/doc/HARVEST-Translate Design.md
+++ b/doc/HARVEST-Translate Design.md
@@ -86,9 +86,9 @@ The diagnostic output is emitted to a directory. It will have at least the
 following subdirectories:
 
 * `ir/` Contains all the revisions of the HARVEST-IR. The first revision
-  (after the input project is loaded) will be named `0000` (field width to be
-  extended as necessary to keep them all the same size). The second revision
-  (after the first tool invocation) will be `0001`, etc.
+  (after the first tool completes running) will be named `0001` (field width to
+  be extended as necessary to keep them all the same size). The second revision
+  (after the second tool invocation) will be `0002`, etc.
 * `steps/` Contains a subdirectory for each tool invocation. The name of each
   subdirectory is the same as the name of the IR revision immediately after that
   tool finishes. As a result, `0000` will be skipped and the subdirectory

--- a/ir/src/id.rs
+++ b/ir/src/id.rs
@@ -45,6 +45,12 @@ impl Display for Id {
     }
 }
 
+impl From<Id> for u64 {
+    fn from(value: Id) -> u64 {
+        value.0.into()
+    }
+}
+
 // `Id::new_array`, but with an injected AtomicU64. This allows `tests::new` to
 // use its own AtomicU64, which prevents other tests that are run in parallel
 // from interfering with it.

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -33,6 +33,9 @@ pub struct HarvestIR {
 
 /// An abstract representation of a program
 pub trait Representation: Any + Display + Send + Sync {
+    /// This representation's name. Used for diagnostics.
+    fn name(&self) -> &'static str;
+
     /// Materialize the [Representation] to a directory at the
     /// provided `path`.
     ///
@@ -100,7 +103,11 @@ mod tests {
             write!(f, "EmptyRepresentation")
         }
     }
-    impl Representation for EmptyRepresentation {}
+    impl Representation for EmptyRepresentation {
+        fn name(&self) -> &'static str {
+            "empty"
+        }
+    }
 
     /// A Representation that contains only an ID number.
     #[derive(Debug, Eq, Hash, PartialEq)]
@@ -110,7 +117,11 @@ mod tests {
             write!(f, "IdRepresentation({})", self.0)
         }
     }
-    impl Representation for IdRepresentation {}
+    impl Representation for IdRepresentation {
+        fn name(&self) -> &'static str {
+            "id"
+        }
+    }
 
     #[test]
     fn get_by_representation() {

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -18,6 +18,7 @@ config = { default-features = false, features = ["toml"], version = "0.15.18" }
 directories = "6.0.0"
 env_logger = "0.11.8"
 harvest_ir = { workspace = true }
+libc = "0.2.177"
 llm = { default-features = false, features = ["ollama", "openai", "openrouter", "rustls-tls" ], version = "1.3.4" }
 log = { workspace = true }
 serde = { workspace = true }

--- a/translate/src/cli.rs
+++ b/translate/src/cli.rs
@@ -49,6 +49,11 @@ pub struct Config {
     /// Path to output directory.
     pub output: PathBuf,
 
+    /// Path to the diagnostics directory, if you want diagnostics output. If you do not specify a
+    /// diagnostics path, a temporary directory will be created (so that working directories can be
+    /// created for tools) and cleaned up when translate completes.
+    pub diagnostics_dir: Option<PathBuf>,
+
     /// For both the output directory and diagnostics directory (if enabled):
     /// If true: if the directory exists and is nonempty, translate will delete the contents of the
     /// directory before running.
@@ -72,6 +77,7 @@ impl Config {
         Self {
             input: PathBuf::from("mock_input"),
             output: PathBuf::from("mock_output"),
+            diagnostics_dir: None,
             force: false,
             tools: tools::ToolConfigs::mock(),
             unknown: HashMap::new(),

--- a/translate/src/diagnostics.rs
+++ b/translate/src/diagnostics.rs
@@ -1,0 +1,167 @@
+//! Provides interfaces for writing and inspecting diagnostics. Diagnostics are collected into two
+//! places:
+//!
+//! 1. The diagnostics directory (if one is configured)
+//! 2. The [Diagnostics] struct, which is returned by `transpile`.
+//!
+//! This module also provides directories for tools to use, as those directories live under the
+//! diagnostic directory.
+
+use crate::cli::Config;
+use crate::util::{EmptyDirError, empty_writable_dir};
+use harvest_ir::HarvestIR;
+use log::error;
+use std::fmt::Write as _;
+use std::fs::{canonicalize, create_dir, write};
+use std::io;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, MutexGuard};
+use tempfile::{TempDir, tempdir};
+use thiserror::Error;
+
+/// Diagnostics produced by transpilation. Can be used by callers of `transpile` to inspect the
+/// diagnostics produced during its execution.
+pub struct Diagnostics {
+    // TODO: Figure out what we want to have here, versus only on disk. From
+    // https://github.com/betterbytes-org/harvest-code/issues/51#issuecomment-3524208160,
+    // we at least want information on tool invocation results (successes and errors with error
+    // messages).
+
+    // TODO: If this needs to access the diagnostics directory, then we need to move
+    // Option<TempDir> from `Collector` into here.
+}
+
+/// Component that collects diagnostics during the execution of `transpile`. Creating a Collector
+/// will start collecting `tracing` events (writing them into log files and echoing some events to
+/// stdout).
+// TODO: Implement collecting `tracing` events.
+pub(crate) struct Collector {
+    shared: Arc<Mutex<Option<Shared>>>,
+    // If no diagnostics directory has been configured, Collector will use a temporary directory
+    // instead (as tools still need to be able to create temporary files). In that case, the
+    // TempDir will be stored here so the directory is cleaned up when Collector is dropped.
+    _tempdir: Option<TempDir>,
+}
+
+impl Collector {
+    /// Creates a Collector, starting diagnostics collection.
+    pub fn initialize(config: &Config) -> Result<Collector, CollectorNewError> {
+        // We canonicalize the diagnostics path because it will be used to construct paths that are
+        // passed as to external commands (as command-line arguments), and the canonicalized path
+        // is probably the most compatible representation.
+        let (diagnostics_dir, _tempdir) = match &config.diagnostics_dir {
+            None => {
+                let tempdir = tempdir()?;
+                (canonicalize(tempdir.path()), Some(tempdir))
+            }
+            Some(path) => {
+                empty_writable_dir(path, config.force)?;
+                (canonicalize(path), None)
+            }
+        };
+        let diagnostics_dir = diagnostics_dir.expect("invalid diagnostics path?");
+        create_dir(PathBuf::from_iter([
+            diagnostics_dir.as_path(),
+            "ir".as_ref(),
+        ]))?;
+        Ok(Collector {
+            shared: Arc::new(Mutex::new(Some(Shared {
+                diagnostics: Diagnostics {},
+                diagnostics_dir,
+            }))),
+            _tempdir,
+        })
+    }
+
+    /// Consumes this [Collector], extracting the collected diagnostics. Diagnostics emitted after
+    /// this is called will be dropped rather than written to the diagnostics directory (if e.g. an
+    /// unjoined background thread tries to write diagnostics).
+    pub fn diagnostics(self) -> Diagnostics {
+        lock_shared(&self.shared)
+            .take()
+            .expect("diagnostics Shared missing")
+            .diagnostics
+    }
+
+    /// Returns a new [Reporter] that passes diagnostics to this Collector.
+    pub fn reporter(&self) -> Reporter {
+        Reporter {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+/// A handle used to report diagnostics. Created by using `Collector::reporter`.
+#[derive(Clone)]
+pub(crate) struct Reporter {
+    shared: Arc<Mutex<Option<Shared>>>,
+}
+
+impl Reporter {
+    /// Reports a new version of the IR.
+    pub fn report_ir_version(&self, version: u64, snapshot: &HarvestIR) {
+        let Some(ref mut shared) = *lock_shared(&self.shared) else {
+            return;
+        };
+        let mut path = shared.diagnostics_dir.clone();
+        path.push("ir");
+        path.push(format!("{version:03}"));
+        if let Err(error) = create_dir(&path) {
+            error!("Failed to create IR directory: {error}");
+            return;
+        }
+        let mut types = vec![];
+        for (id, repr) in snapshot.iter() {
+            let id_string = format!("{:03}", Into::<u64>::into(id));
+            path.push(&id_string);
+            if let Err(error) = repr.materialize(&path) {
+                error!("Failed to materialize repr: {error}");
+            }
+            path.pop();
+            types.push((id, id_string, repr.name()));
+        }
+        // TODO: For now, HarvestIR does not guarantee a particular iteration order, but it
+        // *happens* to iterate in this same order. We should figure out what guarantees we want
+        // HarvestIR to have, and then update this accordingly.
+        types.sort_unstable_by_key(|t| t.0);
+        let mut index = String::new();
+        for (_, id_string, name) in types {
+            let _ = writeln!(index, "{id_string}: {name}");
+        }
+        path.push("index");
+        if let Err(error) = write(path, index) {
+            error!("Failed to write IR index: {error}");
+        }
+    }
+}
+
+/// Error type returned by Collector::new.
+#[derive(Debug, Error)]
+pub(crate) enum CollectorNewError {
+    #[error("diagnostics directory error")]
+    DiagnosticsEmptyDir(#[from] EmptyDirError),
+    #[error("I/O error")]
+    IoError(#[from] io::Error),
+}
+
+/// Utility to lock one of the `Shared` references, logging an error if it is poisoned (and
+/// unpoisoning it).
+fn lock_shared<'m>(shared: &'m Mutex<Option<Shared>>) -> MutexGuard<'m, Option<Shared>> {
+    match shared.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            error!("diagnostics mutex poisoned");
+            shared.clear_poison();
+            poisoned.into_inner()
+        }
+    }
+}
+
+/// Values shared by the Collector and various diagnostics handles. This is contained in an Option,
+/// which is set to `None` when [Collector::diagnostics] is called (and must remain Some() until
+/// then).
+struct Shared {
+    diagnostics: Diagnostics,
+    // Path to the root of the diagnostics directory structure.
+    diagnostics_dir: PathBuf,
+}

--- a/translate/src/main.rs
+++ b/translate/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use harvest_translate::cli::{Args, initialize};
 use harvest_translate::transpile;
-use harvest_translate::util::empty_writable_dir;
+use harvest_translate::util::{empty_writable_dir, set_user_only_umask};
 use log::{error, info};
 use std::sync::Arc;
 
@@ -14,6 +14,7 @@ fn main() {
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
+    set_user_only_umask();
     let args: Arc<_> = Args::parse().into();
     let Some(config) = initialize(args) else {
         return Ok(()); // An early-exit argument was passed.

--- a/translate/src/test_util.rs
+++ b/translate/src/test_util.rs
@@ -33,6 +33,7 @@ pub struct MockTool {
 ///     .might_write(|_| MightWriteOutcome::Runnable([].into()))
 ///     .run(|_| Ok(()));
 /// ```
+#[cfg_attr(miri, allow(unused))]
 impl MockTool {
     /// Creates a new MockTool. The MockTool is boxed, because most users of MockTool will use it
     /// to create a `Box<dyn Tool>`.

--- a/translate/src/tools/load_raw_source.rs
+++ b/translate/src/tools/load_raw_source.rs
@@ -55,6 +55,10 @@ impl std::fmt::Display for RawSource {
 }
 
 impl Representation for RawSource {
+    fn name(&self) -> &'static str {
+        "RawSource"
+    }
+
     fn materialize(&self, path: &Path) -> std::io::Result<()> {
         self.dir.materialize(path)
     }

--- a/translate/src/tools/raw_source_to_cargo_llm/mod.rs
+++ b/translate/src/tools/raw_source_to_cargo_llm/mod.rs
@@ -136,6 +136,10 @@ impl std::fmt::Display for CargoPackage {
 }
 
 impl Representation for CargoPackage {
+    fn name(&self) -> &'static str {
+        "CargoPackage"
+    }
+
     fn materialize(&self, path: &Path) -> std::io::Result<()> {
         self.dir.materialize(path)
     }

--- a/translate/src/tools/try_cargo_build.rs
+++ b/translate/src/tools/try_cargo_build.rs
@@ -150,6 +150,10 @@ impl std::fmt::Display for CargoBuildResult {
 }
 
 impl Representation for CargoBuildResult {
+    fn name(&self) -> &'static str {
+        "CargoBuildResult"
+    }
+
     fn materialize(&self, _path: &Path) -> std::io::Result<()> {
         Ok(())
     }

--- a/translate/src/util.rs
+++ b/translate/src/util.rs
@@ -52,6 +52,20 @@ pub enum EmptyDirError {
     NotWritable,
 }
 
+/// Sets the umask value for this process to a value that makes files and directories only
+/// accessible by this user. This applies to all new files and directories created by the process,
+/// and is inherited by subprocesses as well.
+///
+/// This is used by the `translate` binary to make its output and diagnostics directories
+/// not-world-accessible.
+pub fn set_user_only_umask() {
+    // Safety: This is only unsafe because libc marks all its bindings as unsafe by default. The
+    // `umask` function cannot induce UB.
+    unsafe {
+        libc::umask(0o077);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(not(miri))]


### PR DESCRIPTION
This adds an initial structure for collecting diagnostics:

1. A `Collector` represents the overall diagnostics collection process. Constructing it starts collecting diagnostics, then it is consumed to retrieve the `Diagnostics`.
2. `Reporter` is a handle that is handed out to code that needs to write diagnostic data. For now, only the tool runner uses Reporter, but eventually the scheduler (and probably other components) will use it as well.
3. `Diagnostics` represents the resulting diagnostics. I do not yet know how much will be kept in memory versus kept on disk; that will be worked out later.