### PR TITLE
Record log messages in the diagnostics directory.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,29 +302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,16 +492,16 @@ dependencies = [
  "clap",
  "config",
  "directories",
- "env_logger",
  "harvest_ir",
  "libc",
  "llm",
- "log",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -787,30 +764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +772,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -892,6 +851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +889,15 @@ checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -997,21 +974,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1443,6 +1405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1530,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1715,9 +1695,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -1725,11 +1705,41 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1785,6 +1795,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -65,7 +65,10 @@ pub fn translate_c_directory_to_rust_project(
         force: false,
     }
     .into();
-    let config = harvest_translate::cli::initialize(args).expect("Failed to generate config");
+    let mut config = harvest_translate::cli::initialize(args).expect("Failed to generate config");
+    if config.log_filter.is_empty() {
+        config.log_filter = "off".to_owned(); // Disable console logging in harvest_translate
+    }
     let tool_config = &config.tools.raw_source_to_cargo_llm;
     log::info!(
         "Translating code using {}:{} with max tokens: {}",
@@ -73,7 +76,7 @@ pub fn translate_c_directory_to_rust_project(
         tool_config.model,
         tool_config.max_tokens
     );
-    let ir_result = transpile(config);
+    let ir_result = transpile(config.into());
     let raw_c_source = raw_source(ir_result.as_ref().unwrap()).unwrap();
     raw_c_source
         .materialize(output_dir.join("c_src"))

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -16,16 +16,16 @@ cargo_metadata = "0.23.0"
 clap = { workspace = true }
 config = { default-features = false, features = ["toml"], version = "0.15.18" }
 directories = "6.0.0"
-env_logger = "0.11.8"
 harvest_ir = { workspace = true }
 libc = "0.2.177"
 llm = { default-features = false, features = ["ollama", "openai", "openrouter", "rustls-tls" ], version = "1.3.4" }
-log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { features = ["net", "rt"], version = "1.47.1" }
+tracing-subscriber = { features = ["env-filter"], version = "0.3.22" }
+tracing = { default-features = false, features = ["std"], version = "0.1.43" }
 
 [lints]
 workspace = true

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -1,6 +1,7 @@
 # The default configurations options for harvest_translate.
 
 force = false
+log_filter = "info"
 
 [tools.raw_source_to_cargo_llm]
 address = "http://localhost:11434"

--- a/translate/src/cli.rs
+++ b/translate/src/cli.rs
@@ -60,6 +60,10 @@ pub struct Config {
     /// If false: if the directory exists and is nonempty, translate will output an error and exit.
     pub force: bool,
 
+    /// Filter describing which log messages should be output to stdout. This is in the
+    /// `tracing_subscriber::filter::EnvFilter` format.
+    pub log_filter: String,
+
     /// Sub-configuration for each tool.
     pub tools: tools::ToolConfigs,
 
@@ -79,6 +83,7 @@ impl Config {
             output: PathBuf::from("mock_output"),
             diagnostics_dir: None,
             force: false,
+            log_filter: "off".to_owned(),
             tools: tools::ToolConfigs::mock(),
             unknown: HashMap::new(),
         }
@@ -103,7 +108,7 @@ pub(crate) fn unknown_field_warning(prefix: &str, unknown: &HashMap<String, Valu
 ///
 /// Returns the config, or None if a command line flag that calls for an early exit (such as
 /// --print_config_path) was provided.
-pub fn initialize(args: Arc<Args>) -> Option<Arc<Config>> {
+pub fn initialize(args: Arc<Args>) -> Option<Config> {
     let dirs = ProjectDirs::from("", "", "harvest").expect("no home directory");
     if args.print_config_path {
         println!("Config file location: {:?}", config_file(dirs.config_dir()));
@@ -112,7 +117,7 @@ pub fn initialize(args: Arc<Args>) -> Option<Arc<Config>> {
     let config = load_config(&args, dirs.config_dir());
     unknown_field_warning("", &config.unknown);
     config.tools.validate();
-    Some(config.into())
+    Some(config)
 }
 
 fn load_config(args: &Args, config_dir: &Path) -> Config {

--- a/translate/src/diagnostics/tests.rs
+++ b/translate/src/diagnostics/tests.rs
@@ -1,0 +1,75 @@
+use super::*;
+use crate::test_util::MockTool;
+use std::{fs::read_to_string, sync::mpsc::channel, thread::spawn};
+
+/// Verifies that tracing messages are written into the correct files.
+#[test]
+fn messages() {
+    let mut config = Config::mock();
+    let tempdir = tempdir().unwrap();
+    config.diagnostics_dir = Some(tempdir.path().to_path_buf());
+    info!("AAAA"); // Should not be collected.
+    let collector = Collector::initialize(&config).unwrap();
+    info!("BBBB");
+    // Spawns a new thread with a tool reporter. Returns the join handle and a closure that makes
+    // the thread write an info! log message. The thread will exit when the closure is dropped.
+    let spawn_tool_thread = |name| {
+        let ((send_msg, recv_msg), (send_done, recv_done)) = (channel(), channel());
+        let reporter = collector.reporter();
+        let join = spawn(move || {
+            let (_, tool_reporter) = reporter
+                .start_tool_run(&MockTool::new().name(name))
+                .unwrap();
+            let _guard = tool_reporter.setup_thread_logger();
+            while let Ok(msg) = recv_msg.recv() {
+                info!("{msg}");
+                send_done.send(()).unwrap();
+            }
+        });
+        (join, move |msg: &'static str| {
+            send_msg.send(msg).unwrap();
+            recv_done.recv().unwrap();
+        })
+    };
+    let (join1, info1) = spawn_tool_thread("tool_a");
+    let (join2, info2) = spawn_tool_thread("tool_b");
+    let (join3, info3) = spawn_tool_thread("tool_a");
+    info!("CCCC");
+    info1("DDDD");
+    info3("EEEE");
+    info!("FFFF");
+    info3("GGGG");
+    info2("HHHH");
+    info3("IIII");
+    info1("JJJJ");
+    info!("KKKK");
+    drop((info1, info2, info3));
+    let _ = [join1, join2, join3].map(|j| j.join().unwrap());
+    info!("LLLL");
+    drop(collector);
+    info!("MMMM"); // Should not be collected
+
+    // Verifies the given file (path relative to the diagnostic directory) contains log lines with
+    // the given contents in order.
+    let verify = |path: &str, expected: &[_]| {
+        let contents = read_to_string(PathBuf::from_iter([tempdir.path(), path.as_ref()])).unwrap();
+        let mut lines = contents.lines();
+        for (i, expected) in expected.iter().enumerate() {
+            let line = lines.next().unwrap();
+            assert!(
+                line.contains(expected),
+                "{path} line number {} contains {line}, expected {expected}",
+                i + 1
+            );
+        }
+        assert_eq!(lines.next(), None);
+    };
+    #[rustfmt::skip]
+    verify(
+        "messages",
+        &["BBBB", "CCCC", "DDDD", "EEEE", "FFFF", "GGGG", "HHHH", "IIII", "JJJJ", "KKKK", "LLLL"],
+    );
+    verify("steps/tool_a_001/messages", &["DDDD", "JJJJ"]);
+    verify("steps/tool_b_001/messages", &["HHHH"]);
+    verify("steps/tool_a_002/messages", &["EEEE", "GGGG", "IIII"]);
+}

--- a/translate/src/main.rs
+++ b/translate/src/main.rs
@@ -2,25 +2,23 @@ use clap::Parser;
 use harvest_translate::cli::{Args, initialize};
 use harvest_translate::transpile;
 use harvest_translate::util::{empty_writable_dir, set_user_only_umask};
-use log::{error, info};
 use std::sync::Arc;
 
 fn main() {
     if let Err(e) = run() {
-        error!("{}", e);
+        eprintln!("{}", e);
         std::process::exit(1);
     }
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
     set_user_only_umask();
     let args: Arc<_> = Args::parse().into();
     let Some(config) = initialize(args) else {
         return Ok(()); // An early-exit argument was passed.
     };
     empty_writable_dir(&config.output, config.force).expect("output directory error");
-    let ir = transpile(config)?;
-    info!("{}", ir);
+    let ir = transpile(config.into())?;
+    println!("{}", ir);
     Ok(())
 }

--- a/translate/src/test_util.rs
+++ b/translate/src/test_util.rs
@@ -35,11 +35,10 @@ pub struct MockTool {
 /// ```
 #[cfg_attr(miri, allow(unused))]
 impl MockTool {
-    /// Creates a new MockTool. The MockTool is boxed, because most users of MockTool will use it
-    /// to create a `Box<dyn Tool>`.
+    /// Creates a new MockTool.
     pub fn new() -> MockTool {
         MockTool {
-            name: "MockTool",
+            name: "mock_tool",
             might_write: Box::new(|_| MightWriteOutcome::Runnable([].into())),
             run: Box::new(|_| Ok(())),
         }

--- a/translate/src/tools/load_raw_source.rs
+++ b/translate/src/tools/load_raw_source.rs
@@ -4,6 +4,7 @@ use crate::tools::{MightWriteContext, MightWriteOutcome, RunContext, Tool};
 use harvest_ir::{Representation, fs::RawDir};
 use std::fs::read_dir;
 use std::path::{Path, PathBuf};
+use tracing::info;
 
 pub struct LoadRawSource {
     directory: PathBuf,
@@ -31,7 +32,7 @@ impl Tool for LoadRawSource {
     fn run(self: Box<Self>, context: RunContext) -> Result<(), Box<dyn std::error::Error>> {
         let dir = read_dir(self.directory.clone())?;
         let (rawdir, directories, files) = RawDir::populate_from(dir)?;
-        log::info!(
+        info!(
             "Loaded {directories} directories and {files} files from {}.",
             self.directory.display()
         );

--- a/translate/src/tools/try_cargo_build.rs
+++ b/translate/src/tools/try_cargo_build.rs
@@ -5,6 +5,7 @@ use crate::tools::{MightWriteContext, MightWriteOutcome, RunContext, Tool};
 use harvest_ir::{HarvestIR, Representation, fs::RawDir};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tracing::info;
 
 pub struct TryCargoBuild;
 // Either a vector of compiled artifact filenames (on success)
@@ -49,7 +50,7 @@ fn parse_compiled_artifacts(stdout: &[u8]) -> Result<Vec<PathBuf>, Box<dyn std::
 /// - If the project fails to build, it returns Ok(Err(error_message)).
 /// - If there is an error running cargo, it returns Err.
 fn try_cargo_build(project_path: &PathBuf) -> Result<BuildResult, Box<dyn std::error::Error>> {
-    log::info!("Validating that the generated Rust project builds...");
+    info!("Validating that the generated Rust project builds...");
 
     // Run cargo build in the project directory
     let output = Command::new("cargo")
@@ -67,7 +68,7 @@ fn try_cargo_build(project_path: &PathBuf) -> Result<BuildResult, Box<dyn std::e
         })?;
 
     if output.status.success() {
-        log::info!("Project builds successfully!");
+        info!("Project builds successfully!");
         let artifact_filenames = parse_compiled_artifacts(&output.stdout)?;
         Ok(Ok(artifact_filenames))
     } else {


### PR DESCRIPTION
This switches from `log` to `tracing` so that the `harvest_translate` library can install thread-local log message writers (`Subscriber`s in `tracing` parlance). On `transpile`'s main thread, messages are written into `$diagnostic_dir/messages` as well as the console (with configurable filtering). On tool threads, the messages are written into `$diagnostic_dir/steps/$tool_run/messages` as well.

The benchmark harness previously suppressed log output from the `harvest_translate` crate. This keeps that behavior, but via a different implementation: now, it configures the console message filter to `off`.