### PR TITLE
feat: add kiro-cli translation harness

### DIFF
--- a/scripts/kiro-translate.sh
+++ b/scripts/kiro-translate.sh
@@ -95,7 +95,7 @@ for test_case in "$INPUT_DIR"/*/; do
 
     # Load prompt based on project type
     if [[ "$name" == *_lib ]]; then
-        prompt=$(cat "$SCRIPT_DIR/prompts/library.md")
+        prompt=$(cat "$SCRIPT_DIR/prompts/library.md" | sed "s/LIBRARY_NAME_PLACEHOLDER/$name/")
     else
         prompt=$(cat "$SCRIPT_DIR/prompts/executable.md")
     fi

--- a/scripts/kiro-translate.sh
+++ b/scripts/kiro-translate.sh
@@ -4,6 +4,11 @@
 # Usage:
 #   ./kiro-translate.sh <test-corpus-dir> <output-dir> [--filter regex]
 #
+# Features:
+#   - Skips already-completed cases (resume-friendly)
+#   - Writes per-case status to progress.csv in real-time
+#   - Safe to interrupt — completed cases are preserved
+#
 # Output is compatible with the Test-Corpus Rust runner:
 #   python3 -m runtests.rust --root <output-dir> --subset <output-dir> --keep-going
 
@@ -22,11 +27,29 @@ LOG_DIR="$OUTPUT_DIR/logs_$TIMESTAMP"
 mkdir -p "$LOG_DIR"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROGRESS="$OUTPUT_DIR/progress.csv"
+
+# Initialize progress file if it doesn't exist
+if [[ ! -f "$PROGRESS" ]]; then
+    echo "name,status,timestamp,duration_s" > "$PROGRESS"
+fi
 
 total=0
 translated=0
 failed=0
+skipped=0
 
+# Count total eligible cases first
+for test_case in "$INPUT_DIR"/*/; do
+    name=$(basename "$test_case")
+    [[ -d "$test_case/test_case" && -d "$test_case/test_vectors" ]] || continue
+    if [[ -n "$FILTER" ]] && ! echo "$name" | grep -qE "$FILTER"; then
+        continue
+    fi
+    total=$((total + 1))
+done
+
+current=0
 for test_case in "$INPUT_DIR"/*/; do
     name=$(basename "$test_case")
 
@@ -38,15 +61,25 @@ for test_case in "$INPUT_DIR"/*/; do
         continue
     fi
 
-    total=$((total + 1))
-    echo "[$total] Translating: $name"
+    current=$((current + 1))
+
+    # Skip already-completed cases (resume support)
+    if [[ -f "$OUTPUT_DIR/$name/translated_rust/Cargo.toml" ]]; then
+        skipped=$((skipped + 1))
+        translated=$((translated + 1))
+        echo "[$current/$total] ⏭️  $name (already done)"
+        continue
+    fi
+
+    echo "[$current/$total] Translating: $name"
+    start_time=$(date +%s)
 
     # Set up output directory
     out="$OUTPUT_DIR/$name"
+    rm -rf "$out"
     mkdir -p "$out/translated_rust"
 
-    # Copy test_vectors and runner (for _lib cases), cleaning first to avoid nesting
-    rm -rf "$out/test_vectors" "$out/runner"
+    # Copy test_vectors and runner (for _lib cases)
     cp -r "$test_case/test_vectors" "$out/"
     [[ -d "$test_case/runner" ]] && cp -r "$test_case/runner" "$out/"
 
@@ -69,22 +102,30 @@ for test_case in "$INPUT_DIR"/*/; do
             "$prompt" \
             2>&1 | tee "$LOG_DIR/$name.log" | tail -5
     ); then
+        end_time=$(date +%s)
+        duration=$((end_time - start_time))
         if [[ -f "$out/translated_rust/Cargo.toml" ]]; then
             translated=$((translated + 1))
-            echo "  ✅ $name translated"
+            echo "$name,success,$TIMESTAMP,${duration}" >> "$PROGRESS"
+            echo "  ✅ $name (${duration}s) [$translated translated, $failed failed of $current/$total]"
         else
             failed=$((failed + 1))
-            echo "  ❌ $name failed (no Cargo.toml produced)"
+            echo "$name,no_cargo_toml,$TIMESTAMP,${duration}" >> "$PROGRESS"
+            echo "  ❌ $name — no Cargo.toml (${duration}s) [$translated translated, $failed failed of $current/$total]"
         fi
     else
+        end_time=$(date +%s)
+        duration=$((end_time - start_time))
         failed=$((failed + 1))
-        echo "  ❌ $name failed (kiro-cli error)"
+        echo "$name,error,$TIMESTAMP,${duration}" >> "$PROGRESS"
+        echo "  ❌ $name — kiro-cli error (${duration}s) [$translated translated, $failed failed of $current/$total]"
     fi
-    echo
 done
 
+echo ""
 echo "========================================"
-echo "Done: $translated/$total translated, $failed failed"
+echo "Done: $translated/$total translated, $failed failed, $skipped skipped (already done)"
+echo "Progress: $PROGRESS"
 echo "Logs: $LOG_DIR"
 echo ""
 echo "To validate, run from the Test-Corpus repo:"

--- a/scripts/kiro-translate.sh
+++ b/scripts/kiro-translate.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# kiro-translate.sh — Translate C test cases to Rust using kiro-cli
+#
+# Usage:
+#   ./kiro-translate.sh <test-corpus-dir> <output-dir> [--filter regex]
+#
+# The output is compatible with the Test-Corpus Rust runner:
+#   python3 -m runtests.rust --root <test-corpus-dir> --subset <output-dir>
+#
+# Each test case gets a translated_rust/ directory alongside its test_vectors/.
+
+set -euo pipefail
+
+INPUT_DIR="${1:?Usage: $0 <test-corpus-dir> <output-dir> [--filter regex]}"
+OUTPUT_DIR="${2:?Usage: $0 <test-corpus-dir> <output-dir> [--filter regex]}"
+FILTER="${3:-}"
+
+if [[ "$FILTER" == "--filter" ]]; then
+    FILTER="${4:?--filter requires a regex argument}"
+fi
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_DIR="$OUTPUT_DIR/logs_$TIMESTAMP"
+mkdir -p "$LOG_DIR"
+
+total=0
+translated=0
+failed=0
+
+for test_case in "$INPUT_DIR"/*/; do
+    name=$(basename "$test_case")
+
+    # Must have test_case/ and test_vectors/
+    [[ -d "$test_case/test_case" && -d "$test_case/test_vectors" ]] || continue
+
+    # Apply filter if provided
+    if [[ -n "$FILTER" ]] && ! echo "$name" | grep -qE "$FILTER"; then
+        continue
+    fi
+
+    total=$((total + 1))
+    echo "[$total] Translating: $name"
+
+    # Set up output directory mirroring Test-Corpus structure
+    out="$OUTPUT_DIR/$name"
+    mkdir -p "$out/translated_rust"
+
+    # Copy test_vectors and runner (for _lib cases) so the Rust runner can find them
+    cp -r "$test_case/test_vectors" "$out/"
+    [[ -d "$test_case/runner" ]] && cp -r "$test_case/runner" "$out/"
+
+    # Load prompt based on project type
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ "$name" == *_lib ]]; then
+        prompt=$(cat "$SCRIPT_DIR/prompts/library.md")
+    else
+        prompt=$(cat "$SCRIPT_DIR/prompts/executable.md")
+    fi
+
+    # Invoke kiro-cli
+    (
+        cd "$out/translated_rust"
+        mkdir -p c_src
+        cp -r "$test_case/test_case/src/"* c_src/ 2>/dev/null || true
+        cp "$test_case/test_case/include/"* c_src/ 2>/dev/null || true
+
+        kiro-cli chat \
+            --no-interactive \
+            --trust-all-tools \
+            "$prompt" \
+            2>&1 | tee "$LOG_DIR/$name.log" | tail -5
+    )
+
+    if [[ -f "$out/translated_rust/Cargo.toml" ]]; then
+        translated=$((translated + 1))
+        echo "  ✅ $name translated"
+    else
+        failed=$((failed + 1))
+        echo "  ❌ $name failed"
+    fi
+    echo
+done
+
+echo "========================================"
+echo "Done: $translated/$total translated, $failed failed"
+echo "Logs: $LOG_DIR"
+echo ""
+echo "To validate, run from the Test-Corpus repo:"
+echo "  python3 -m runtests.rust --root $OUTPUT_DIR --keep-going"

--- a/scripts/kiro-translate.sh
+++ b/scripts/kiro-translate.sh
@@ -81,7 +81,17 @@ for test_case in "$INPUT_DIR"/*/; do
 
     # Copy test_vectors and runner (for _lib cases)
     cp -r "$test_case/test_vectors" "$out/"
-    [[ -d "$test_case/runner" ]] && cp -r "$test_case/runner" "$out/"
+    if [[ -d "$test_case/runner" ]]; then
+        cp -r "$test_case/runner" "$out/"
+        # Fix cando2 relative path to absolute
+        if [[ -f "$out/runner/Cargo.toml" ]]; then
+            CANDO2_ABS="$(cd "$INPUT_DIR" && realpath ../../../tools/cando2 2>/dev/null || realpath "$INPUT_DIR/../../tools/cando2" 2>/dev/null || echo "")"
+            if [[ -n "$CANDO2_ABS" && -d "$CANDO2_ABS" ]]; then
+                sed -i '' "s|path = \"../../../../tools/cando2\"|path = \"$CANDO2_ABS\"|" "$out/runner/Cargo.toml" 2>/dev/null || \
+                sed -i "s|path = \"../../../../tools/cando2\"|path = \"$CANDO2_ABS\"|" "$out/runner/Cargo.toml" 2>/dev/null || true
+            fi
+        fi
+    fi
 
     # Load prompt based on project type
     if [[ "$name" == *_lib ]]; then
@@ -105,6 +115,10 @@ for test_case in "$INPUT_DIR"/*/; do
         end_time=$(date +%s)
         duration=$((end_time - start_time))
         if [[ -f "$out/translated_rust/Cargo.toml" ]]; then
+            # Add workspace isolation so this package isn't pulled into a parent workspace
+            if ! grep -q '\[workspace\]' "$out/translated_rust/Cargo.toml"; then
+                echo -e '\n[workspace]' >> "$out/translated_rust/Cargo.toml"
+            fi
             translated=$((translated + 1))
             echo "$name,success,$TIMESTAMP,${duration}" >> "$PROGRESS"
             echo "  ✅ $name (${duration}s) [$translated translated, $failed failed of $current/$total]"
@@ -124,6 +138,25 @@ done
 
 echo ""
 echo "========================================"
+
+# Generate root workspace Cargo.toml for lib runners
+runners=""
+for runner_toml in "$OUTPUT_DIR"/*/runner/Cargo.toml; do
+    [[ -f "$runner_toml" ]] || continue
+    dir=$(dirname "$runner_toml")
+    rel=${dir#"$OUTPUT_DIR/"}
+    runners="$runners    \"$rel\","$'\n'
+done
+if [[ -n "$runners" ]]; then
+    cat > "$OUTPUT_DIR/Cargo.toml" << EOF
+[workspace]
+members = [
+$runners]
+resolver = "2"
+EOF
+    echo "Generated root workspace with $(echo "$runners" | wc -l | tr -d ' ') lib runners"
+fi
+
 echo "Done: $translated/$total translated, $failed failed, $skipped skipped (already done)"
 echo "Progress: $PROGRESS"
 echo "Logs: $LOG_DIR"

--- a/scripts/kiro-translate.sh
+++ b/scripts/kiro-translate.sh
@@ -4,10 +4,8 @@
 # Usage:
 #   ./kiro-translate.sh <test-corpus-dir> <output-dir> [--filter regex]
 #
-# The output is compatible with the Test-Corpus Rust runner:
-#   python3 -m runtests.rust --root <test-corpus-dir> --subset <output-dir>
-#
-# Each test case gets a translated_rust/ directory alongside its test_vectors/.
+# Output is compatible with the Test-Corpus Rust runner:
+#   python3 -m runtests.rust --root <output-dir> --subset <output-dir> --keep-going
 
 set -euo pipefail
 
@@ -22,6 +20,8 @@ fi
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 LOG_DIR="$OUTPUT_DIR/logs_$TIMESTAMP"
 mkdir -p "$LOG_DIR"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 total=0
 translated=0
@@ -41,42 +41,44 @@ for test_case in "$INPUT_DIR"/*/; do
     total=$((total + 1))
     echo "[$total] Translating: $name"
 
-    # Set up output directory mirroring Test-Corpus structure
+    # Set up output directory
     out="$OUTPUT_DIR/$name"
     mkdir -p "$out/translated_rust"
 
-    # Copy test_vectors and runner (for _lib cases) so the Rust runner can find them
+    # Copy test_vectors and runner (for _lib cases), cleaning first to avoid nesting
+    rm -rf "$out/test_vectors" "$out/runner"
     cp -r "$test_case/test_vectors" "$out/"
     [[ -d "$test_case/runner" ]] && cp -r "$test_case/runner" "$out/"
 
     # Load prompt based on project type
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     if [[ "$name" == *_lib ]]; then
         prompt=$(cat "$SCRIPT_DIR/prompts/library.md")
     else
         prompt=$(cat "$SCRIPT_DIR/prompts/executable.md")
     fi
 
-    # Invoke kiro-cli
-    (
+    # Invoke kiro-cli, capturing failures without killing the script
+    if (
         cd "$out/translated_rust"
         mkdir -p c_src
-        cp -r "$test_case/test_case/src/"* c_src/ 2>/dev/null || true
-        cp "$test_case/test_case/include/"* c_src/ 2>/dev/null || true
+        cp -a "$test_case/test_case/." c_src/
 
         kiro-cli chat \
             --no-interactive \
             --trust-all-tools \
             "$prompt" \
             2>&1 | tee "$LOG_DIR/$name.log" | tail -5
-    )
-
-    if [[ -f "$out/translated_rust/Cargo.toml" ]]; then
-        translated=$((translated + 1))
-        echo "  ✅ $name translated"
+    ); then
+        if [[ -f "$out/translated_rust/Cargo.toml" ]]; then
+            translated=$((translated + 1))
+            echo "  ✅ $name translated"
+        else
+            failed=$((failed + 1))
+            echo "  ❌ $name failed (no Cargo.toml produced)"
+        fi
     else
         failed=$((failed + 1))
-        echo "  ❌ $name failed"
+        echo "  ❌ $name failed (kiro-cli error)"
     fi
     echo
 done
@@ -86,4 +88,4 @@ echo "Done: $translated/$total translated, $failed failed"
 echo "Logs: $LOG_DIR"
 echo ""
 echo "To validate, run from the Test-Corpus repo:"
-echo "  python3 -m runtests.rust --root $OUTPUT_DIR --keep-going"
+echo "  python3 -m runtests.rust --root $OUTPUT_DIR --subset $OUTPUT_DIR --keep-going"

--- a/scripts/prompts/executable.md
+++ b/scripts/prompts/executable.md
@@ -1,0 +1,8 @@
+Translate the C code in c_src/ to an idiomatic Rust Cargo project.
+Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+This is an EXECUTABLE. Requirements:
+- The binary name in Cargo.toml must be "driver" (use [[bin]] name = "driver")
+- Preserve the exact I/O behavior (same stdout output for same inputs)
+- Use safe Rust internally where possible
+Run 'cargo build --release' and fix any errors until it compiles.
+Do NOT modify anything in c_src/.

--- a/scripts/prompts/executable.md
+++ b/scripts/prompts/executable.md
@@ -1,9 +1,14 @@
 <!-- markdownlint-disable MD041 -->
-Translate the C code in c_src/ to an idiomatic Rust Cargo project.
+Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
 Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+
 This is an EXECUTABLE. Requirements:
 - The binary name in Cargo.toml must be "driver" (use [[bin]] name = "driver")
-- Preserve the exact I/O behavior (same stdout output for same inputs)
+- Do NOT fix bugs in the original C code — if the C has incorrect behavior, reproduce it exactly
+- Preserve the exact order of error checks and validation
+- Match C's stdin reading behavior exactly (scanf reads across newlines, fgets does not)
+- Match C's exact printf format output including spacing and newlines
 - Use safe Rust internally where possible
+
 Run 'cargo build --release' and fix any errors until it compiles.
 Do NOT modify anything in c_src/.

--- a/scripts/prompts/executable.md
+++ b/scripts/prompts/executable.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 Translate the C code in c_src/ to an idiomatic Rust Cargo project.
 Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
 This is an EXECUTABLE. Requirements:

--- a/scripts/prompts/library.md
+++ b/scripts/prompts/library.md
@@ -3,7 +3,7 @@ Translate the C code in c_src/ to Rust that produces **byte-identical output** f
 Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
 
 This is a LIBRARY. Requirements:
-- Read c_src/CMakeLists.txt to find the library name (from add_library(<name> ...)) and use that EXACT name as the package name in Cargo.toml
+- The package name in Cargo.toml MUST be exactly: LIBRARY_NAME_PLACEHOLDER
 - Cargo.toml must have crate-type = ["cdylib"] under [lib]
 - All public C functions must use #[unsafe(no_mangle)] and extern "C"
 - Preserve the exact C function signatures (use *const c_char, c_int, etc. from std::ffi)

--- a/scripts/prompts/library.md
+++ b/scripts/prompts/library.md
@@ -1,0 +1,9 @@
+Translate the C code in c_src/ to an idiomatic Rust Cargo project.
+Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+This is a LIBRARY. Requirements:
+- Cargo.toml must have crate-type = ["cdylib"] under [lib]
+- All public C functions must use #[unsafe(no_mangle)] and extern "C"
+- Preserve the exact C function signatures (use *const c_char, c_int, etc. from std::ffi)
+- Use safe Rust internally where possible
+Run 'cargo build' and fix any errors until it compiles.
+Do NOT modify anything in c_src/.

--- a/scripts/prompts/library.md
+++ b/scripts/prompts/library.md
@@ -3,6 +3,7 @@ Translate the C code in c_src/ to Rust that produces **byte-identical output** f
 Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
 
 This is a LIBRARY. Requirements:
+- Read c_src/CMakeLists.txt to find the library name (from add_library(<name> ...)) and use that EXACT name as the package name in Cargo.toml
 - Cargo.toml must have crate-type = ["cdylib"] under [lib]
 - All public C functions must use #[unsafe(no_mangle)] and extern "C"
 - Preserve the exact C function signatures (use *const c_char, c_int, etc. from std::ffi)

--- a/scripts/prompts/library.md
+++ b/scripts/prompts/library.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 Translate the C code in c_src/ to an idiomatic Rust Cargo project.
 Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
 This is a LIBRARY. Requirements:

--- a/scripts/prompts/library.md
+++ b/scripts/prompts/library.md
@@ -5,5 +5,5 @@ This is a LIBRARY. Requirements:
 - All public C functions must use #[unsafe(no_mangle)] and extern "C"
 - Preserve the exact C function signatures (use *const c_char, c_int, etc. from std::ffi)
 - Use safe Rust internally where possible
-Run 'cargo build' and fix any errors until it compiles.
+Run 'cargo build --release' and fix any errors until it compiles.
 Do NOT modify anything in c_src/.

--- a/scripts/prompts/library.md
+++ b/scripts/prompts/library.md
@@ -1,10 +1,14 @@
 <!-- markdownlint-disable MD041 -->
-Translate the C code in c_src/ to an idiomatic Rust Cargo project.
+Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
 Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+
 This is a LIBRARY. Requirements:
 - Cargo.toml must have crate-type = ["cdylib"] under [lib]
 - All public C functions must use #[unsafe(no_mangle)] and extern "C"
 - Preserve the exact C function signatures (use *const c_char, c_int, etc. from std::ffi)
+- Do NOT fix bugs in the original C code — if the C has incorrect behavior, reproduce it exactly
+- Preserve the exact order of error checks and validation
 - Use safe Rust internally where possible
+
 Run 'cargo build --release' and fix any errors until it compiles.
 Do NOT modify anything in c_src/.


### PR DESCRIPTION
Adds a script that uses kiro-cli as an agentic C-to-Rust translator. Unlike HARVEST's single-shot LLM approach, kiro-cli can iteratively read files, compile, and fix errors until the code builds.

## Files
- `scripts/kiro-translate.sh` — harness that loops over test cases
- `scripts/prompts/executable.md` — prompt for executable translations
- `scripts/prompts/library.md` — prompt for library translations (FFI-aware)

## Usage

```bash
# Translate all B01_synthetic cases
./scripts/kiro-translate.sh \
  /path/to/Test-Corpus/Public-Tests/B01_synthetic \
  /tmp/kiro_results

# Filter to specific cases
./scripts/kiro-translate.sh \
  /path/to/Test-Corpus/Public-Tests/B01_synthetic \
  /tmp/kiro_results \
  --filter "001_helloworld$"
```

## Validation

Output is compatible with the Test-Corpus Rust runner:
```bash
cd /path/to/Test-Corpus
python3 -m runtests.rust --root /tmp/kiro_results --subset /tmp/kiro_results --keep-going
```

## Testing

Tested on B01_synthetic/001_helloworld — translation, build, and all 3 test vectors pass.