### PR TITLE
Implement Dir::get.

### DIFF
--- a/core/src/fs/dir/mod.rs
+++ b/core/src/fs/dir/mod.rs
@@ -305,8 +305,8 @@ impl Dir {
                 DirEntry::Symlink(symlink) => symlink,
             };
             // This DirEntry is a symlink. Check the cache to see if we've already encountered it.
-            let link_path: PathBuf = current.iter().map(|p| p.name).chain(once(name)).collect();
-            match cache.entry(link_path.clone()) {
+            let mut link_path: PathBuf = current.iter().map(|p| p.name).chain(once(name)).collect();
+            match cache.entry(link_path) {
                 // We've encountered this symlink before.
                 Entry::Occupied(entry) => match entry.get() {
                     None => return Err(GetError::FilesystemLoop),
@@ -317,9 +317,10 @@ impl Dir {
                     }
                 },
                 Entry::Vacant(entry) => {
+                    link_path = entry.key().clone();
                     entry.insert(None);
                 }
-            }
+            };
             // This is the first time we've encountered this symlink. Add a step to update the
             // symlink cache, and copy the symlink's contents into `remaining` (reminder that
             // `remaining` is reversed).

--- a/core/src/fs/dir/tests.rs
+++ b/core/src/fs/dir/tests.rs
@@ -98,6 +98,7 @@ fn get_basic() -> io::Result<()> {
     assert_dir_contains(dir.get("subdir1"), ["a.txt"]);
     assert_file_contains(dir.get("subdir1/a.txt"), "a");
     assert_dir_contains(dir.get("subdir1/.."), root_names);
+    assert_file_contains(dir.get("symlink"), "b");
     assert_dir_contains(dir.get("subdir2/original_dir"), root_names);
     assert_dir_contains(dir.get("subdir2/original_dir/subdir1"), ["a.txt"]);
     assert_file_contains(dir.get("b.txt"), "b");


### PR DESCRIPTION
`Dir::get` performs lookup like a real filesystem. It handles `.`, `..`, and symlinks.

I definitely would've written a naive algorithm (no caching, no loop detection beyond a limit on the number of steps) if I had known this was going to be so difficult. Alas, I implemented the complete solution, so here it is.

This is the last of the already-written FS code that I have.