### PR TITLE
feat: add --pre-translated mode, --include-ub flag, and has_ub filtering

### DIFF
--- a/benchmark/src/cli.rs
+++ b/benchmark/src/cli.rs
@@ -40,4 +40,12 @@ pub struct Args {
     /// Cannot be used together with --filter.
     #[arg(long, conflicts_with = "filter")]
     pub exclude: Option<String>,
+    /// Use pre-translated results instead of running translation.
+    /// When set, input_dir is the test corpus and output_dir has existing translations.
+    #[arg(long)]
+    pub pre_translated: bool,
+
+    /// Include test vectors with undefined behavior (skipped by default).
+    #[arg(long)]
+    pub include_ub: bool,
 }

--- a/benchmark/src/harness/library.rs
+++ b/benchmark/src/harness/library.rs
@@ -80,7 +80,8 @@ pub fn run_library_validation(
     output_dir: &Path,
     test_cases: &[TestCase],
     timeout: u64,
-) -> HarvestResult<(Vec<TestResult>, Vec<String>, usize)> {
+    include_ub: bool,
+) -> HarvestResult<(Vec<TestResult>, Vec<String>, usize, usize)> {
     // === Library-specific preparation ===
 
     // Prevent cargo from attaching to the parent workspace
@@ -134,7 +135,13 @@ pub fn run_library_validation(
     log::info!("Runner binary located at: {}", runner_bin.display());
 
     // Run tests
-    run_test_suite(&runner_bin, &ld_library_path, test_cases, timeout)
+    run_test_suite(
+        &runner_bin,
+        &ld_library_path,
+        test_cases,
+        timeout,
+        include_ub,
+    )
 }
 
 /// Locates the compiled shared library artifact in the target directory.
@@ -150,25 +157,42 @@ pub fn run_library_validation(
 /// # Returns
 /// Path to the shared library file (.so, .dylib, or .dll)
 pub fn locate_compiled_library(output_dir: &Path, program_name: &str) -> HarvestResult<PathBuf> {
-    let pkg_name = cargo_utils::read_package_name(&output_dir.join("Cargo.toml"))
-        .unwrap_or_else(|| program_name.to_string());
+    let cargo_toml = output_dir.join("Cargo.toml");
     let target_release = output_dir.join("target").join("release");
 
-    // Construct expected library name from package name
-    let lib_stem = format!("lib{}", pkg_name.replace('-', "_"));
+    // Try [lib] name first (cargo uses this for the .so filename), then package name
+    let candidates: Vec<String> = {
+        let mut c = Vec::new();
+        if let Ok(contents) = fs::read_to_string(&cargo_toml) {
+            if let Ok(doc) = contents.parse::<toml_edit::DocumentMut>() {
+                if let Some(name) = doc
+                    .get("lib")
+                    .and_then(|l| l.get("name"))
+                    .and_then(|n| n.as_str())
+                {
+                    c.push(name.replace('-', "_"));
+                }
+            }
+        }
+        let pkg_name =
+            cargo_utils::read_package_name(&cargo_toml).unwrap_or_else(|| program_name.to_string());
+        c.push(pkg_name.replace('-', "_"));
+        c
+    };
 
-    // Try common extensions
-    for ext in LIBRARY_EXTENSIONS {
-        let lib_path = target_release.join(format!("{}.{}", lib_stem, ext));
-        if lib_path.exists() {
-            return Ok(lib_path);
+    for name in &candidates {
+        let lib_stem = format!("lib{}", name);
+        for ext in LIBRARY_EXTENSIONS {
+            let lib_path = target_release.join(format!("{}.{}", lib_stem, ext));
+            if lib_path.exists() {
+                return Ok(lib_path);
+            }
         }
     }
 
-    // If not found, return error with helpful message
     Err(format!(
-        "Library not found: expected {} in {}",
-        lib_stem,
+        "Library not found: tried {:?} in {}",
+        candidates,
         target_release.display()
     )
     .into())
@@ -460,15 +484,29 @@ pub fn run_test_suite(
     ld_library_path: &str,
     test_cases: &[TestCase],
     timeout: u64,
-) -> HarvestResult<(Vec<TestResult>, Vec<String>, usize)> {
+    include_ub: bool,
+) -> HarvestResult<(Vec<TestResult>, Vec<String>, usize, usize)> {
     let mut test_results = Vec::new();
     let mut error_messages = Vec::new();
     let mut passed_tests = 0;
+    let mut skipped_tests = 0;
     let timeout_duration = Duration::from_secs(timeout);
 
     log::info!("Validating library outputs against test cases...");
 
     for (i, test_case) in test_cases.iter().enumerate() {
+        // Skip has_ub test vectors (mark as skipped+passed, matching MIT runtests)
+        if !include_ub && test_case.has_ub.is_some() {
+            skipped_tests += 1;
+            passed_tests += 1;
+            test_results.push(TestResult {
+                filename: test_case.filename.clone(),
+                passed: true,
+                skipped: true,
+            });
+            continue;
+        }
+
         log::info!(
             "Running library test case {} ({} of {})...",
             test_case.filename,
@@ -485,6 +523,7 @@ pub fn run_test_suite(
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: true,
+                    skipped: false,
                 });
                 log::info!("✅ Test case {} passed", test_case.filename);
             }
@@ -492,16 +531,17 @@ pub fn run_test_suite(
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: false,
+                    skipped: false,
                 });
                 let error = format_test_failure(&test_case.filename, &output);
                 error_messages.push(error.clone());
                 log::info!("❌ Test case {} failed: {}", test_case.filename, error);
             }
             Err(e) => {
-                // Treat runner errors as failed tests rather than aborting the entire suite
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: false,
+                    skipped: false,
                 });
                 let error = format!("Test case {} failed: {}", test_case.filename, e);
                 error_messages.push(error.clone());
@@ -510,7 +550,7 @@ pub fn run_test_suite(
         }
     }
 
-    Ok((test_results, error_messages, passed_tests))
+    Ok((test_results, error_messages, passed_tests, skipped_tests))
 }
 
 /// Runs a single library test case.

--- a/benchmark/src/harness/mod.rs
+++ b/benchmark/src/harness/mod.rs
@@ -35,7 +35,7 @@ pub struct TestCase {
     pub stdout: StdoutPattern,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub rc: Option<usize>,
+    pub rc: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub has_ub: Option<String>,
@@ -269,9 +269,13 @@ pub fn validate_binary_output(
     let actual_stdout = String::from_utf8_lossy(&output.stdout);
     let actual_stderr = String::from_utf8_lossy(&output.stderr);
 
+    // Check return code (default expected: 0)
+    let expected_rc = test_case.rc.unwrap_or(0);
+    let actual_rc = output.status.code().unwrap_or(-1);
+    let rc_ok = actual_rc == expected_rc;
+
     // Compare stdout against expected pattern
-    let matches = if test_case.stdout.is_regex {
-        // Use regex matching
+    let stdout_ok = if test_case.stdout.is_regex {
         let regex = Regex::new(&test_case.stdout.pattern).map_err(|e| {
             format!(
                 "Invalid regex pattern '{}': {}",
@@ -280,24 +284,35 @@ pub fn validate_binary_output(
         })?;
         regex.is_match(actual_stdout.trim())
     } else {
-        // Use simple equality matching
         actual_stdout.trim() == test_case.stdout.pattern.trim()
     };
 
-    if matches {
+    if rc_ok && stdout_ok {
         Ok(())
     } else {
-        let pattern_type = if test_case.stdout.is_regex {
-            "regex pattern"
-        } else {
-            "expected stdout"
-        };
+        let mut reasons = Vec::new();
+        if !stdout_ok {
+            let pattern_type = if test_case.stdout.is_regex {
+                "Regex pattern"
+            } else {
+                "Expected stdout"
+            };
+            reasons.push(format!(
+                "{}: {}\n\nActual stdout:\n{}",
+                pattern_type, test_case.stdout.pattern, actual_stdout
+            ));
+        }
+        if !rc_ok {
+            reasons.push(format!(
+                "Expected rc={}, actual rc={}",
+                expected_rc, actual_rc
+            ));
+        }
         Err(format!(
-            "❌ Binary produced unexpected output:\n\n{}: {}\n\nActual stdout:\n{}\n\nActual stderr:\n{}",
-            pattern_type.chars().next().unwrap().to_uppercase().collect::<String>() + &pattern_type[1..],
-            test_case.stdout.pattern,
-            actual_stdout,
+            "❌ Binary produced unexpected output:\n\n{}\n\nActual stderr:\n{}",
+            reasons.join("\n\n"),
             actual_stderr
-        ).into())
+        )
+        .into())
     }
 }

--- a/benchmark/src/io.rs
+++ b/benchmark/src/io.rs
@@ -33,6 +33,7 @@ pub fn write_csv_results(file_path: &PathBuf, results: &[ProgramEvalStats]) -> H
         "rust_build_success",
         "total_tests",
         "passed_tests",
+        "skipped_tests",
         "success_rate",
         "error_message",
     ])?;
@@ -45,6 +46,7 @@ pub fn write_csv_results(file_path: &PathBuf, results: &[ProgramEvalStats]) -> H
             &result.rust_build_success.to_string(),
             &result.total_tests.to_string(),
             &result.passed_tests.to_string(),
+            &result.skipped_tests.to_string(),
             &format!("{:.2}", result.success_rate()),
             result.error_message.as_deref().unwrap_or(""),
         ])?;

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -25,6 +25,7 @@ use harvest_translate::{transpile, util::set_user_only_umask};
 use regex::Regex;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 
 /// Encapsulate important results from transpilation
@@ -124,6 +125,8 @@ pub fn run_all_benchmarks(
     config_overrides: &[String],
     timeout: u64,
     modular: bool,
+    pre_translated: bool,
+    include_ub: bool,
 ) -> HarvestResult<Vec<ProgramEvalStats>> {
     // Process all examples
     let mut results = Vec::new();
@@ -134,8 +137,15 @@ pub fn run_all_benchmarks(
         log::info!("Processing example {} of {}", i + 1, total_examples);
         log::info!("{}", "=".repeat(80));
 
-        let result =
-            benchmark_single_program(program_dir, output_dir, config_overrides, timeout, modular);
+        let result = benchmark_single_program(
+            program_dir,
+            output_dir,
+            config_overrides,
+            timeout,
+            modular,
+            pre_translated,
+            include_ub,
+        );
 
         results.push(result);
     }
@@ -149,14 +159,28 @@ fn run_test_validation(
     test_cases: &[crate::harness::TestCase],
     timeout: u64,
     output_dir: &Path,
-) -> (Vec<TestResult>, Vec<String>, usize) {
+    include_ub: bool,
+) -> (Vec<TestResult>, Vec<String>, usize, usize) {
     let mut test_results = Vec::new();
     let mut error_messages = Vec::new();
     let mut passed_tests = 0;
+    let mut skipped_tests = 0;
 
     log::info!("Validating Rust binary outputs against test cases...");
 
     for (i, test_case) in test_cases.iter().enumerate() {
+        // Skip has_ub test vectors (mark as skipped+passed, matching MIT runtests)
+        if !include_ub && test_case.has_ub.is_some() {
+            skipped_tests += 1;
+            passed_tests += 1;
+            test_results.push(TestResult {
+                filename: test_case.filename.clone(),
+                passed: true,
+                skipped: true,
+            });
+            continue;
+        }
+
         log::info!(
             "Running test case {} ({} of {})...",
             test_case.filename,
@@ -177,6 +201,7 @@ fn run_test_validation(
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: true,
+                    skipped: false,
                 });
                 log::info!("✅ Test case {} passed", test_case.filename);
             }
@@ -184,6 +209,7 @@ fn run_test_validation(
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: false,
+                    skipped: false,
                 });
                 let error = format!("Test case {} failed: {}", test_case.filename, e);
                 error_messages.push(error);
@@ -195,7 +221,7 @@ fn run_test_validation(
         }
     }
 
-    (test_results, error_messages, passed_tests)
+    (test_results, error_messages, passed_tests, skipped_tests)
 }
 
 /// Run all benchmarks for a single program
@@ -205,6 +231,8 @@ fn benchmark_single_program(
     config_overrides: &[String],
     timeout: u64,
     modular: bool,
+    pre_translated: bool,
+    include_ub: bool,
 ) -> ProgramEvalStats {
     let program_name = program_dir
         .file_name()
@@ -225,6 +253,12 @@ fn benchmark_single_program(
     // Get program output directory
     let output_dir = output_root_dir.join(&program_name);
     log::info!("Output directory: {}", output_dir.display());
+
+    // In pre-translated mode, skip cases without a Cargo.toml (not translated)
+    if pre_translated && !output_dir.join("Cargo.toml").exists() {
+        log::info!("⏭️  Skipping {} (no translation found)", program_name);
+        return result;
+    }
 
     // Check for required subdirectories & log error if we don't find them
     // We use the test_case root (not src/) so translate can see CMakeLists.txt.
@@ -252,59 +286,99 @@ fn benchmark_single_program(
         log::info!("✅ Successfully parsed {} test case(s)", test_cases.len());
     }
 
-    // Do the actual translation
-    let translation_result = translate_c_directory_to_rust_project(
-        &test_case_dir,
-        &output_dir,
-        config_overrides,
-        modular,
-    );
-
-    result.translation_success = translation_result.translation_success;
-    result.rust_build_success = translation_result.build_success;
-
-    if translation_result.translation_success {
-        log::info!("✅ Translation completed successfully!");
+    // Do the actual translation (or skip if pre-translated)
+    let rust_binary_path;
+    if pre_translated {
+        result.translation_success = true;
+        // Build the pre-translated project
+        let build_output = Command::new("cargo")
+            .args(["build", "--release", "--message-format=json"])
+            .current_dir(&output_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+        match build_output {
+            Ok(output) if output.status.success() => {
+                result.rust_build_success = true;
+                // Discover binary from cargo JSON output (exec cases only)
+                rust_binary_path = if !is_lib {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    stdout
+                        .lines()
+                        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+                        .find_map(|v| {
+                            if v["reason"] == "compiler-artifact"
+                                && v["target"]["kind"]
+                                    .as_array()
+                                    .is_some_and(|k| k.iter().any(|e| e == "bin"))
+                            {
+                                v["executable"].as_str().map(PathBuf::from)
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or_default()
+                } else {
+                    PathBuf::new()
+                };
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                result.error_message = Some(format!("cargo build --release failed: {}", stderr));
+                return result;
+            }
+            Err(e) => {
+                result.error_message = Some(format!("Failed to run cargo build: {}", e));
+                return result;
+            }
+        }
     } else {
-        let error = format!(
-            "Failed to translate C project: {:?}",
-            translation_result.build_error
+        let translation_result = translate_c_directory_to_rust_project(
+            &test_case_dir,
+            &output_dir,
+            config_overrides,
+            modular,
         );
-        result.error_message = Some(error.clone());
-        log::info!("❌ Translation failed");
-        return result;
-    }
 
-    if translation_result.build_success {
-        log::info!("✅ Rust build completed successfully!");
-    } else {
-        let error = format!(
-            "Failed to build Rust project: {:?}",
-            translation_result.build_error
-        );
-        result.error_message = Some(error.clone());
-        log::info!("❌ Rust build failed");
-        return result;
-    }
+        result.translation_success = translation_result.translation_success;
+        result.rust_build_success = translation_result.build_success;
 
-    if !is_lib && !translation_result.rust_binary_path.exists() {
-        let error = format!(
-            "Rust build reported success, but expected output artifact was not found at {:?}",
-            translation_result.rust_binary_path
-        );
-        log::error!("{}", error);
-        result.error_message = Some(error);
-        return result;
+        if !translation_result.translation_success {
+            result.error_message = Some(format!(
+                "Failed to translate C project: {:?}",
+                translation_result.build_error
+            ));
+            return result;
+        }
+
+        if !translation_result.build_success {
+            result.error_message = Some(format!(
+                "Failed to build Rust project: {:?}",
+                translation_result.build_error
+            ));
+            return result;
+        }
+
+        rust_binary_path = translation_result.rust_binary_path;
+
+        if !is_lib && !rust_binary_path.exists() {
+            result.error_message = Some(format!(
+                "Rust build reported success, but expected output artifact was not found at {:?}",
+                rust_binary_path
+            ));
+            return result;
+        }
     }
 
     // Library and executable validation differ.
-    let (test_results, error_messages, passed_tests) = if is_lib {
+    let (test_results, error_messages, passed_tests, skipped_tests) = if is_lib {
         match harness::library::run_library_validation(
             &program_name,
             program_dir,
             &output_dir,
             &test_cases,
             timeout,
+            include_ub,
         ) {
             Ok(r) => r,
             Err(e) => {
@@ -316,15 +390,17 @@ fn benchmark_single_program(
         }
     } else {
         run_test_validation(
-            &translation_result.rust_binary_path,
+            &rust_binary_path,
             &test_cases,
             timeout,
             &output_dir,
+            include_ub,
         )
     };
 
     result.test_results = test_results;
     result.passed_tests = passed_tests;
+    result.skipped_tests = skipped_tests;
 
     // Print summary for this example
     log::info!("\nResults for {}:", program_name);
@@ -446,6 +522,8 @@ fn run(args: Args) -> HarvestResult<()> {
         &args.config,
         args.timeout,
         args.modular,
+        args.pre_translated,
+        args.include_ub,
     )?;
     let csv_output_path = args.output_dir.join("results.csv");
     write_csv_results(&csv_output_path, &results)?;

--- a/benchmark/src/stats.rs
+++ b/benchmark/src/stats.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 pub struct TestResult {
     pub filename: String,
     pub passed: bool,
+    pub skipped: bool,
 }
 
 /// Statistics for running many tests on a single program
@@ -15,6 +16,7 @@ pub struct ProgramEvalStats {
     pub rust_build_success: bool,
     pub total_tests: usize,
     pub passed_tests: usize,
+    pub skipped_tests: usize,
     pub error_message: Option<String>,
     // Store individual test results with filenames and pass/fail status
     pub test_results: Vec<TestResult>,
@@ -28,6 +30,7 @@ impl ProgramEvalStats {
             rust_build_success: false,
             total_tests: 0,
             passed_tests: 0,
+            skipped_tests: 0,
             error_message: None,
             test_results: Vec::new(),
         }
@@ -51,6 +54,7 @@ pub struct SummaryStats {
     pub successful_rust_builds: usize,
     pub total_tests: usize,
     pub total_passed_tests: usize,
+    pub total_skipped_tests: usize,
 }
 
 impl SummaryStats {
@@ -90,6 +94,7 @@ impl SummaryStats {
             successful_rust_builds: results.iter().filter(|r| r.rust_build_success).count(),
             total_tests: results.iter().map(|r| r.total_tests).sum(),
             total_passed_tests: results.iter().map(|r| r.passed_tests).sum(),
+            total_skipped_tests: results.iter().map(|r| r.skipped_tests).sum(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Minimal changes to the existing benchmark tool to support standalone evaluation of pre-translated results, matching MIT runner behavior.

### Changes

1. **`--pre-translated` flag**: Skips translation and tests pre-existing Rust projects against test vectors. Runs `cargo build --release`, discovers binary from JSON output (exec) or uses existing lib validation (lib). Skips cases without `Cargo.toml`.

2. **`--include-ub` flag**: By default, test vectors with `has_ub` are skipped (not run, matching MIT `runtests`). Pass `--include-ub` to run them. Skipped tests are tracked separately from passed in both stats and CSV output (`skipped_tests` column), enabling different statistics: `passed/total`, `(passed-skipped)/(total-skipped)`, etc.

3. **`locate_compiled_library` fix**: Checks `[lib] name` from Cargo.toml first, then falls back to package name.

4. **`rc` field fix**: Changed from `usize` to `i32` to handle negative return codes (e.g. `-11` for segfault). Previously, test vectors with negative `rc` silently failed to parse and were dropped. Also added return code validation against expected `rc` (default 0), matching MIT runner.

### Usage

```bash
# Pre-translated mode (test only, skipping UB by default)
cargo run --release --bin=benchmark -- <corpus_dir> <results_dir> --pre-translated

# Include UB test vectors
cargo run --release --bin=benchmark -- <corpus_dir> <results_dir> --pre-translated --include-ub
```

### Verified against existing results

Using `harvest-translate-results/3_2_results/B01_synthetic/B01_synthetic_e2e_codex`:

```bash
cargo run --release --bin=benchmark -- \
  ../Test-Corpus/Public-Tests/B01_synthetic \
  ../harvest-translate-results/3_2_results/B01_synthetic/B01_synthetic_e2e_codex \
  --pre-translated --timeout 10 --include-ub
```

| Mode | Cases | Builds | Tests | Skipped |
|---|---|---|---|---|
| With UB | 85 | 83/85 | 354/417 (84.9%) | 0 |
| Without UB | 85 | 83/85 | 372/417 (89.2%) | 24 |

Note: Amit's reported number is 348/412 (84.5%). The difference is because this PR fixes silent dropping of 5 test vectors that had negative `rc` values (e.g. `rc: -11`), which previously failed `usize` deserialization. With the fix, total test count is 417 instead of 412.