### PR TITLE
raw_source_to_cargo_llm: make the prompt configurable.

### DIFF
--- a/tools/raw_source_to_cargo_llm/src/lib.rs
+++ b/tools/raw_source_to_cargo_llm/src/lib.rs
@@ -10,6 +10,7 @@ use harvest_core::{Id, Representation};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::fs::read_to_string;
 use std::path::PathBuf;
 use tracing::{debug, info, trace};
 
@@ -48,13 +49,17 @@ impl Tool for RawSourceToCargoLlm {
 
         // Use the llm crate to connect to the LLM.
         // Select system prompt based on project kind
-        let system_prompt = match project_kind {
-            ProjectKind::Executable => SYSTEM_PROMPT_EXECUTABLE,
-            ProjectKind::Library => SYSTEM_PROMPT_LIBRARY,
+        let (config_prompt, builtin_prompt) = match project_kind {
+            ProjectKind::Executable => (config.prompt_executable, SYSTEM_PROMPT_EXECUTABLE),
+            ProjectKind::Library => (config.prompt_library, SYSTEM_PROMPT_LIBRARY),
         };
+        let system_prompt = config_prompt
+            .map(read_to_string)
+            .transpose()?
+            .unwrap_or_else(|| builtin_prompt.to_owned());
 
         // Build LLM client using core/llm
-        let llm = HarvestLLM::build(&config.llm, STRUCTURED_OUTPUT_SCHEMA, system_prompt)?;
+        let llm = HarvestLLM::build(&config.llm, STRUCTURED_OUTPUT_SCHEMA, &system_prompt)?;
 
         // Assemble the LLM request.
         let files: Vec<OutputFile> = in_dir
@@ -103,6 +108,14 @@ pub struct Config {
     #[serde(flatten)]
     pub llm: LLMConfig,
 
+    /// System prompt to use for executable projects. If not specified, a built-in default prompt
+    /// will be used.
+    pub prompt_executable: Option<PathBuf>,
+
+    /// System prompt to use for library projects. If not specified, a built-in default prompt will
+    /// be used.
+    pub prompt_library: Option<PathBuf>,
+
     #[serde(flatten)]
     unknown: HashMap<String, Value>,
 }
@@ -122,6 +135,8 @@ impl Config {
                 model: "mock_model".into(),
                 max_tokens: 1000,
             },
+            prompt_executable: None,
+            prompt_library: None,
             unknown: HashMap::new(),
         }
     }


### PR DESCRIPTION
This adds two config options to the raw_source_to_cargo_llm tool: a system prompt for executables and a system prompt for libraries. These config options should be paths to files containing the prompt text. If a prompt is not given, the existing prompts are used as a fallback.

Closes #41