### PR TITLE
Track Token Usage

### DIFF
--- a/core/src/llm.rs
+++ b/core/src/llm.rs
@@ -4,10 +4,29 @@
 
 use llm::LLMProvider;
 use llm::builder::{LLMBackend, LLMBuilder};
-pub use llm::chat::ChatMessage;
 use llm::chat::StructuredOutputFormat;
+pub use llm::chat::{ChatMessage, Usage};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+
+/// Aggregated token usage across one or more LLM calls.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LLMUsageTotals {
+    pub prompt_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+}
+
+impl LLMUsageTotals {
+    /// Adds a single call's usage to this aggregate. If usage is absent, no-op.
+    pub fn add_usage(&mut self, usage: Option<&Usage>) {
+        if let Some(usage) = usage {
+            self.prompt_tokens += u64::from(usage.prompt_tokens);
+            self.output_tokens += u64::from(usage.completion_tokens);
+            self.total_tokens += u64::from(usage.total_tokens);
+        }
+    }
+}
 
 /// API Key wrapper that hides the key in debug output.
 #[derive(Deserialize)]
@@ -78,22 +97,27 @@ impl HarvestLLM {
     }
 
     /// Invokes the LLM and cleans up the response.
-    pub fn invoke(&self, request: &[ChatMessage]) -> Result<String, Box<dyn std::error::Error>> {
+    pub fn invoke(
+        &self,
+        request: &[ChatMessage],
+    ) -> Result<(String, Option<Usage>), Box<dyn std::error::Error>> {
         let response = tokio::runtime::Builder::new_current_thread()
             .enable_io()
             .enable_time()
             .build()
             .expect("tokio failed")
-            .block_on(self.client.chat(request))?
-            .text()
-            .expect("no response text");
+            .block_on(self.client.chat(request))?;
+
+        let usage = response.usage();
+
+        let response_text = response.text().expect("no response text");
 
         // Parse the response - strip markdown code fences
-        let response = response.strip_prefix("```").unwrap_or(&response);
-        let response = response.strip_prefix("json").unwrap_or(response);
-        let response = response.strip_suffix("```").unwrap_or(response);
+        let response_text = response_text.strip_prefix("```").unwrap_or(&response_text);
+        let response_text = response_text.strip_prefix("json").unwrap_or(response_text);
+        let response_text = response_text.strip_suffix("```").unwrap_or(response_text);
 
-        Ok(response.to_string())
+        Ok((response_text.to_string(), usage))
     }
 }
 

--- a/tools/modular_translation_llm/src/translation.rs
+++ b/tools/modular_translation_llm/src/translation.rs
@@ -262,6 +262,38 @@ pub fn translate_decls(
 
     let dependencies = collect_dependencies(&combined_translations);
     let cargo_toml = modular_llm.generate_cargo_toml(dependencies, project_kind)?;
+    let usage_by_call = modular_llm.usage_by_call();
+    let usage_totals = modular_llm.usage_totals();
+
+    info!(
+        "token usage [types] - prompt: {}, output: {}, total: {}",
+        usage_by_call.types.prompt_tokens,
+        usage_by_call.types.output_tokens,
+        usage_by_call.types.total_tokens
+    );
+    info!(
+        "token usage [interface] - prompt: {}, output: {}, total: {}",
+        usage_by_call.interface.prompt_tokens,
+        usage_by_call.interface.output_tokens,
+        usage_by_call.interface.total_tokens
+    );
+    info!(
+        "token usage [functions] - prompt: {}, output: {}, total: {}",
+        usage_by_call.functions.prompt_tokens,
+        usage_by_call.functions.output_tokens,
+        usage_by_call.functions.total_tokens
+    );
+    info!(
+        "token usage [cargo_toml] - prompt: {}, output: {}, total: {}",
+        usage_by_call.cargo_toml.prompt_tokens,
+        usage_by_call.cargo_toml.output_tokens,
+        usage_by_call.cargo_toml.total_tokens
+    );
+
+    info!(
+        "token usage [total] - prompt: {}, output: {}, total: {}",
+        usage_totals.prompt_tokens, usage_totals.output_tokens, usage_totals.total_tokens
+    );
 
     Ok(TranslationResult {
         translations: combined_translations,

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -2,10 +2,11 @@
 //! Abstracts away all the string management needed for building dynamically generated prompts and
 //! provides a clean well-typed interface for use by the rest of the transpiler.
 use full_source::RawSource;
-use harvest_core::llm::{HarvestLLM, build_request};
+use harvest_core::llm::{HarvestLLM, LLMUsageTotals, Usage, build_request};
 use identify_project_kind::ProjectKind;
 use serde::Deserialize;
 use serde::Serialize;
+use std::sync::Mutex;
 use tracing::warn;
 
 use crate::Config;
@@ -72,6 +73,42 @@ pub struct ModularTranslationLLM {
     interface_llm: HarvestLLM,
     functions_llm: HarvestLLM,
     cargo_toml_llm: HarvestLLM,
+    usage_totals_by_call: Mutex<ModularLLMUsageTotals>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LLMCallKind {
+    Types,
+    Interface,
+    Functions,
+    CargoToml,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ModularLLMUsageTotals {
+    pub types: LLMUsageTotals,
+    pub interface: LLMUsageTotals,
+    pub functions: LLMUsageTotals,
+    pub cargo_toml: LLMUsageTotals,
+}
+
+impl ModularLLMUsageTotals {
+    pub fn total(&self) -> LLMUsageTotals {
+        LLMUsageTotals {
+            prompt_tokens: self.types.prompt_tokens
+                + self.interface.prompt_tokens
+                + self.functions.prompt_tokens
+                + self.cargo_toml.prompt_tokens,
+            output_tokens: self.types.output_tokens
+                + self.interface.output_tokens
+                + self.functions.output_tokens
+                + self.cargo_toml.output_tokens,
+            total_tokens: self.types.total_tokens
+                + self.interface.total_tokens
+                + self.functions.total_tokens
+                + self.cargo_toml.total_tokens,
+        }
+    }
 }
 
 impl ModularTranslationLLM {
@@ -104,7 +141,33 @@ impl ModularTranslationLLM {
             interface_llm,
             functions_llm,
             cargo_toml_llm,
+            usage_totals_by_call: Mutex::new(ModularLLMUsageTotals::default()),
         })
+    }
+
+    fn record_usage(&self, call_kind: LLMCallKind, usage: Option<&Usage>) {
+        let mut totals_by_call = self
+            .usage_totals_by_call
+            .lock()
+            .expect("usage mutex poisoned in modular translation");
+
+        match call_kind {
+            LLMCallKind::Types => totals_by_call.types.add_usage(usage),
+            LLMCallKind::Interface => totals_by_call.interface.add_usage(usage),
+            LLMCallKind::Functions => totals_by_call.functions.add_usage(usage),
+            LLMCallKind::CargoToml => totals_by_call.cargo_toml.add_usage(usage),
+        }
+    }
+
+    pub fn usage_by_call(&self) -> ModularLLMUsageTotals {
+        *self
+            .usage_totals_by_call
+            .lock()
+            .expect("usage mutex poisoned in modular translation")
+    }
+
+    pub fn usage_totals(&self) -> LLMUsageTotals {
+        self.usage_by_call().total()
     }
 
     /// Translates type declarations to Rust using the types_llm.
@@ -152,7 +215,8 @@ impl ModularTranslationLLM {
             },
         )?;
 
-        let response = self.types_llm.invoke(&request)?;
+        let (response, usage) = self.types_llm.invoke(&request)?;
+        self.record_usage(LLMCallKind::Types, usage.as_ref());
         let translation_result: TypeTranslationResult = serde_json::from_str(&response)?;
         for (decl, translation) in decl_sources
             .iter()
@@ -224,7 +288,8 @@ impl ModularTranslationLLM {
             },
         )?;
 
-        let response = self.functions_llm.invoke(&request)?;
+        let (response, usage) = self.functions_llm.invoke(&request)?;
+        self.record_usage(LLMCallKind::Functions, usage.as_ref());
         let translation_result: FunctionTranslationResult = serde_json::from_str(&response)?;
         let translations = translation_result.translation;
         crate::info!(
@@ -308,7 +373,8 @@ impl ModularTranslationLLM {
             },
         )?;
 
-        let response = self.interface_llm.invoke(&request)?;
+        let (response, usage) = self.interface_llm.invoke(&request)?;
+        self.record_usage(LLMCallKind::Interface, usage.as_ref());
         let interface_result: InterfaceResult = serde_json::from_str(&response)?;
 
         if interface_result.signatures.len() != decl_sources.len() {
@@ -360,7 +426,8 @@ impl ModularTranslationLLM {
             },
         )?;
 
-        let response = self.cargo_toml_llm.invoke(&request)?;
+        let (response, usage) = self.cargo_toml_llm.invoke(&request)?;
+        self.record_usage(LLMCallKind::CargoToml, usage.as_ref());
         let cargo_result: CargoTomlResult = serde_json::from_str(&response)?;
         crate::info!(
             "Cargo.toml Generation complete:\n {}:{:?} \n==>\n {}",

--- a/tools/raw_source_to_cargo_llm/src/lib.rs
+++ b/tools/raw_source_to_cargo_llm/src/lib.rs
@@ -4,7 +4,7 @@
 use full_source::{CargoPackage, RawSource};
 use harvest_core::config::unknown_field_warning;
 use harvest_core::fs::RawDir;
-use harvest_core::llm::{HarvestLLM, LLMConfig, build_request};
+use harvest_core::llm::{HarvestLLM, LLMConfig, LLMUsageTotals, build_request};
 use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
 use serde::{Deserialize, Serialize};
@@ -84,7 +84,9 @@ impl Tool for RawSourceToCargoLlm {
 
         // Make the LLM call.
         trace!("Making LLM call with {:?}", request);
-        let response = llm.invoke(&request)?;
+        let mut usage_totals = LLMUsageTotals::default();
+        let (response, usage) = llm.invoke(&request)?;
+        usage_totals.add_usage(usage.as_ref());
 
         // Parse the response, convert it into a CargoPackage representation.
         #[derive(Deserialize)]
@@ -98,6 +100,12 @@ impl Tool for RawSourceToCargoLlm {
         for file in files.files {
             out_dir.set_file(&file.path, file.contents.into())?;
         }
+
+        info!(
+            "Token usage [total] - prompt: {}, output: {}, total: {}",
+            usage_totals.prompt_tokens, usage_totals.output_tokens, usage_totals.total_tokens
+        );
+
         Ok(Box::new(CargoPackage { dir: out_dir }))
     }
 }


### PR DESCRIPTION
This PR adds token tracking for `raw_source_to_cargo_llm` and `modular_translation_llm` tools. For modular translation, we also break down total token usage by the type of llm call that used the tokens, e.g., `translate types`, `translate interfaces`, etc.

Fixes #113 