### PR TITLE
Switch to `tracing`; record debug messages

### DIFF
--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -65,7 +65,10 @@ pub fn translate_c_directory_to_rust_project(
         force: false,
     }
     .into();
-    let config = harvest_translate::cli::initialize(args).expect("Failed to generate config");
+    let mut config = harvest_translate::cli::initialize(args).expect("Failed to generate config");
+    if config.log_filter.is_empty() {
+        config.log_filter = "off".to_string(); // Disable console logging in harvest_translate
+    }
     let tool_config = &config.tools.raw_source_to_cargo_llm;
     log::info!(
         "Translating code using {}:{} with max tokens: {}",
@@ -73,7 +76,7 @@ pub fn translate_c_directory_to_rust_project(
         tool_config.model,
         tool_config.max_tokens
     );
-    let ir_result = transpile(config);
+    let ir_result = transpile(config.into());
     let raw_c_source = raw_source(ir_result.as_ref().unwrap()).unwrap();
     raw_c_source
         .materialize(output_dir.join("c_src"))

--- a/doc/HARVEST-Translate Design.md
+++ b/doc/HARVEST-Translate Design.md
@@ -90,9 +90,10 @@ following subdirectories:
   be extended as necessary to keep them all the same size). The second revision
   (after the second tool invocation) will be `0002`, etc.
 * `steps/` Contains a subdirectory for each tool invocation. The name of each
-  subdirectory is the same as the name of the IR revision immediately after that
-  tool finishes. As a result, `0000` will be skipped and the subdirectory
-  numbers will start at `0001`. Each subdirectory will contain:
+  subdirectory is `$tool_$number`, where `$number` is the number of times that
+  particular tool has been run (for example, the first run of the
+  `try_cargo_build` tool will have subdirectory name `try_cargo_build_1`). Each
+  subdirectory will contain:
   - `start_ir` A symlink to the IR revision the tool was launched with (i.e.
     links to `../../ir/####`).
   - `end_ir` A symlink to the IR revision the tool was completed with.

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -16,16 +16,16 @@ cargo_metadata = "0.23.0"
 clap = { workspace = true }
 config = { default-features = false, features = ["toml"], version = "0.15.18" }
 directories = "6.0.0"
-env_logger = "0.11.8"
 harvest_ir = { workspace = true }
 libc = "0.2.177"
 llm = { default-features = false, features = ["ollama", "openai", "openrouter", "rustls-tls" ], version = "1.3.4" }
-log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { features = ["net", "rt"], version = "1.47.1" }
+tracing-subscriber = { features = ["env-filter"], version = "0.3.20" }
+tracing = { default-features = false, features = ["std"], version = "0.1.41" }
 
 [lints]
 workspace = true

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -1,6 +1,7 @@
 # The default configurations options for harvest_translate.
 
 force = false
+log_filter = "info"
 
 [tools.raw_source_to_cargo_llm]
 address = "http://localhost:11434"

--- a/translate/src/cli.rs
+++ b/translate/src/cli.rs
@@ -60,6 +60,10 @@ pub struct Config {
     /// If false: if the directory exists and is nonempty, translate will output an error and exit.
     pub force: bool,
 
+    /// Filter describing which log messages should be output to stdout. This is in the
+    /// `tracing_subscriber::filter::EnvFilter` format.
+    pub log_filter: String,
+
     /// Sub-configuration for each tool.
     pub tools: tools::ToolConfigs,
 
@@ -79,6 +83,7 @@ impl Config {
             output: PathBuf::from("mock_output"),
             diagnostics_dir: None,
             force: false,
+            log_filter: String::new(),
             tools: tools::ToolConfigs::mock(),
             unknown: HashMap::new(),
         }
@@ -103,7 +108,7 @@ pub(crate) fn unknown_field_warning(prefix: &str, unknown: &HashMap<String, Valu
 ///
 /// Returns the config, or None if a command line flag that calls for an early exit (such as
 /// --print_config_path) was provided.
-pub fn initialize(args: Arc<Args>) -> Option<Arc<Config>> {
+pub fn initialize(args: Arc<Args>) -> Option<Config> {
     let dirs = ProjectDirs::from("", "", "harvest").expect("no home directory");
     if args.print_config_path {
         println!("Config file location: {:?}", config_file(dirs.config_dir()));
@@ -112,7 +117,7 @@ pub fn initialize(args: Arc<Args>) -> Option<Arc<Config>> {
     let config = load_config(&args, dirs.config_dir());
     unknown_field_warning("", &config.unknown);
     config.tools.validate();
-    Some(config.into())
+    Some(config)
 }
 
 fn load_config(args: &Args, config_dir: &Path) -> Config {

--- a/translate/src/diagnostics/tool_reporter.rs
+++ b/translate/src/diagnostics/tool_reporter.rs
@@ -1,0 +1,117 @@
+use super::{CollectorDropped, lock_shared, Shared};
+use crate::tools::Tool;
+use std::collections::hash_map::Entry;
+use std::fmt::{self, Display, Formatter};
+use std::num::NonZeroU64;
+use std::sync::{Arc, Mutex};
+use tracing::{dispatcher::{DefaultGuard, set_default}, Dispatch};
+use tracing_subscriber::fmt::layer;
+use tracing_subscriber::layer::{Layer as _, SubscriberExt as _};
+use tracing_subscriber::Registry;
+
+/// Diagnostics reporter for a specific tool run. These are provided to tools as part of their
+/// context.
+// TODO: Presumably Tool::might_write also wants a tool-specific reporter, right? Does it get a
+// general Reporter, ToolReporter, or something else? For now I'm not handing a reporter to
+// Tool::might_write.
+#[derive(Clone)]
+pub struct ToolReporter {
+    shared: Arc<Mutex<Option<Shared>>>,
+    tool_run: ToolRunId,
+}
+
+impl ToolReporter {
+    pub(super) fn new(shared: Arc<Mutex<Option<Shared>>>, tool: &dyn Tool) -> Result<ToolReporter, CollectorDropped> {
+        let tool = ToolId::new(tool);
+        let mut guard = lock_shared(&shared);
+        let Some(ref mut shared_inner) = *guard else {
+            return Err(CollectorDropped);
+        };
+        let number = match shared_inner.tool_run_counts.entry(tool) {
+            Entry::Occupied(mut entry) => {
+                let number = entry.get().checked_add(1).unwrap();
+                entry.insert(number);
+                number
+            }
+            Entry::Vacant(entry) => *entry.insert(NonZeroU64::MIN),
+        };
+        let tool_run = ToolRunId { tool, number };
+        shared_inner.run_shared.insert(tool_run, RunShared {
+            default_guards: vec![],
+            dispatch: Registry::default()
+                .with(layer().with_ansi(false).with_writer(SharedWriter(Arc::new(Mutex::new(
+                    File::options()
+                    .append(true)
+                    .create_new(true)
+                    .open(PathBuf::from_iter(todo!()))
+                )))))
+                .with(layer().with_ansi(false).with_writer(shared_inner.messages_file.clone()))
+                .with(layer().with_filter(shared_inner.console_filter.clone()))
+                .into(),
+        });
+        drop(guard);
+        Ok(ToolReporter {
+            shared,
+            tool_run,
+        })
+    }
+
+    /// Log messages reported by tools are written into the correct diagnostic directories by
+    /// thread-local loggers. This sets up that thread-local logger for the current thread,
+    /// logging messages into this tool's diagnostic directory.
+    ///
+    /// Tools only need to call this if they spawn additional threads, as the tool runner will call
+    /// this automatically for the thread that `Tool::run` is called in.
+    pub fn set_thread_logger(&self) {
+        let Some(ref mut shared) = *lock_shared(&self.shared) else {
+            return;
+        };
+        let Some(shared) = shared.run_shared.get_mut(&self.tool_run) else { return };
+        shared.default_guards.push(set_default(&shared.dispatch));
+    }
+}
+
+/// Identifies a particular tool. Conceptually, this is equivalent to the tool's name, but this
+/// design allows us to optimize the representation in the future to e.g. use TypeId for faster
+/// comparisons and hashing.
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+pub(super) struct ToolId {
+    /// The name returned by `Tool::name`.
+    name: &'static str,
+}
+
+impl ToolId {
+    /// Constructs a ToolId for this tool. Note that callers should prefer to construct a ToolId
+    /// once and copy it around when possible rather than repeatedly construct `ToolId`s, in case
+    /// future optimizations make `new` more expensive to decrease the cost of other operations.
+    pub fn new(tool: &dyn Tool) -> ToolId {
+        ToolId { name: tool.name() }
+    }
+}
+
+impl Display for ToolId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+/// An identifier for a tool run. Can be converted into a string, which will look like
+/// `try_cargo_build_2`. This string should be suitable to use as a file/directory name.
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+pub(super) struct ToolRunId {
+    pub tool: ToolId,
+    /// The first run of a particular tool has number 1, the second has 2, etc.
+    pub number: NonZeroU64,
+}
+
+impl Display for ToolRunId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}_{}", self.tool, self.number)
+    }
+}
+
+/// Shared diagnostic data for a particular tool run.
+pub(super) struct RunShared {
+    default_guards: Vec<DefaultGuard>,
+    dispatch: Dispatch,
+}

--- a/translate/src/main.rs
+++ b/translate/src/main.rs
@@ -2,25 +2,23 @@ use clap::Parser;
 use harvest_translate::cli::{Args, initialize};
 use harvest_translate::transpile;
 use harvest_translate::util::{empty_writable_dir, set_user_only_umask};
-use log::{error, info};
 use std::sync::Arc;
 
 fn main() {
     if let Err(e) = run() {
-        error!("{}", e);
+        eprintln!("{}", e);
         std::process::exit(1);
     }
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
     set_user_only_umask();
     let args: Arc<_> = Args::parse().into();
     let Some(config) = initialize(args) else {
         return Ok(()); // An early-exit argument was passed.
     };
     empty_writable_dir(&config.output, config.force).expect("output directory error");
-    let ir = transpile(config)?;
-    info!("{}", ir);
+    let ir = transpile(config.into())?;
+    println!("{}", ir);
     Ok(())
 }

--- a/translate/src/scheduler.rs
+++ b/translate/src/scheduler.rs
@@ -4,8 +4,8 @@
 //! for invoking them.
 
 use crate::tools::Tool;
-use log::debug;
 use std::mem::replace;
+use tracing::debug;
 
 #[derive(Default)]
 pub struct Scheduler {

--- a/translate/src/tools/load_raw_source.rs
+++ b/translate/src/tools/load_raw_source.rs
@@ -4,6 +4,7 @@ use crate::tools::{MightWriteContext, MightWriteOutcome, RunContext, Tool};
 use harvest_ir::{Representation, fs::RawDir};
 use std::fs::read_dir;
 use std::path::{Path, PathBuf};
+use tracing::info;
 
 pub struct LoadRawSource {
     directory: PathBuf,
@@ -19,7 +20,7 @@ impl LoadRawSource {
 
 impl Tool for LoadRawSource {
     fn name(&self) -> &'static str {
-        "LoadRawSource"
+        "load_raw_source"
     }
 
     // LoadRawSource will create a new representation, not modify an existing
@@ -31,7 +32,7 @@ impl Tool for LoadRawSource {
     fn run(self: Box<Self>, context: RunContext) -> Result<(), Box<dyn std::error::Error>> {
         let dir = read_dir(self.directory.clone())?;
         let (rawdir, directories, files) = RawDir::populate_from(dir)?;
-        log::info!(
+        info!(
             "Loaded {directories} directories and {files} files from {}.",
             self.directory.display()
         );

--- a/translate/src/tools/try_cargo_build.rs
+++ b/translate/src/tools/try_cargo_build.rs
@@ -5,6 +5,7 @@ use crate::tools::{MightWriteContext, MightWriteOutcome, RunContext, Tool};
 use harvest_ir::{HarvestIR, Representation, fs::RawDir};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tracing::info;
 
 pub struct TryCargoBuild;
 // Either a vector of compiled artifact filenames (on success)
@@ -49,7 +50,7 @@ fn parse_compiled_artifacts(stdout: &[u8]) -> Result<Vec<PathBuf>, Box<dyn std::
 /// - If the project fails to build, it returns Ok(Err(error_message)).
 /// - If there is an error running cargo, it returns Err.
 fn try_cargo_build(project_path: &PathBuf) -> Result<BuildResult, Box<dyn std::error::Error>> {
-    log::info!("Validating that the generated Rust project builds...");
+    info!("Validating that the generated Rust project builds...");
 
     // Run cargo build in the project directory
     let output = Command::new("cargo")
@@ -67,7 +68,7 @@ fn try_cargo_build(project_path: &PathBuf) -> Result<BuildResult, Box<dyn std::e
         })?;
 
     if output.status.success() {
-        log::info!("Project builds successfully!");
+        info!("Project builds successfully!");
         let artifact_filenames = parse_compiled_artifacts(&output.stdout)?;
         Ok(Ok(artifact_filenames))
     } else {
@@ -151,7 +152,7 @@ impl std::fmt::Display for CargoBuildResult {
 
 impl Representation for CargoBuildResult {
     fn name(&self) -> &'static str {
-        "CargoBuildResult"
+        "cargo_build_result"
     }
 
     fn materialize(&self, _path: &Path) -> std::io::Result<()> {


### PR DESCRIPTION
Note: Still incomplete, I just want to be able to use the review tools while I revise it.

This switches from the `log` library to the `tracing` library, and records debug messages in two places:

1. All messages are logged into `$diagnostic_dir/messages`
2. Messages emitted by tool runs are emitted into `$diagnostic_dir/steps/####/messages`