### PR TITLE
Modular: Keep function definitions over declarations

### DIFF
--- a/tools/modular_translation_llm/src/clang.rs
+++ b/tools/modular_translation_llm/src/clang.rs
@@ -96,7 +96,19 @@ fn deduplicate_decls(declarations: &mut Vec<ClangNode<'_>>) {
         match seen_names.get(&name) {
             Some((existing_idx, existing_has_no_included_from)) => {
                 // We've seen this name before
-                if has_no_included_from && !existing_has_no_included_from {
+                if matches!(node.kind, Clang::FunctionDecl { .. })
+                    && node
+                        .inner
+                        .iter()
+                        .filter(|n| !matches!(n.kind, Clang::ParmVarDecl { .. }))
+                        .count()
+                        > 0
+                {
+                    // Current is a function body, not just a
+                    // declaration, so keep this one
+                    to_remove.insert(*existing_idx);
+                    seen_names.insert(name, (idx, has_no_included_from));
+                } else if has_no_included_from && !existing_has_no_included_from {
                     // Current is better (has no included_from, existing does)
                     to_remove.insert(*existing_idx);
                     seen_names.insert(name, (idx, has_no_included_from));


### PR DESCRIPTION
Adds a tie-break when multiple definitions exist in the AST that favors definitions over merely declarations. This ensures that function bodies are still available for translation after deduplication.

This fixes a fairly prevalent error in modular translations where the final output has a `todo!()` as the function body for any function that is first declared and then defined later. The build succeeds but virtually no tests pass.

The solution is a bit hacky: just look at the AST inner nodes and if any are not `ParamVarDecl`s, it takes the current node is a function definition, and assumes there is only one definition (no tie break between multiple definitions, e.g. if one is weak other than last one wins).