### PR TITLE
Diagnostics: wait for reporters to be dropped before returning Diagnostics.

### DIFF
--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -84,6 +84,8 @@ pub fn transpile(config: Arc<cli::Config>) -> Result<Arc<HarvestIR>, Box<dyn std
             break;
         }
     }
+    drop(scheduler);
+    drop(runner);
     collector.diagnostics(); // TODO: Return this value (see issue 51)
     Ok(ir_organizer.snapshot())
 }


### PR DESCRIPTION
This changes the ownership model of `diagnostics::Shared`. Now, it is owned by an `Arc`. When `Collector::diagnostics` is called, the `Collector`'s handle is dropped, which (if the other handles have already been dropped), will result in the `Shared` being dropped. When `Shared` is dropped, it sends its `Diagnostics` through a channel to the `Collector`, which the `Collector` waits on.

If we later decide that we don't want the diagnostics system to wait for reporters to be dropped, we can change the other `Shared` references into `Weak` references.