### PR TITLE
Insert imports when generate the rust program

### DIFF
--- a/tools/modular_translation_llm/src/recombine.rs
+++ b/tools/modular_translation_llm/src/recombine.rs
@@ -21,13 +21,7 @@ fn prepend_dependency_imports(translations: &[RustDeclaration], rust_code: Strin
         .collect::<Vec<_>>()
         .join("\n");
 
-    if imports.is_empty() {
-        rust_code
-    } else if rust_code.trim().is_empty() {
-        imports
-    } else {
-        format!("{imports}\n\n{rust_code}")
-    }
+    (imports + "\n\n" + &rust_code).trim().into()
 }
 
 /// Recombines translated Rust declarations into a CargoPackage representation.


### PR DESCRIPTION
When Harvest does modular translation of functions, it requests the LLM to report the imports that its translated code uses. Here, we deduplicate the imports and generate an appropriate set of `use` statements. It seems to be improving build performance pretty dramatically - I should have some numbers soon.