### PR TITLE
Update Rust to 1.93.

### DIFF
--- a/nightly/rust-toolchain.toml
+++ b/nightly/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-10-10"
+channel = "nightly-2026-02-10"
 components = ["miri", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.93.0"
 components = [ "clippy", "rustfmt", "rust-analyzer" ]


### PR DESCRIPTION
For the filesystem code's tests, I want to use Path's `PartialEq<str>` impl. That impl was stabilized in Rust 1.91. I don't currently see any reason to only update to 1.91, so this updates the toolchain to latest stable (1.93) and the nightly toolchain to today's toolchain.