### PR TITLE
Pipeline support for fixing cargo build errors with LLM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "quantize_rust_spans"
+version = "0.1.0"
+dependencies = [
+ "full_source",
+ "harvest_core",
+ "proc-macro2",
+ "serde",
+ "serde_json",
+ "syn",
+ "tracing",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
+name = "fix_declarations_llm"
+version = "0.1.0"
+dependencies = [
+ "cargo_metadata",
+ "full_source",
+ "harvest_core",
+ "quantize_rust_spans",
+ "serde",
+ "serde_json",
+ "syn",
+ "tracing",
+ "try_cargo_build",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_project_spec", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans" ]
+members = ["benchmark", "core", "tools/full_source", "tools/build_project_spec", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans" , "tools/fix_declarations_llm"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -13,6 +13,7 @@ raw_source_to_cargo_llm = { path = "tools/raw_source_to_cargo_llm" }
 try_cargo_build = { path = "tools/try_cargo_build" }
 c_ast = { path = "tools/c_ast" }
 modular_translation_llm = { path = "tools/modular_translation_llm" }
+quantize_rust_spans = { path = "tools/quantize_rust_spans" }
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_project_spec", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "translate", "tools/c_ast", "tools/modular_translation_llm" ]
+members = ["benchmark", "core", "tools/full_source", "tools/build_project_spec", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans" ]
 resolver = "3"
 
 [workspace.dependencies]

--- a/benchmark/src/ir_utils.rs
+++ b/benchmark/src/ir_utils.rs
@@ -1,10 +1,9 @@
 use crate::error::HarvestResult;
 use harvest_core::fs::RawDir;
 use harvest_core::HarvestIR;
-use std::path::PathBuf;
 
 use full_source::{CargoPackage, RawSource};
-use try_cargo_build::CargoBuildResult;
+use try_cargo_build::{Artifact, CargoBuildResult};
 
 /// Extract a single CargoPackage representation from the IR.
 /// Returns an error if there are 0 or multiple CargoPackage representations.
@@ -42,15 +41,15 @@ pub fn raw_source(ir: &HarvestIR) -> HarvestResult<&RawDir> {
 
 /// Extract cargo build results from the IR.
 /// Returns the build artifacts or an error if no results or multiple results are found.
-pub fn cargo_build_result(ir: &HarvestIR) -> Result<Vec<PathBuf>, String> {
-    let build_results: Vec<Result<Vec<PathBuf>, String>> = ir
+pub fn cargo_build_result(ir: &HarvestIR) -> Result<&Vec<Artifact>, String> {
+    let build_results: Vec<_> = ir
         .get_by_representation::<CargoBuildResult>()
-        .map(|(_, r)| r.result.clone())
+        .map(|(_, r)| &r.artifacts)
         .collect();
 
     match build_results.len() {
         0 => Err("No artifacts built".into()),
-        1 => build_results[0].clone(),
+        1 => Ok(build_results[0]),
         n => Err(format!("Found {} build results, expected at most 1", n)),
     }
 }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 pub struct TranspilationResult {
     translation_success: bool,
     build_success: bool,
-    rust_binary_path: PathBuf,
+    rust_binary_path: Option<PathBuf>,
     build_error: Option<String>,
 }
 
@@ -45,16 +45,17 @@ impl TranspilationResult {
                     // Empty artifacts list indicates build succeeded but produced no output
                     (
                         false,
-                        PathBuf::new(),
+                        None,
                         Some("Build succeeded but produced no artifacts".to_string()),
                     )
                 } else {
-                    // Prefer the first artifact as the "binary" path for executable cases.
-                    let first = artifacts.first().cloned().unwrap();
+                    let first = artifacts
+                        .iter()
+                        .find_map(|a| a.executable.as_ref().map(|e| e.as_std_path().into()));
                     (true, first, None)
                 }
             }
-            Err(err) => (false, PathBuf::new(), Some(err.clone())),
+            Err(err) => (false, None, Some(err.clone())),
         };
 
         Self {
@@ -113,7 +114,7 @@ pub fn translate_c_directory_to_rust_project(
             TranspilationResult {
                 translation_success: false,
                 build_success: false,
-                rust_binary_path: PathBuf::new(),
+                rust_binary_path: None,
                 build_error: Some(format!("Failed to transpile: {}", e)),
             }
         }
@@ -304,40 +305,37 @@ fn benchmark_single_program(
         return result;
     }
 
-    if !is_lib && !translation_result.rust_binary_path.exists() {
-        let error = format!(
-            "Rust build reported success, but expected output artifact was not found at {:?}",
-            translation_result.rust_binary_path
-        );
-        log::error!("{}", error);
-        result.error_message = Some(error);
-        return result;
-    }
-
     // Library and executable validation differ.
-    let (test_results, error_messages) = if is_lib {
-        match harness::library::run_library_validation(
-            &program_name,
-            program_dir,
-            &output_dir,
-            &test_cases,
-            timeout,
-        ) {
-            Ok(r) => r,
-            Err(e) => {
-                let error_msg = format!("Library validation failed: {}", e);
-                log::error!("{}", error_msg);
-                result.error_message = Some(error_msg);
-                return result;
+    let (test_results, error_messages) = match (is_lib, translation_result.rust_binary_path) {
+        (true, _) => {
+            match harness::library::run_library_validation(
+                &program_name,
+                program_dir,
+                &output_dir,
+                &test_cases,
+                timeout,
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    let error_msg = format!("Library validation failed: {}", e);
+                    log::error!("{}", error_msg);
+                    result.error_message = Some(error_msg);
+                    return result;
+                }
             }
         }
-    } else {
-        run_test_validation(
-            &translation_result.rust_binary_path,
-            &test_cases,
-            timeout,
-            &output_dir,
-        )
+        (false, Some(binary_path)) if binary_path.exists() => {
+            run_test_validation(&binary_path, &test_cases, timeout, &output_dir)
+        }
+        (_, binary_path) => {
+            let error = format!(
+                "Rust build reported success, but expected output artifact was not found at {:?}",
+                binary_path
+            );
+            log::error!("{}", error);
+            result.error_message = Some(error);
+            return result;
+        }
     };
 
     result.passed_tests = test_results

--- a/core/src/fs/mod.rs
+++ b/core/src/fs/mod.rs
@@ -23,7 +23,7 @@ mod freezer;
 
 use crate::utils::{EmptyDirError, empty_writable_dir};
 use std::collections::{BTreeMap, btree_map};
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs::Permissions;
 use std::fs::ReadDir;
 use std::fs::canonicalize;
@@ -182,7 +182,7 @@ impl Symlink {
 
 // TODO: Remove; RawEntry is being replaced by DirEntry.
 /// A representation of a file-system directory entry.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum RawEntry {
     Dir(RawDir),
@@ -207,7 +207,7 @@ impl RawEntry {
 
 /// A representation of a file-system directory tree.
 // TODO: Removed; RawDir is being replaced by Dir.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct RawDir(BTreeMap<OsString, RawEntry>);
 
@@ -310,38 +310,41 @@ impl RawDir {
     /// just removes the previously-specified directory (in general
     /// this isn't correct in the presence of symlinks, but `RawDir`
     /// does not support symlinks).
-    pub fn get_file<P: AsRef<Path>>(&self, path: P) -> Result<&Vec<u8>, GetFileError> {
-        // Determine which directories we need to descend into to reach the file (handling normal
-        // directory names as well as . and ..), and split out the file name.
-        let mut segments = vec![];
-        // Whether the most-recently-processed entry can be a file.
-        let mut last_can_be_file = true;
-        for component in path.as_ref().components() {
-            last_can_be_file = match component {
-                Component::CurDir => false,
-                Component::Normal(name) => {
-                    segments.push(name);
-                    true
-                }
-                Component::ParentDir => {
-                    if segments.pop().is_none() {
-                        return Err(GetFileError::OutsideDir);
-                    }
-                    false
-                }
-                Component::Prefix(_) | Component::RootDir => {
-                    return Err(GetFileError::AbsolutePath);
-                }
-            };
+    pub fn get_file_mut<P: AsRef<Path>>(&mut self, path: P) -> Result<&mut Vec<u8>, GetFileError> {
+        let (segments, file_name) = resolve_file_path(path.as_ref())?;
+
+        let mut cur_dir = self;
+        for component in segments {
+            if let RawEntry::Dir(rd) = cur_dir
+                .0
+                .get_mut(component)
+                .ok_or(GetFileError::DoesNotExist)?
+            {
+                cur_dir = rd;
+            } else {
+                return Err(GetFileError::UnderFile);
+            }
         }
-        if !last_can_be_file {
-            return Err(GetFileError::Directory);
+        if let RawEntry::File(v) = cur_dir
+            .0
+            .get_mut(file_name)
+            .ok_or(GetFileError::DoesNotExist)?
+        {
+            Ok(v)
+        } else {
+            Err(GetFileError::Directory)
         }
-        let file_name = match segments.pop() {
-            None => return Err(GetFileError::DoesNotExist),
-            Some(empty) if empty.is_empty() => return Err(GetFileError::DoesNotExist),
-            Some(name) => name,
-        };
+    }
+
+    /// Gets the contents of a file at the given path. The file must
+    /// exist. On success, returns a reference to file's contents.
+    ///
+    /// `path` must be a relative path. `..` is resolved lexically: it
+    /// just removes the previously-specified directory (in general
+    /// this isn't correct in the presence of symlinks, but `RawDir`
+    /// does not support symlinks).
+    pub fn get_file<P: AsRef<Path>>(&self, path: P) -> Result<&[u8], GetFileError> {
+        let (segments, file_name) = resolve_file_path(path.as_ref())?;
 
         let mut cur_dir = self;
         for component in segments {
@@ -631,4 +634,41 @@ mod tests {
             PathBuf::from_iter([diagnostics_dir.path(), "relative/path".as_ref()])
         );
     }
+}
+
+// Helper function that deconstructs a [Path] to a vector of directory
+// components and a file component.
+fn resolve_file_path(path: &Path) -> Result<(Vec<&OsStr>, &OsStr), GetFileError> {
+    // Determine which directories we need to descend into to reach the file (handling normal
+    // directory names as well as . and ..), and split out the file name.
+    let mut segments = vec![];
+    // Whether the most-recently-processed entry can be a file.
+    let mut last_can_be_file = true;
+    for component in path.components() {
+        last_can_be_file = match component {
+            Component::CurDir => false,
+            Component::Normal(name) => {
+                segments.push(name);
+                true
+            }
+            Component::ParentDir => {
+                if segments.pop().is_none() {
+                    return Err(GetFileError::OutsideDir);
+                }
+                false
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(GetFileError::AbsolutePath);
+            }
+        };
+    }
+    if !last_can_be_file {
+        return Err(GetFileError::Directory);
+    }
+    let file_name = match segments.pop() {
+        None => return Err(GetFileError::DoesNotExist),
+        Some(empty) if empty.is_empty() => return Err(GetFileError::DoesNotExist),
+        Some(name) => name,
+    };
+    Ok((segments, file_name))
 }

--- a/tools/fix_declarations_llm/Cargo.toml
+++ b/tools/fix_declarations_llm/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fix_declarations_llm"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+harvest_core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+try_cargo_build.workspace = true
+full_source.workspace = true
+quantize_rust_spans.workspace = true
+cargo_metadata = "0.23.1"
+syn = { version = "2", features = ["full"] }
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/fix_declarations_llm/src/fix_llm.rs
+++ b/tools/fix_declarations_llm/src/fix_llm.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+
+use harvest_core::config::unknown_field_warning;
+use harvest_core::llm::{ChatMessage, HarvestLLM, LLMConfig};
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Configuration read from `[tools.fix_declarations_llm]`.
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    #[serde(flatten)]
+    pub llm: LLMConfig,
+
+    #[serde(flatten)]
+    unknown: HashMap<String, Value>,
+}
+
+impl Config {
+    pub fn validate(&self) {
+        unknown_field_warning("tools.fix_declarations_llm", &self.unknown);
+    }
+}
+
+// LLM wrapper
+
+#[derive(Debug, Deserialize)]
+struct FixResult {
+    fixed_code: String,
+}
+
+pub struct FixLlm {
+    llm: HarvestLLM,
+}
+
+impl FixLlm {
+    pub fn new(config: &LLMConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        let system_prompt = include_str!("prompts/fix/system_prompt.txt");
+        let schema = include_str!("prompts/fix/structured_schema.json");
+        let llm = HarvestLLM::build(config, schema, system_prompt)?;
+        Ok(FixLlm { llm })
+    }
+
+    pub fn fix_declaration(
+        &self,
+        decl_source: &str,
+        errors_text: &str,
+        context: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let prompt = include_str!("prompts/fix/user_prompt.txt")
+            .replace("{context}", context)
+            .replace("{errors}", errors_text)
+            .replace("{declaration}", decl_source);
+
+        let messages = vec![ChatMessage::user().content(&prompt).build()];
+        let (response, _usage) = self.llm.invoke(&messages)?;
+        let result: FixResult = serde_json::from_str(&response).map_err(|e| {
+            format!("Failed to parse fix LLM response as JSON: {e}\nResponse: {response}")
+        })?;
+
+        Ok(result.fixed_code.trim_end_matches('\n').to_string())
+    }
+}

--- a/tools/fix_declarations_llm/src/lib.rs
+++ b/tools/fix_declarations_llm/src/lib.rs
@@ -1,0 +1,262 @@
+//! `FixDeclarationsLlm`: calls the LLM to repair declarations that have compiler errors,
+//! producing an updated `SplitPackage` with fixed declarations and a recomputed line index.
+
+use cargo_metadata::diagnostic::{Diagnostic, DiagnosticLevel};
+use full_source::CargoPackage;
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use quantize_rust_spans::RustItemMap;
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+use std::ops::{Bound, RangeBounds as _};
+use std::path::PathBuf;
+use syn::spanned::Spanned;
+use tracing::{info, warn};
+use try_cargo_build::CargoBuildResult;
+
+mod fix_llm;
+// Stub helpers (for interface context)
+
+fn stub_item(item: syn::Item, source: &[u8]) -> String {
+    let mut source = Vec::from(source);
+    match item {
+        syn::Item::Fn(f) => {
+            let todo = "{ todo!() }".bytes();
+            source.splice(f.block.span().byte_range(), todo);
+        }
+        syn::Item::Impl(impl_block) => {
+            let mut pieces = vec![];
+            let mut last_end = 0;
+            impl_block.items.iter().for_each(|impl_item| {
+                if let syn::ImplItem::Fn(method) = impl_item {
+                    let byte_range = method.block.span().byte_range();
+                    pieces.push(source[last_end..byte_range.start].to_vec());
+
+                    pieces.push(b"{ todo!() }".to_vec());
+                    last_end = byte_range.end;
+                }
+            });
+            pieces.push(source[last_end..].to_vec());
+            source = pieces.into_iter().flatten().collect();
+        }
+        _ => {}
+    }
+    String::from_utf8(source).unwrap()
+}
+
+fn stub_declaration(source: &[u8]) -> Option<String> {
+    let sstr = str::from_utf8(source).ok()?;
+    let Ok(file) = syn::parse_file(sstr) else {
+        return Some(sstr.trim_end_matches('\n').to_string());
+    };
+    file.items
+        .into_iter()
+        .map(|item| stub_item(item, source))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .into()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_stub_declaration() {
+        assert_eq!(
+            Some(
+                r"
+fn foo() { todo!() }
+"
+                .into()
+            ),
+            super::stub_declaration(
+                br"
+fn foo() { println!() }
+"
+            )
+        );
+
+        assert_eq!(
+            Some(
+                r"
+
+impl Foo {
+    fn foo() { todo!() }
+
+    fn bar() { todo!() }
+}
+
+"
+                .into()
+            ),
+            super::stub_declaration(
+                br"
+
+impl Foo {
+    fn foo() { println!() }
+
+    fn bar() {
+      scanf!()
+    }
+}
+
+"
+            )
+        );
+    }
+}
+
+/// Calls the LLM to fix each declaration that has compiler errors, and returns a new
+/// `SplitPackage` with updated declarations and a freshly computed line index.
+pub struct FixDeclarationsLlm;
+
+impl Tool for FixDeclarationsLlm {
+    fn name(&self) -> &'static str {
+        "fix_declarations_llm"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let config =
+            fix_llm::Config::deserialize(context.config.tools.get("fix_declarations_llm").ok_or(
+                "No fix_declarations_llm config found in config.toml. \
+                     Please add a [tools.fix_declarations_llm] section.",
+            )?)?;
+        config.validate();
+
+        let fix_llm = fix_llm::FixLlm::new(&config.llm)?;
+
+        let item_map = context
+            .ir_snapshot
+            .get::<RustItemMap>(inputs[0])
+            .ok_or("DiagnosticAttributor: no RustItemMap found in IR")?;
+
+        let mut cargo_package = context
+            .ir_snapshot
+            .get::<CargoPackage>(item_map.cargo_pkg_idx)
+            .ok_or("DiagnosticAttributor: no CargoPackage found in IR")?
+            .clone();
+
+        let build_result = context
+            .ir_snapshot
+            .get::<CargoBuildResult>(inputs[1])
+            .ok_or("DiagnosticAttributor: no CargoBuildResult found in IR")?;
+
+        let mut decl_errors: HashMap<(PathBuf, Bound<usize>, Bound<usize>), Vec<Diagnostic>> =
+            HashMap::new();
+
+        let error_diagnostics = build_result
+            .diagnostics
+            .iter()
+            .map(|d| &d.message)
+            .filter(|m| m.level == DiagnosticLevel::Error);
+
+        for msg in error_diagnostics {
+            for span in msg.spans.iter() {
+                let file_name = PathBuf::new().join(&span.file_name);
+                cargo_package.dir.get_file(&file_name)?;
+
+                let (decl_start, decl_end) = item_map
+                    .items
+                    .get(&file_name)
+                    .ok_or("")?
+                    .iter()
+                    .find_map(|v| {
+                        if v.contains(&(span.byte_start as usize))
+                            && v.contains(&(span.byte_end as usize))
+                        {
+                            Some((v.start_bound().cloned(), v.end_bound().cloned()))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or((Bound::Unbounded, Bound::Unbounded));
+                decl_errors
+                    .entry((file_name, decl_start, decl_end))
+                    .or_default()
+                    .push(msg.clone());
+            }
+        }
+
+        // Build an interface context string: all declarations with
+        // function bodies replaced by `{ todo!() }`. Used as
+        // reference context for the LLM in each fix call.
+        let interface_ctx = item_map
+            .items
+            .iter()
+            .flat_map(|(file_name, irs)| Some((cargo_package.dir.get_file(file_name).ok()?, irs)))
+            .flat_map(|(src, item_ranges)| {
+                item_ranges
+                    .iter()
+                    .flat_map(|r| stub_declaration(&src[r.clone()]))
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        let mut fixed_count = 0usize;
+
+        let mut fixes: HashMap<PathBuf, BTreeMap<(usize, usize), String>> = HashMap::new();
+
+        for ((file_name, start, end), diagnostics) in &decl_errors {
+            let source = cargo_package.dir.get_file(file_name)?;
+            let decl_source = str::from_utf8(&source[(*start, *end)])?;
+            let errors_text = diagnostics
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>()
+                .join("\n\n");
+
+            match fix_llm.fix_declaration(decl_source, &errors_text, &interface_ctx) {
+                Ok(fixed) if !fixed.is_empty() => {
+                    let start = match start {
+                        Bound::Included(i) => *i,
+                        Bound::Excluded(i) => i + 1,
+                        Bound::Unbounded => 0,
+                    };
+                    let end = match end {
+                        Bound::Included(i) => i + 1,
+                        Bound::Excluded(i) => *i,
+                        Bound::Unbounded => 0,
+                    };
+                    fixes
+                        .entry(file_name.clone())
+                        .or_default()
+                        .insert((start, end), fixed);
+                    fixed_count += 1;
+                }
+                Ok(_) => {
+                    warn!("FixDeclarationsLlm: LLM returned empty response for declaration",);
+                }
+                Err(e) => {
+                    warn!("FixDeclarationsLlm: LLM fix failed for declaration: {}", e);
+                }
+            }
+        }
+
+        for (file_name, patches) in fixes.drain() {
+            let source = cargo_package.dir.get_file_mut(&file_name)?;
+            let mut offset: isize = 0;
+            // patches are sorted by start bound since they are stored
+            // in a BTree, and start bound is first part of key
+            for ((orig_start, orig_end), new_entry) in patches.into_iter() {
+                let diff = new_entry.len().cast_signed() - (orig_end - orig_start).cast_signed();
+                source.splice(
+                    (orig_start.strict_add_signed(offset))..(orig_end.strict_add_signed(offset)),
+                    new_entry.bytes(),
+                );
+
+                offset += diff;
+            }
+        }
+
+        info!(
+            "FixDeclarationsLlm: fixed {}/{} declarations",
+            fixed_count,
+            decl_errors.len()
+        );
+
+        Ok(Box::new(cargo_package))
+    }
+}

--- a/tools/fix_declarations_llm/src/prompts/fix/structured_schema.json
+++ b/tools/fix_declarations_llm/src/prompts/fix/structured_schema.json
@@ -1,0 +1,14 @@
+{
+  "name": "fix_result",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "fixed_code": {
+        "type": "string",
+        "description": "The corrected Rust declaration source code, without markdown fences"
+      }
+    },
+    "required": ["fixed_code"],
+    "additionalProperties": false
+  }
+}

--- a/tools/fix_declarations_llm/src/prompts/fix/system_prompt.txt
+++ b/tools/fix_declarations_llm/src/prompts/fix/system_prompt.txt
@@ -1,0 +1,9 @@
+You are a Rust compilation error repair tool. You will be given a single Rust declaration (function, struct, impl block, or similar) that has one or more compilation errors, along with the rustc error messages.
+
+Your task is to fix the declaration so it compiles correctly. Rules:
+- Fix only the compilation errors shown. Do not add comments, docstrings, or explanatory text.
+- Preserve the declaration's name, overall structure, and semantic intent.
+- You MAY change the signature (name, parameter types, return type, lifetimes, trait bounds, visibility) of the declaration being fixed if the compilation error requires it. Signature changes will propagate to callers in subsequent repair iterations. Prefer minimal changes: only alter the signature when the error clearly points to it.
+- Output only the corrected source for this one declaration — not the whole file.
+- If the declaration uses `todo!()` as a placeholder body, you may replace the body with a real implementation to fix the errors.
+- Respond with valid JSON only: {"fixed_code": "..."} where the value is the corrected Rust source. Never include markdown code fences in the JSON value.

--- a/tools/fix_declarations_llm/src/prompts/fix/user_prompt.txt
+++ b/tools/fix_declarations_llm/src/prompts/fix/user_prompt.txt
@@ -1,0 +1,10 @@
+REFERENCE CONTEXT (previous iteration, for context only -- all function bodies are stubbed):
+{context}
+
+The following Rust declaration has compilation errors. Fix it so it compiles correctly.
+
+COMPILATION ERRORS:
+{errors}
+
+DECLARATION TO FIX:
+{declaration}

--- a/tools/full_source/src/lib.rs
+++ b/tools/full_source/src/lib.rs
@@ -25,6 +25,7 @@ impl Representation for RawSource {
 }
 
 /// A cargo project representation (Cargo.toml, src/, etc).
+#[derive(Clone)]
 pub struct CargoPackage {
     pub dir: RawDir,
 }

--- a/tools/quantize_rust_spans/Cargo.toml
+++ b/tools/quantize_rust_spans/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "quantize_rust_spans"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+full_source.workspace = true
+harvest_core.workspace = true
+proc-macro2 = { version = "1", features = ["span-locations"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+syn = { version = "2", features = ["full"] }
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/quantize_rust_spans/src/lib.rs
+++ b/tools/quantize_rust_spans/src/lib.rs
@@ -1,0 +1,168 @@
+//! A [Tool] and [Representation] to deconstruct a [CargoPackage] into
+//! the top-level items in each Rust source file.
+
+use full_source::CargoPackage;
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::{fmt, fs};
+use syn::spanned::Spanned;
+use tracing::{debug, warn};
+
+// Copy from proc_macro2 so we can derive [Serialize] and [Deserialize]
+/// A line-column pair representing the start or end of a `Span`.
+///
+/// This type is semver exempt and not exposed by default.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct LineColumn {
+    /// The 1-indexed line in the source file on which the span starts or ends
+    /// (inclusive).
+    pub line: usize,
+    /// The 0-indexed column (in UTF-8 characters) in the source file on which
+    /// the span starts or ends (inclusive).
+    pub column: usize,
+}
+
+impl From<proc_macro2::LineColumn> for LineColumn {
+    fn from(value: proc_macro2::LineColumn) -> Self {
+        Self {
+            line: value.line,
+            column: value.column,
+        }
+    }
+}
+
+impl Ord for LineColumn {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.line
+            .cmp(&other.line)
+            .then(self.column.cmp(&other.column))
+    }
+}
+
+impl PartialOrd for LineColumn {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A [Representation] that maps top-level items in a [CargoPackage].
+///
+/// Stores a list of spans of top-level items in each Rust file
+/// of a [CargoPackage].
+pub struct RustItemMap {
+    /// [Representation] index of the [CargoPackage] from which this
+    /// [Representation] is derived.
+    pub cargo_pkg_idx: Id,
+
+    /// Stores a list of spans (starting [LineColumn] and ending
+    /// [LineColumn]) for top-level items in each Rust file in
+    /// a [CargoPackage]. Keys are full paths relative to the root of
+    /// the [CargoPackage].
+    pub items: HashMap<PathBuf, Vec<Range<usize>>>,
+}
+
+impl fmt::Display for RustItemMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "RustItemMap ({} files):", self.items.len())?;
+        for (path, items) in self.items.iter() {
+            writeln!(f, "\t{}: {} items", path.display(), items.len())?;
+        }
+        Ok(())
+    }
+}
+
+impl Representation for RustItemMap {
+    fn name(&self) -> &'static str {
+        "rust_items_map"
+    }
+
+    /// Materializes the package to disk as a compilable Cargo project layout.
+    /// Writes `Cargo.toml` and `src/<filename>` under `path`.
+    fn materialize(&self, path: &Path) -> std::io::Result<()> {
+        fs::create_dir_all(path)?;
+        fs::write(
+            path.join("_cargo_package_idx"),
+            serde_json::ser::to_vec(&self.cargo_pkg_idx)?,
+        )?;
+        for (p, items) in self.items.iter() {
+            // source_file_name is e.g. "src/main.rs"
+            let full_path = path.join(p);
+            if let Some(parent) = full_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(full_path, serde_json::ser::to_vec(items)?)?;
+        }
+        Ok(())
+    }
+}
+
+/// Split `source` into top-level items strings, each formatted with `prettyplease`.
+///
+/// Falls back to a single "whole-file" items if `syn` cannot parse the source.
+fn extract_top_level_spans(source: &str) -> Result<Vec<Range<usize>>, impl std::error::Error> {
+    syn::parse_file(source).map(|file| {
+        file.items
+            .iter()
+            .map(|item| item.span().byte_range())
+            .collect()
+    })
+}
+
+// Tool
+
+/// A [Tool] to deconstruct a [CargoPackage] into the top-level items
+/// in each Rust source file.
+pub struct QuantizeRustSpans;
+
+impl Tool for QuantizeRustSpans {
+    fn name(&self) -> &'static str {
+        "quantize_rust_spans"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let cargo_pkg_idx = inputs[0];
+        let cargo_pkg = context
+            .ir_snapshot
+            .get::<CargoPackage>(cargo_pkg_idx)
+            .ok_or("QuantizeRustSpans: no CargoPackage found in IR")?;
+
+        let mut items = HashMap::new();
+
+        let source_files = cargo_pkg
+            .dir
+            .files_recursive()
+            .into_iter()
+            .filter(|(path, _)| path.ends_with(".rs"));
+        for (path, source) in source_files {
+            let source = str::from_utf8(source)?;
+            match extract_top_level_spans(source) {
+                Ok(decls) => {
+                    debug!(
+                        "QuantizeRustSpans: split {} into {} items",
+                        path.display(),
+                        decls.len()
+                    );
+
+                    items.insert(path, decls);
+                }
+                Err(e) => {
+                    warn!("syn failed to parse source, treating as single items: {e}");
+                    items.insert(path, vec![]);
+                }
+            }
+        }
+
+        Ok(Box::new(RustItemMap {
+            cargo_pkg_idx,
+            items,
+        }))
+    }
+}

--- a/tools/try_cargo_build/src/lib.rs
+++ b/tools/try_cargo_build/src/lib.rs
@@ -1,5 +1,6 @@
 //! Checks if a generated Rust project builds by materializing
 //! it to a tempdir and running `cargo build --release`.
+pub use cargo_metadata::{Artifact, CompilerMessage};
 use full_source::CargoPackage;
 use harvest_core::cargo_utils::{add_workspace_guard, normalize_package_name};
 use harvest_core::tools::{RunContext, Tool};
@@ -11,46 +12,14 @@ use tracing::info;
 pub struct TryCargoBuild;
 // Either a vector of compiled artifact filenames (on success)
 // or a string containing error messages (on failure).
-pub type BuildResult = Result<Vec<PathBuf>, String>;
-
-/// Parses cargo output stream and concatenates all compiler messages into a single string.
-fn parse_compiler_messages(stdout: &[u8]) -> Result<String, Box<dyn std::error::Error>> {
-    let mut messages = Vec::new();
-
-    for message in cargo_metadata::Message::parse_stream(stdout) {
-        let message = message?;
-        if let cargo_metadata::Message::CompilerMessage(comp_msg) = message {
-            messages.push(format!("Compiler Message: {}", comp_msg));
-        }
-    }
-
-    Ok(messages.join("\n"))
-}
-
-/// Parses cargo output stream and extracts the filenames of all compiled artifacts.
-/// Returns a vector of PathBuf containing the artifact filenames.
-fn parse_compiled_artifacts(stdout: &[u8]) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
-    let mut artifact_filenames = Vec::new();
-
-    for message in cargo_metadata::Message::parse_stream(stdout) {
-        let message = message?;
-        if let cargo_metadata::Message::CompilerArtifact(artifact) = message {
-            // Extract filenames from all artifact files
-            for filename in artifact.filenames {
-                artifact_filenames.push(filename.into());
-            }
-        }
-    }
-
-    Ok(artifact_filenames)
-}
+pub type BuildResult = Result<Vec<PathBuf>, Vec<CompilerMessage>>;
 
 /// Validates that the generated Rust project builds by running `cargo build --release`.
 /// Note: It has a bit of a confusing return type:
 /// - If the project builds successfully, it returns Ok(Ok(artifact_filenames)).
 /// - If the project fails to build, it returns Ok(Err(error_message)).
 /// - If there is an error running cargo, it returns Err.
-fn try_cargo_build(project_path: &PathBuf) -> Result<BuildResult, Box<dyn std::error::Error>> {
+fn try_cargo_build(project_path: &PathBuf) -> Result<CargoBuildResult, Box<dyn std::error::Error>> {
     info!("Validating that the generated Rust project builds...");
 
     // Prevent accidentally picking up a parent workspace by marking this project as its own root.
@@ -73,16 +42,37 @@ fn try_cargo_build(project_path: &PathBuf) -> Result<BuildResult, Box<dyn std::e
             )
         })?;
 
-    if output.status.success() {
-        info!("Project builds successfully!");
-        let artifact_filenames = parse_compiled_artifacts(&output.stdout)?;
-        Ok(Ok(artifact_filenames))
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let compiler_messages = parse_compiler_messages(&output.stdout)?;
-        let error_message = format!("{}\n{}", compiler_messages, stderr);
-        Ok(Err(error_message))
+    let mut artifacts = vec![];
+    let mut diagnostics = vec![];
+    let mut success = false;
+    for message in cargo_metadata::Message::parse_stream(output.stdout.as_slice()) {
+        let message = message?;
+        match message {
+            // Compiled artifacts for a particular target
+            cargo_metadata::Message::CompilerArtifact(artifact) => artifacts.push(artifact),
+            cargo_metadata::Message::CompilerMessage(compiler_message) => {
+                diagnostics.push(compiler_message)
+            }
+            cargo_metadata::Message::BuildFinished(build_finished) => {
+                success = build_finished.success
+            }
+            // Ignore the following variants for now
+            cargo_metadata::Message::BuildScriptExecuted(_) => {}
+            cargo_metadata::Message::TextLine(_) => {}
+            // Non-exhaustive pattern, so need a catch-all
+            _ => {}
+        }
     }
+
+    if success {
+        info!("Project builds successfully!");
+    }
+    Ok(CargoBuildResult {
+        artifacts,
+        diagnostics,
+        success,
+        err: String::from_utf8(output.stderr)?,
+    })
 }
 
 impl Tool for TryCargoBuild {
@@ -104,31 +94,31 @@ impl Tool for TryCargoBuild {
         cargo_package.materialize(&output_path)?;
 
         // Validate that the Rust project builds
-        let compilation_result = try_cargo_build(&output_path)?;
-        let repr = CargoBuildResult {
-            result: compilation_result,
-        };
-        Ok(Box::new(repr))
+        Ok(Box::new(try_cargo_build(&output_path)?))
     }
 }
 
 /// A Representation that contains the results of running `cargo build`.
+#[derive(Clone)]
 pub struct CargoBuildResult {
-    pub result: Result<Vec<PathBuf>, String>,
+    pub artifacts: Vec<Artifact>,
+    pub diagnostics: Vec<CompilerMessage>,
+    pub success: bool,
+    pub err: String,
 }
 
 impl std::fmt::Display for CargoBuildResult {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         writeln!(f, "Built Rust artifact:")?;
-        let artifact_filenames = match &self.result {
-            Err(err) => return writeln!(f, "  Build failed: {err}"),
-            Ok(filenames) => filenames,
-        };
-        writeln!(f, "  Build succeeded. Artifacts:")?;
-        for filename in artifact_filenames {
-            writeln!(f, "    {}", filename.display())?;
+        if self.success {
+            writeln!(f, "  Build succeeded. Artifacts:")?;
+            for filename in self.artifacts.iter().flat_map(|a| &a.filenames) {
+                writeln!(f, "    {}", filename)?;
+            }
+            Ok(())
+        } else {
+            writeln!(f, "  Build failed: {}", self.err)
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Subsumes #118

This PR adds pipeline support for attempting to fix cargo build errors using an LLM.

It includes one supporting change, and 3 larger ones, with commits separated by change and in that order:

1. Add `get_file_mut` method to `RawDir`. This just allows for a more efficient way of modifying a `CargoPackage` (or any `RawDir`-based representation) in place. The changes basically move common path parsing logic with `get_file` to a helper function, and otherwise just adds the method.

2. Augments the `CargoPackage` Representation and `try_cargo_build` Tool, to retain much more information, including any build error messages from a `cargo build` run.

3. Adds a `QuantizeRustSpans` tool which parses all Rust files in a `CargoPackage` and generates an index of spans for each top-level item in the each file. The purpose is to allow mapping a smaller span to a quantized (larger) span.

4. Add `FixDeclarationsLlm` which uses the error information in `CargoPackage` and quantized spans to query an LLM for fixes to top-level items, and creates a new `CargoPackage` with patched files based on the LLM's fixes.

So far the PR does _not_ yet include changes to the translate binary/pipeline to exercise this new pipeline, so it is untested.

The best way to review this is probably to go commit by commit.