### PR TITLE
Introduce new file, directory, and symlink abstractions.

### DIFF
--- a/core/src/diagnostics/mod.rs
+++ b/core/src/diagnostics/mod.rs
@@ -13,6 +13,7 @@ mod tool_reporter;
 
 use crate::HarvestIR;
 use crate::config::Config;
+use crate::fs::DirEntry;
 use crate::tools::Tool;
 use crate::utils::{EmptyDirError, empty_writable_dir};
 use std::collections::HashMap;
@@ -33,8 +34,7 @@ use tracing_subscriber::fmt::{MakeWriter, layer};
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::{EnvFilter, Layer as _, Registry};
 
-pub use tool_reporter::ToolJoiner;
-pub use tool_reporter::ToolReporter;
+pub use tool_reporter::{Scratch, ToolJoiner, ToolReporter};
 
 /// Diagnostics produced by transpilation. Can be used by callers of `transpile` to inspect the
 /// diagnostics produced during its execution.
@@ -146,6 +146,29 @@ pub struct Reporter {
 }
 
 impl Reporter {
+    /// Makes a read-only copy of a filesystem object in the diagnostic directory. `path` must be
+    /// relative to the diagnostics directory, and cannot contain `.`, `..`, or symlinks.
+    pub fn copy_ro<P: AsRef<Path>>(&mut self, path: P, entry: DirEntry) -> io::Result<()> {
+        let _ = (path, entry);
+        todo!()
+    }
+
+    /// Makes a read-write copy of a filesystem object in the diagnostic directory. `path` must be
+    /// relative to the diagnostics directory, and cannot contain `.`, `..`, or symlinks.
+    pub fn copy_rw<P: AsRef<Path>>(&mut self, path: P, entry: DirEntry) -> io::Result<()> {
+        let _ = (path, entry);
+        todo!()
+    }
+
+    /// Freezes the given path, returning an object referencing it. `path` must be relative to the
+    /// diagnostics directory, and cannot contain `.` or `..`. This will not follow symlinks (i.e.
+    /// `path` cannot have symlinks in its directory path, and if `path` points to a symlink then a
+    /// Symlink will be returned).
+    pub fn freeze<P: AsRef<Path>>(&mut self, path: P) -> io::Result<DirEntry> {
+        let _ = path;
+        todo!()
+    }
+
     /// Reports a new version of the IR.
     pub fn report_ir_version(&self, version: u64, snapshot: &HarvestIR) {
         let shared = lock_shared(&self.shared);

--- a/core/src/diagnostics/tool_reporter.rs
+++ b/core/src/diagnostics/tool_reporter.rs
@@ -1,14 +1,17 @@
 //! Diagnostics-reporting infrastructure for tools.
 
 use super::{Shared, SharedWriter, lock_shared};
+use crate::fs::DirEntry;
 use crate::tools::Tool;
 use std::fmt::{self, Display, Formatter};
 use std::fs::create_dir;
 use std::io;
 use std::num::NonZeroU64;
+use std::path::Path;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::{collections::hash_map::Entry, path::PathBuf};
+use thiserror::Error;
 use tracing::dispatcher::{DefaultGuard, set_default};
 use tracing::{Dispatch, error, info};
 use tracing_subscriber::fmt::layer;
@@ -76,6 +79,12 @@ impl ToolReporter {
         ))
     }
 
+    /// Creates a new scratch location within this tool's diagnostic directory.
+    pub fn scratch(&self, name: &str) -> Result<Scratch, ScratchError> {
+        let _ = name;
+        todo!()
+    }
+
     /// Initializes log collection for this thread. Tools should call this for each new thread they
     /// spawn, if they spawn threads. Note that the tool runner sets up the thread logger for the
     /// tool's main thread, so Tools that do not spawn any threads do not need to call this.
@@ -96,6 +105,40 @@ impl ToolReporter {
                 poisoned.into_inner()
             }
         }
+    }
+}
+
+/// An error returned by [ToolReporter::scratch]
+#[derive(Debug, Error, Hash, Eq, PartialEq)]
+pub enum ScratchError {
+    #[error("location already exists")]
+    AlreadyExists,
+}
+
+/// A scratch area in a tool run's diagnostic directory. Tools may use this scratch location to
+/// create a file, directory, or symlink. Tools may use `freeze` to freeze the scratch value,
+/// converting it into a [DirEntry] for further use (e.g. to store in a repr). Dropping a `Scratch`
+/// also freezes the directory.
+pub struct Scratch {
+    // TODO: Implement
+}
+
+impl Scratch {
+    /// Freezes this scratch area.
+    pub fn freeze(self) -> io::Result<DirEntry> {
+        todo!()
+    }
+
+    /// Returns the path to this scratch area.
+    pub fn path(&self) -> &Path {
+        todo!()
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        // TODO Freeze the scratch area. Ignore NotFound errors (that just means the scratch area
+        // was not used), but panic on any other error.
     }
 }
 


### PR DESCRIPTION
This API offers the following improvements over the RawDir/RawFile API:

1. It is designed to use hardlinks to make multiple copies of the same file in the diagnostic directory, so that the IR revision portion of the diagnostic output (the `ir/` directory) does not duplicate files after every tool invocation. It can also use reflink copies when writable copies of files are needed, and automatically track whether the diagnostic directory is on a FS that supports reflink copies.
1. It keeps file contents on disk, so file representations won't cause a significant growth in memory usage over time.
1. It has a separate `TextFile` type for files that are valid UTF-8, so tool code does not need to manually call `str::from_utf8` repeatedly (and redundantly).
1. It supports symlinks.

I spent quite a bit of time trying to figure out how to keep file contents on disk (and support hardlinks within the diagnostic directory) without making the API overly complex. The solution I arrived at is to give the API the following limitations:

1. The abstractions are immutable (e.g. `Dir`, `File`, `TextFile`, and `Symlink` cannot be modified).
1. They only represent items in the diagnostic directory, not files outside the diagnostic directory.

Tools that want to create a `Dir` or `File` should:

1. Create scratch space using `ToolReporter::scratch`.
1. Write the directory and/or file contents they want into that scratch space.
1. "freeze" the scratch space contents. This makes the files read-only, and returns abstraction types that reference them.

The resulting `Dir`/`File`/etc types can then be passed around or stored in representations cheaply.

This PR introduces the basic API, but no complex implementations, to keep the review focused on design (and the PR size limited). Future PRs will move the `Dir` and `File` implementations into separate files and provide implementations of their functionality.