### PR TITLE
Benchmark: don't run UB tests & mark skipped

### DIFF
--- a/benchmark/src/harness/library.rs
+++ b/benchmark/src/harness/library.rs
@@ -80,7 +80,7 @@ pub fn run_library_validation(
     output_dir: &Path,
     test_cases: &[TestCase],
     timeout: u64,
-) -> HarvestResult<(Vec<TestResult>, Vec<String>, usize)> {
+) -> HarvestResult<(Vec<TestResult>, Vec<String>)> {
     // === Library-specific preparation ===
 
     // Prevent cargo from attaching to the parent workspace
@@ -460,15 +460,28 @@ pub fn run_test_suite(
     ld_library_path: &str,
     test_cases: &[TestCase],
     timeout: u64,
-) -> HarvestResult<(Vec<TestResult>, Vec<String>, usize)> {
+) -> HarvestResult<(Vec<TestResult>, Vec<String>)> {
     let mut test_results = Vec::new();
     let mut error_messages = Vec::new();
-    let mut passed_tests = 0;
     let timeout_duration = Duration::from_secs(timeout);
 
     log::info!("Validating library outputs against test cases...");
 
     for (i, test_case) in test_cases.iter().enumerate() {
+        if test_case.has_ub.is_some() {
+            log::info!(
+                "Skipping library test case {} ({} of {})",
+                test_case.filename,
+                i + 1,
+                test_cases.len()
+            );
+            test_results.push(TestResult {
+                filename: test_case.filename.clone(),
+                passed: true,
+                skipped: true,
+            });
+            continue;
+        }
         log::info!(
             "Running library test case {} ({} of {})...",
             test_case.filename,
@@ -481,10 +494,10 @@ pub fn run_test_suite(
 
         match result {
             Ok(output) if output.status.success() => {
-                passed_tests += 1;
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: true,
+                    skipped: false,
                 });
                 log::info!("✅ Test case {} passed", test_case.filename);
             }
@@ -492,6 +505,7 @@ pub fn run_test_suite(
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: false,
+                    skipped: false,
                 });
                 let error = format_test_failure(&test_case.filename, &output);
                 error_messages.push(error.clone());
@@ -502,6 +516,7 @@ pub fn run_test_suite(
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: false,
+                    skipped: false,
                 });
                 let error = format!("Test case {} failed: {}", test_case.filename, e);
                 error_messages.push(error.clone());
@@ -510,7 +525,7 @@ pub fn run_test_suite(
         }
     }
 
-    Ok((test_results, error_messages, passed_tests))
+    Ok((test_results, error_messages))
 }
 
 /// Runs a single library test case.

--- a/benchmark/src/io.rs
+++ b/benchmark/src/io.rs
@@ -33,6 +33,7 @@ pub fn write_csv_results(file_path: &PathBuf, results: &[ProgramEvalStats]) -> H
         "rust_build_success",
         "total_tests",
         "passed_tests",
+        "skipped_tests",
         "success_rate",
         "error_message",
     ])?;
@@ -45,6 +46,7 @@ pub fn write_csv_results(file_path: &PathBuf, results: &[ProgramEvalStats]) -> H
             &result.rust_build_success.to_string(),
             &result.total_tests.to_string(),
             &result.passed_tests.to_string(),
+            &result.skipped_tests.to_string(),
             &format!("{:.2}", result.success_rate()),
             result.error_message.as_deref().unwrap_or(""),
         ])?;

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -149,14 +149,27 @@ fn run_test_validation(
     test_cases: &[crate::harness::TestCase],
     timeout: u64,
     output_dir: &Path,
-) -> (Vec<TestResult>, Vec<String>, usize) {
+) -> (Vec<TestResult>, Vec<String>) {
     let mut test_results = Vec::new();
     let mut error_messages = Vec::new();
-    let mut passed_tests = 0;
 
     log::info!("Validating Rust binary outputs against test cases...");
 
     for (i, test_case) in test_cases.iter().enumerate() {
+        if test_case.has_ub.is_some() {
+            log::info!(
+                "Skipping test case {} ({} of {})",
+                test_case.filename,
+                i + 1,
+                test_cases.len()
+            );
+            test_results.push(TestResult {
+                filename: test_case.filename.clone(),
+                passed: true,
+                skipped: true,
+            });
+            continue;
+        }
         log::info!(
             "Running test case {} ({} of {})...",
             test_case.filename,
@@ -173,10 +186,10 @@ fn run_test_validation(
         let timeout_opt = Some(timeout);
         match validate_binary_output(binary_path, test_case, timeout_opt) {
             Ok(()) => {
-                passed_tests += 1;
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: true,
+                    skipped: false,
                 });
                 log::info!("✅ Test case {} passed", test_case.filename);
             }
@@ -184,6 +197,7 @@ fn run_test_validation(
                 test_results.push(TestResult {
                     filename: test_case.filename.clone(),
                     passed: false,
+                    skipped: false,
                 });
                 let error = format!("Test case {} failed: {}", test_case.filename, e);
                 error_messages.push(error);
@@ -195,7 +209,7 @@ fn run_test_validation(
         }
     }
 
-    (test_results, error_messages, passed_tests)
+    (test_results, error_messages)
 }
 
 /// Run all benchmarks for a single program
@@ -298,7 +312,7 @@ fn benchmark_single_program(
     }
 
     // Library and executable validation differ.
-    let (test_results, error_messages, passed_tests) = if is_lib {
+    let (test_results, error_messages) = if is_lib {
         match harness::library::run_library_validation(
             &program_name,
             program_dir,
@@ -323,8 +337,12 @@ fn benchmark_single_program(
         )
     };
 
+    result.passed_tests = test_results
+        .iter()
+        .filter(|t| t.passed && !t.skipped)
+        .count();
+    result.skipped_tests = test_results.iter().filter(|t| t.skipped).count();
     result.test_results = test_results;
-    result.passed_tests = passed_tests;
 
     // Print summary for this example
     log::info!("\nResults for {}:", program_name);

--- a/benchmark/src/stats.rs
+++ b/benchmark/src/stats.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 pub struct TestResult {
     pub filename: String,
     pub passed: bool,
+    pub skipped: bool,
 }
 
 /// Statistics for running many tests on a single program
@@ -15,6 +16,7 @@ pub struct ProgramEvalStats {
     pub rust_build_success: bool,
     pub total_tests: usize,
     pub passed_tests: usize,
+    pub skipped_tests: usize,
     pub error_message: Option<String>,
     // Store individual test results with filenames and pass/fail status
     pub test_results: Vec<TestResult>,
@@ -28,6 +30,7 @@ impl ProgramEvalStats {
             rust_build_success: false,
             total_tests: 0,
             passed_tests: 0,
+            skipped_tests: 0,
             error_message: None,
             test_results: Vec::new(),
         }
@@ -39,7 +42,7 @@ impl ProgramEvalStats {
             return 0.0;
         };
 
-        (self.passed_tests as f64 / self.total_tests as f64) * 100.0
+        (self.passed_tests as f64 / (self.total_tests - self.skipped_tests) as f64) * 100.0
     }
 }
 
@@ -50,6 +53,7 @@ pub struct SummaryStats {
     pub successful_translations: usize,
     pub successful_rust_builds: usize,
     pub total_tests: usize,
+    pub total_skipped_tests: usize,
     pub total_passed_tests: usize,
 }
 
@@ -89,6 +93,7 @@ impl SummaryStats {
             successful_translations: results.iter().filter(|r| r.translation_success).count(),
             successful_rust_builds: results.iter().filter(|r| r.rust_build_success).count(),
             total_tests: results.iter().map(|r| r.total_tests).sum(),
+            total_skipped_tests: results.iter().map(|r| r.skipped_tests).sum(),
             total_passed_tests: results.iter().map(|r| r.passed_tests).sum(),
         }
     }


### PR DESCRIPTION
In the benchmark, check if test vectors include the `has_ub` field and, if so, do not run them. Instead, mark them as passed and skipped.

Then, when outputting results to CSV, output `passed_tests` as tests that passed and were not skipped, and `skipped_tests` as tests that were skipped.

Subsumes part of #120 