### PR TITLE
Robust parsing

### DIFF
--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -50,12 +50,7 @@ fn build_parser<'a>(index: &'a Index, src_root: &Path, rel_file: &Path) -> clang
 
 /// Extract top-level entities from the file at `rel_path`.
 /// This includes both entities that survive preprocessing (types, functions, globals) and preprocessor directives (includes, defines, compiler args).
-fn extract_entities(
-    parser: clang::Parser<'_>,
-    rel_file: &Path,
-    file_bytes: &[u8],
-    out: &mut RichSourceMap,
-) {
+fn extract_entities(parser: clang::Parser<'_>, rel_file: &Path, out: &mut RichSourceMap) {
     let tu = match parser.parse() {
         Ok(tu) => tu,
         Err(e) => {
@@ -71,14 +66,20 @@ fn extract_entities(
         let Some(decl_kind) = rsm::map_top_level_decl_kind(child.get_kind()) else {
             continue;
         };
+
         // Ignore imports
-        if !child.is_in_main_file() {
+        if child.is_in_system_header()
+            || child
+                .get_location()
+                .map(|loc| loc.get_file_location().file)
+                .flatten()
+                .is_none()
+        {
             continue;
         }
 
         // Read the source text from the file
-        let Some((span, source_text)) =
-            utils::range_to_span_and_text(child.get_range(), rel_file, file_bytes)
+        let Some((span, source_text)) = utils::range_to_span_and_text(child.get_range(), rel_file)
         else {
             continue;
         };
@@ -125,7 +126,7 @@ impl Tool for ParseToAst {
 
         let mut out = RichSourceMap::new();
 
-        for (rel_path, bytes) in rs.dir.files_recursive() {
+        for (rel_path, _) in rs.dir.files_recursive() {
             if utils::should_skip_path(&rel_path) {
                 continue;
             }
@@ -134,7 +135,7 @@ impl Tool for ParseToAst {
             }
             tracing::info!("Parsing file: {}", rel_path.to_string_lossy());
             let parser = build_parser(&index, src_dir.path(), &rel_path);
-            extract_entities(parser, &rel_path, bytes, &mut out);
+            extract_entities(parser, &rel_path, &mut out);
         }
 
         debug!(

--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -71,8 +71,7 @@ fn extract_entities(parser: clang::Parser<'_>, rel_file: &Path, out: &mut RichSo
         if child.is_in_system_header()
             || child
                 .get_location()
-                .map(|loc| loc.get_file_location().file)
-                .flatten()
+                .and_then(|loc| loc.get_file_location().file)
                 .is_none()
         {
             continue;

--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -125,9 +125,13 @@ impl Tool for ParseToAst {
         let mut out = RichSourceMap::new();
 
         for (rel_path, bytes) in rs.dir.files_recursive() {
+            if utils::should_skip_path(&rel_path) {
+                continue;
+            }
             if !utils::is_c_or_header(&rel_path) {
                 continue;
             }
+            tracing::info!("Parsing file: {}", rel_path.to_string_lossy());
             let parser = build_parser(&index, src_dir.path(), &rel_path);
             extract_entities(parser, &rel_path, bytes, &mut out);
         }

--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -92,6 +92,7 @@ fn extract_entities(
                 span,
                 ast,
                 annotations: EntityAnnotations::default(),
+                sub_entities: Vec::new(),
             },
             &child,
         );

--- a/tools/c_ast/src/rsm.rs
+++ b/tools/c_ast/src/rsm.rs
@@ -7,7 +7,7 @@ use crate::EntityAnnotations;
 
 /// Representaiton of a single point in a source file, used for source mapping.
 /// `column` and `offset` are UTF8 byte offsets, to match Clang's source location representation.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SourcePoint {
     pub line: u32,
     pub column: u32,
@@ -16,7 +16,7 @@ pub struct SourcePoint {
 
 /// Our own simplified representation of a span.
 /// Corresponds to clang's spelling_loc.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SourceSpan {
     pub file: String,
     pub start: SourcePoint,
@@ -64,6 +64,10 @@ pub struct TopLevelEntity {
     pub ast: Option<ClangAST>,
     #[serde(default)]
     pub annotations: EntityAnnotations,
+    /// If this entity encloses another (sourcespan of child is fully contained within parent), we store it here.
+    // This helps us deduplicate typedefs and struct/enum/union declarations.
+    #[serde(default)]
+    pub sub_entities: Vec<TopLevelEntity>,
 }
 
 /// This is the output of the parsing step, and therefore this tool.
@@ -101,7 +105,7 @@ impl RichSourceMap {
             | EntityKind::RecordDecl
             | EntityKind::UnionDecl
             | EntityKind::EnumDecl => {
-                self.app_types.push(item);
+                self.push_type(item);
             }
             EntityKind::VarDecl => {
                 self.app_globals.push(item);
@@ -125,6 +129,34 @@ impl RichSourceMap {
         }
     }
 
+    fn push_type(&mut self, item: TopLevelEntity) {
+        Self::insert_type_into(&mut self.app_types, item);
+    }
+
+    fn insert_type_into(nodes: &mut Vec<TopLevelEntity>, mut item: TopLevelEntity) {
+        // If an existing top-level node contains this item, attach it directly
+        // as an immediate child. We do not preserve deeper sub-entity ordering.
+        for node in nodes.iter_mut() {
+            if Self::span_contains(&node.span, &item.span) {
+                node.sub_entities.push(item);
+                return;
+            }
+        }
+
+        // Otherwise, absorb any existing nodes contained by this item.
+        let mut i = 0;
+        while i < nodes.len() {
+            if Self::span_contains(&item.span, &nodes[i].span) {
+                let child = nodes.remove(i);
+                item.sub_entities.push(child);
+            } else {
+                i += 1;
+            }
+        }
+
+        nodes.push(item);
+    }
+
     /// Iterate over the entities that survive preprocessing.
     /// They should all have AST representations.
     pub fn iter_definitions(&self) -> impl Iterator<Item = &TopLevelEntity> {
@@ -140,6 +172,60 @@ impl RichSourceMap {
             .iter()
             .chain(self.defines.iter())
             .chain(self.compiler_args.iter())
+    }
+
+    fn span_contains(parent: &SourceSpan, child: &SourceSpan) -> bool {
+        if parent.file != child.file {
+            return false;
+        }
+
+        parent.start.offset <= child.start.offset && parent.end.offset >= child.end.offset
+    }
+
+    /// Iterate over every top-level source entity tracked by the map.
+    fn iter_all_entities(&self) -> impl Iterator<Item = &TopLevelEntity> {
+        self.app_types
+            .iter()
+            .chain(self.app_globals.iter())
+            .chain(self.app_functions.iter())
+            .chain(self.app_func_sigs.iter())
+            .chain(self.include_paths.iter())
+            .chain(self.defines.iter())
+            .chain(self.compiler_args.iter())
+    }
+
+    /// Returns true when the map satisfies its span invariants:
+    /// - every span is internally valid (`start.offset <= end.offset`)
+    /// - no two top-level entities overlap within the same file
+    pub fn well_formed(&self) -> bool {
+        let mut spans: Vec<&SourceSpan> = self
+            .iter_all_entities()
+            .map(|entity| &entity.span)
+            .collect();
+
+        spans.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.start.offset.cmp(&b.start.offset))
+                .then(a.end.offset.cmp(&b.end.offset))
+        });
+
+        let mut prev_span: Option<&SourceSpan> = None;
+        for span in spans {
+            if span.start.offset > span.end.offset {
+                return false;
+            }
+
+            if let Some(prev) = prev_span {
+                if prev.file == span.file && prev.end.offset > span.start.offset {
+                    return false;
+                }
+            }
+
+            prev_span = Some(span);
+        }
+
+        true
     }
 }
 

--- a/tools/c_ast/src/rsm.rs
+++ b/tools/c_ast/src/rsm.rs
@@ -216,10 +216,11 @@ impl RichSourceMap {
                 return false;
             }
 
-            if let Some(prev) = prev_span {
-                if prev.file == span.file && prev.end.offset > span.start.offset {
-                    return false;
-                }
+            if let Some(prev) = prev_span
+                && prev.file == span.file
+                && prev.end.offset > span.start.offset
+            {
+                return false;
             }
 
             prev_span = Some(span);

--- a/tools/c_ast/src/utils.rs
+++ b/tools/c_ast/src/utils.rs
@@ -38,7 +38,6 @@ pub(crate) fn language_args_for_file(path: &Path) -> [&'static str; 2] {
 pub(crate) fn range_to_span_and_text(
     range: Option<SourceRange<'_>>,
     rel_file: &Path,
-    file_bytes: &[u8],
 ) -> Option<(SourceSpan, String)> {
     let range = range?;
     let start = range.get_start().get_file_location();
@@ -53,8 +52,13 @@ pub(crate) fn range_to_span_and_text(
         return None;
     }
 
+    let file_bytes = std::fs::read(&start_path).ok()?;
+
     let start_offset = start.offset as usize;
     let end_offset = end.offset as usize;
+    if start_offset > end_offset || end_offset > file_bytes.len() {
+        return None;
+    }
     let source_text = String::from_utf8_lossy(&file_bytes[start_offset..end_offset]).to_string();
 
     let span = SourceSpan {

--- a/tools/c_ast/src/utils.rs
+++ b/tools/c_ast/src/utils.rs
@@ -11,6 +11,19 @@ pub(crate) fn is_c_or_header(path: &Path) -> bool {
     }
 }
 
+/// Returns true when a file path should be skipped by source parsers.
+///
+/// Currently excludes generated internals in any `CMakeFiles`, `.cache`, or
+/// `build` directory.
+pub(crate) fn should_skip_path(path: &Path) -> bool {
+    path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .is_some_and(|name| matches!(name, "CMakeFiles" | ".cache" | "build"))
+    })
+}
+
 /// Generate appropriate libClang parser arguments based on the file type.
 pub(crate) fn language_args_for_file(path: &Path) -> [&'static str; 2] {
     if path.extension().and_then(|ext| ext.to_str()) == Some("h") {

--- a/tools/modular_translation_llm/src/prompts/func_translation/system_prompt.txt
+++ b/tools/modular_translation_llm/src/prompts/func_translation/system_prompt.txt
@@ -1,6 +1,12 @@
-You are a code translation tool performing the function/global translation pass. In this pass, you translate function implementations and global variables. Type declarations (typedefs, structs, enums) and interface signatures (function and global variable signatures) have already been translated and will be provided to you as context.
+You are one pass in a C to Rust translation tool.
+You translate functions and globals. 
+Type declarations (typedefs, structs, enums) and interface signatures (function and global variable signatures) have already been translated and will be provided to you as context.
 
-You translate one declaration at a time in isolation. You translate functions and global variables but not comments. Do not include or write any new comments. You preserve external interfaces but internally use canonical and safe Rust as much as possible. When asked to generate a structured JSON response, you always respond with valid JSON only: never any preceding markdown block formatting, and you take extreme care for the JSON to be valid.
+You translate one function or global at a time in isolation. 
+You do not translate comments. 
+You preserve external interfaces but internally use canonical and safe Rust as much as possible. 
+All outputs must be byte-identical to the original C.
+When asked to generate a structured JSON response, you always respond with valid JSON only: never any preceding markdown block formatting, and you take extreme care for the JSON to be valid.
 
 For each declaration you translate, you must provide:
 1. The translated Rust code


### PR DESCRIPTION
This PR introduces the changes needed to get 100% on `P00_perlin_noise` with the modular translator.
These are mostly small bookkeeping fixes. Specifically, it changes harvest to:
1. Exclude top-level declarations by blacklisting system headers and builtins directly.
2. Exclude files for parsing if they come from known "bad" locations like `CMakeFiles/` or `.cache/`
3.  Deduplicate typedefs in a more robust way (typedef spans overlap with RecordDecl/EnumDecl/UnionDecl). Specifically, if one span for a top-level declaration encloses another, we store the smaller span as a subspan of the first and remove it from the top-level decls.
4. I added a line to the prompt to ask the LLM to generate bit-precise outputs. This makes P00 more consistent and is sufficiently general such that it doesn't feel like overfitting.