### PR TITLE
Make `reporter` a generic closure

### DIFF
--- a/translate/src/runner.rs
+++ b/translate/src/runner.rs
@@ -99,7 +99,7 @@ impl ToolRunner {
                     ir_edit: &mut edit,
                     ir_snapshot,
                     config,
-                    reporter: tool_reporter,
+                    reporter: Box::new(move || Box::new(tool_reporter.setup_thread_logger())),
                 })
                 .map(|_| edit)
             }));


### PR DESCRIPTION
This aims to decouple RunContext (and thus Tool) from the specific internals of the translate/diagnostics libraries. Rather than store a ToolReporter directly in a the RunContext struct, RunContext stores an arbitrary closure that yields a value to drop at when a thread completes.

Also introduces a wrapper around `std::thread::spawn` that generates and drops the guard.