### PR TITLE
dont trim during regex matches

### DIFF
--- a/benchmark/src/harness/mod.rs
+++ b/benchmark/src/harness/mod.rs
@@ -278,7 +278,7 @@ pub fn validate_binary_output(
                 test_case.stdout.pattern, e
             )
         })?;
-        regex.is_match(actual_stdout.trim())
+        regex.is_match(&actual_stdout)
     } else {
         // Use simple equality matching
         actual_stdout.trim() == test_case.stdout.pattern.trim()


### PR DESCRIPTION
Regex checking was trimming the output. We should not do that.
This should fix testing of P00_perlin_noise.