### PR TITLE
Preliminary design for a tool retry mechanism

### DIFF
--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -62,6 +62,7 @@ pub fn translate_c_directory_to_rust_project(
         output: Some(output_dir.to_path_buf()),
         print_config_path: false,
         config: config_overrides.to_vec(),
+        retries: 0,
         force: false,
     }
     .into();

--- a/translate/src/tools/try_cargo_build.rs
+++ b/translate/src/tools/try_cargo_build.rs
@@ -88,12 +88,7 @@ fn raw_cargo_package(ir: &HarvestIR) -> Result<&RawDir, Box<dyn std::error::Erro
 
     match cargo_packages.len() {
         0 => Err("No CargoPackage representation found in IR".into()),
-        1 => Ok(cargo_packages[0]),
-        n => Err(format!(
-            "Found {} CargoPackage representations, expected at most 1",
-            n
-        )
-        .into()),
+        _ => Ok(cargo_packages.last().unwrap()),
     }
 }
 


### PR DESCRIPTION
This PR contains an attempt at implementing a mechanism for retrying tools as part of `Translate`'s workflow.
In particular, this PR adds:
1. A new CLI and config option for providing a max number of retries `--retries`
2. A refactoring of the `RawSourceToCargoLLM` tool to allow it to maintain a persistent LLM chat and incorporate previous compiler errors into its prompt.


There are currently 2 outstanding technical issues:
1. The scheduler does not enforce strict ordering on tool invocations. Currently, `Translate` tools check in `might_write` whether the previous tool's output is present in the IR, but this starts to fail if we run a tool multiple times. The consequence of this is that when we try to run a workflow like:
`LoadSource -> Translate -> TryBuild -> Translate -> TryBuild -> ...`, we can end up getting traces that look like `LoadSource -> Translate -> TryBuild -> TryBuild -> TryBuild -> Translate`. 
My instinct is to make the scheduler enforce a strict ordering by default, but this may be unpopular, so I'm open to alternative ideas here.
2. The `TryBuild` tool needs to write the translated project to disk so that it can run `cargo build`. When we have multiple `TryBuild` runs happening, we should probably write the intermediate runs to temp directories. 

There is also one particularly dubious design decision in this code, which is to do tool-specific LLM initialization in the top-level `translate` function. This was the simplest way to implement a persistent llm session throughout multiple tool invocations, but I'm open to alternative designs.

 