### PR TITLE
Make `tracing` a workspace dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,19 +1732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tempfile = "3.23.0"
 thiserror = "2.0.17"
+tracing = { default-features = false, features = ["std"], version = "0.1.44" }
 
 [workspace.lints.clippy]
 self_named_module_files = "warn"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 serde_json.workspace = true
 thiserror = { workspace = true }
 tracing-subscriber = { features = ["env-filter"], version = "0.3.22" }
-tracing = { default-features = false, features = ["std"], version = "0.1.43" }
+tracing.workspace = true
 tempfile = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 

--- a/tools/load_raw_source/Cargo.toml
+++ b/tools/load_raw_source/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 full_source.workspace = true
 harvest_core.workspace = true
-tracing = "0.1.44"
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/tools/raw_source_to_cargo_llm/Cargo.toml
+++ b/tools/raw_source_to_cargo_llm/Cargo.toml
@@ -11,7 +11,7 @@ llm = { default-features = false, features = ["ollama", "openai", "openrouter", 
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = "1.48.0"
-tracing = "0.1.44"
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/tools/try_cargo_build/Cargo.toml
+++ b/tools/try_cargo_build/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 cargo_metadata = "0.23.1"
 full_source.workspace = true
 harvest_core.workspace = true
-tracing = "0.1.44"
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2.177"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tracing = { default-features = false, features = ["std"], version = "0.1.43" }
+tracing.workspace = true
 load_raw_source = { version = "0.1.0", path = "../tools/load_raw_source" }
 identify_project_kind = { version = "0.1.0", path = "../tools/identify_project_kind" }
 try_cargo_build = { version = "0.1.0", path = "../tools/try_cargo_build" }


### PR DESCRIPTION
This removes the duplicate `tracing` dependency definitions by moving them to the workspace. This removes default features requirement, which may help build times a bit.