### PR TITLE
Benchmark: Remove superfluous .trim() from regex comparison

### DIFF
--- a/benchmark/src/harness/mod.rs
+++ b/benchmark/src/harness/mod.rs
@@ -278,7 +278,7 @@ pub fn validate_binary_output(
                 test_case.stdout.pattern, e
             )
         })?;
-        regex.is_match(actual_stdout.trim())
+        regex.is_match(actual_stdout.as_ref())
     } else {
         // Use simple equality matching
         actual_stdout.trim() == test_case.stdout.pattern.trim()


### PR DESCRIPTION
Removes the `.trim()` from the stdout of a test run when comparing with a regex pattern in the test vector.

With this simple fix, Perlin now passes all tests:

```
Results for 001_perlin_noise:
  Translation: ✅
  Rust Build: ✅
  Tests: 30/30 passed (0 skipped, 100.0%)

================================================================================
FINAL SUMMARY - All Benchmark Processing Complete!
================================================================================

Summary Statistics:
  Total programs processed: 1
  Successful translations: 1 (100.0%)
  Successful Rust builds: 1 (100.0%)
```

Haven't tested with other batteries, but from a cursory look it doesn't seem like it should affect them and, anyway, this is the correct behavior.

We should probably also remove the trims for both stdout and pattern in the non-regex case, but doing this first in lieu of tainting progress on other work, just in case.