### PR TITLE
Support configurable programs in agentic translation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,6 +1359,7 @@ dependencies = [
 name = "harvest-benchmark"
 version = "0.1.0"
 dependencies = [
+ "build_project_spec",
  "clap",
  "csv",
  "full_source",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -14,6 +14,7 @@ name = "benchmark"
 path = "src/main.rs"
 
 [dependencies]
+build_project_spec = { version = "0.1.0", path = "../tools/build_project_spec" }
 clap = { workspace = true }
 csv = "1.3"
 full_source = { version = "0.1.0", path = "../tools/full_source" }

--- a/benchmark/src/harness/mod.rs
+++ b/benchmark/src/harness/mod.rs
@@ -124,7 +124,6 @@ pub fn parse_benchmark_dir(input_dir: &Path) -> HarvestResult<(PathBuf, PathBuf)
 
     // Check for required subdirectories
     let test_case_dir = input_dir.join("test_case");
-    let test_case_src_dir = test_case_dir.join("src");
     let test_vectors_dir = input_dir.join("test_vectors");
 
     if !test_case_dir.exists() || !test_case_dir.is_dir() {
@@ -135,10 +134,13 @@ pub fn parse_benchmark_dir(input_dir: &Path) -> HarvestResult<(PathBuf, PathBuf)
         .into());
     }
 
-    if !test_case_src_dir.exists() || !test_case_src_dir.is_dir() {
+    // Accept test_case/src (normal layout) or test_case/app (configurable layout).
+    let has_src = test_case_dir.join("src").is_dir();
+    let has_app = test_case_dir.join("app").is_dir();
+    if !has_src && !has_app {
         return Err(format!(
-            "Required test_case/src directory not found: {}",
-            test_case_src_dir.display()
+            "Required test_case/src or test_case/app directory not found under: {}",
+            test_case_dir.display()
         )
         .into());
     }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -18,6 +18,7 @@ use crate::io::{
 use crate::ir_utils::{cargo_build_result, raw_cargo_package, raw_source};
 use crate::logger::TeeLogger;
 use crate::stats::{ProgramEvalStats, SummaryStats, TestResult};
+use build_project_spec::{detect_project_kind, ProjectKind};
 use clap::Parser;
 use harvest_core::utils::get_version;
 use harvest_core::HarvestIR;
@@ -249,11 +250,6 @@ fn benchmark_single_program(
 
     log::info!("Translating program: {}", program_name);
     log::info!("Input directory: {}", program_dir.display());
-    let is_lib = program_name.ends_with("_lib");
-    log::info!(
-        "Detected project type: {}",
-        if is_lib { "library" } else { "executable" }
-    );
 
     // Get program output directory
     let output_dir = output_root_dir.join(&program_name);
@@ -268,6 +264,16 @@ fn benchmark_single_program(
             return result;
         }
     };
+
+    // Detect project kind from the C source root (same heuristic as build_project_spec).
+    let project_kind = detect_project_kind(&test_case_dir);
+    log::info!(
+        "Detected project type: {}",
+        project_kind
+            .as_ref()
+            .map(|k| k.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    );
 
     // Parse test vectors
     let test_cases = match parse_test_vectors(test_vectors_dir) {
@@ -323,37 +329,45 @@ fn benchmark_single_program(
     }
 
     // Library and executable validation differ.
-    let (test_results, error_messages) = match (is_lib, translation_result.rust_binary_path) {
-        (true, _) => {
-            match harness::library::run_library_validation(
-                &program_name,
-                program_dir,
-                &output_dir,
-                &test_cases,
-                timeout,
-            ) {
-                Ok(r) => r,
-                Err(e) => {
-                    let error_msg = format!("Library validation failed: {}", e);
-                    log::error!("{}", error_msg);
-                    result.error_message = Some(error_msg);
-                    return result;
+    // Both Library and Configurable projects use cando2 (runner + test_vectors).
+    // Executable projects run the binary directly against test vectors.
+    // Unknown project kinds fall back to the binary path if available.
+    let use_library_validation = matches!(
+        project_kind,
+        Some(ProjectKind::Library) | Some(ProjectKind::Configurable)
+    );
+    let (test_results, error_messages) =
+        match (use_library_validation, translation_result.rust_binary_path) {
+            (true, _) => {
+                match harness::library::run_library_validation(
+                    &program_name,
+                    program_dir,
+                    &output_dir,
+                    &test_cases,
+                    timeout,
+                ) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let error_msg = format!("Library validation failed: {}", e);
+                        log::error!("{}", error_msg);
+                        result.error_message = Some(error_msg);
+                        return result;
+                    }
                 }
             }
-        }
-        (false, Some(binary_path)) if binary_path.exists() => {
-            run_test_validation(&binary_path, &test_cases, timeout, &output_dir)
-        }
-        (_, binary_path) => {
-            let error = format!(
+            (false, Some(binary_path)) if binary_path.exists() => {
+                run_test_validation(&binary_path, &test_cases, timeout, &output_dir)
+            }
+            (_, binary_path) => {
+                let error = format!(
                 "Rust build reported success, but expected output artifact was not found at {:?}",
                 binary_path
             );
-            log::error!("{}", error);
-            result.error_message = Some(error);
-            return result;
-        }
-    };
+                log::error!("{}", error);
+                result.error_message = Some(error);
+                return result;
+            }
+        };
 
     result.passed_tests = test_results
         .iter()

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -453,6 +453,8 @@ fn run(args: Args) -> HarvestResult<()> {
         "Using {} Translation",
         if args.modular {
             "Modular"
+        } else if args.agentic {
+            "Agentic"
         } else {
             "All-at-once"
         }

--- a/tools/build_project_spec/src/lib.rs
+++ b/tools/build_project_spec/src/lib.rs
@@ -8,6 +8,7 @@ use harvest_core::tools::{RunContext, Tool};
 pub enum ProjectKind {
     Library,
     Executable,
+    Configurable,
 }
 
 impl Display for ProjectKind {
@@ -15,6 +16,7 @@ impl Display for ProjectKind {
         match self {
             ProjectKind::Library => write!(f, "Library"),
             ProjectKind::Executable => write!(f, "Executable"),
+            ProjectKind::Configurable => write!(f, "Configurable"),
         }
     }
 }
@@ -52,6 +54,13 @@ impl Tool for BuildProjectSpec {
             .ir_snapshot
             .get::<RawSource>(inputs[0])
             .ok_or("No RawSource representation found in IR")?;
+
+        // CMakePresets.json signals a build-time configurable project (e.g. sphincs).
+        if repr.dir.get_file("CMakePresets.json").is_ok() {
+            return Ok(Box::new(ProjectSpec {
+                kind: ProjectKind::Configurable,
+            }));
+        }
 
         if let Ok(cmakelists) = repr.dir.get_file("CMakeLists.txt") {
             if String::from_utf8_lossy(cmakelists)

--- a/tools/build_project_spec/src/lib.rs
+++ b/tools/build_project_spec/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::path::Path;
 
 use full_source::RawSource;
 use harvest_core::Id;
@@ -37,6 +38,37 @@ impl Representation for ProjectSpec {
     }
 }
 
+/// Core detection logic shared by [`detect_project_kind`] and [`BuildProjectSpec::run`].
+///
+/// Examines the top-level `CMakeLists.txt` content to classify the project:
+/// - `add_executable(` at line start -> Executable
+/// - `add_library(` at line start -> Library
+/// - `add_subdirectory(` at line start (with neither of the above) -> Configurable
+///   (e.g. sphincs, where the real targets live in sub-CMakeLists)
+fn kind_from_cmakelists(cmakelists: &[u8]) -> Option<ProjectKind> {
+    let text = String::from_utf8_lossy(cmakelists);
+    if text.lines().any(|l| l.starts_with("add_executable(")) {
+        return Some(ProjectKind::Executable);
+    }
+    if text.lines().any(|l| l.starts_with("add_library(")) {
+        return Some(ProjectKind::Library);
+    }
+    if text.lines().any(|l| l.starts_with("add_subdirectory(")) {
+        return Some(ProjectKind::Configurable);
+    }
+    None
+}
+
+/// Detect the project kind from a source directory on the filesystem.
+///
+/// Useful for callers (e.g. the benchmark harness) that need the project kind
+/// before or outside of a full tool pipeline.  Returns `None` if the kind
+/// cannot be determined.
+pub fn detect_project_kind(dir: &Path) -> Option<ProjectKind> {
+    let cmakelists = std::fs::read(dir.join("CMakeLists.txt")).ok()?;
+    kind_from_cmakelists(&cmakelists)
+}
+
 pub struct BuildProjectSpec;
 
 impl Tool for BuildProjectSpec {
@@ -49,37 +81,18 @@ impl Tool for BuildProjectSpec {
         context: RunContext,
         inputs: Vec<Id>,
     ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
-        // Get RawSource representation (the first and only arg of build_project_spec)
         let repr = context
             .ir_snapshot
             .get::<RawSource>(inputs[0])
             .ok_or("No RawSource representation found in IR")?;
 
-        // CMakePresets.json signals a build-time configurable project (e.g. sphincs).
-        if repr.dir.get_file("CMakePresets.json").is_ok() {
-            return Ok(Box::new(ProjectSpec {
-                kind: ProjectKind::Configurable,
-            }));
-        }
+        let cmakelists = repr.dir.get_file("CMakeLists.txt").map_err(
+            |_| "Could not identify project kind from CMakeLists.txt (or could not find it)",
+        )?;
+        let kind = kind_from_cmakelists(cmakelists).ok_or(
+            "CMakeLists.txt found but contains no add_executable, add_library, or add_subdirectory",
+        )?;
 
-        if let Ok(cmakelists) = repr.dir.get_file("CMakeLists.txt") {
-            if String::from_utf8_lossy(cmakelists)
-                .lines()
-                .any(|line| line.starts_with("add_executable("))
-            {
-                return Ok(Box::new(ProjectSpec {
-                    kind: ProjectKind::Executable,
-                }));
-            } else if String::from_utf8_lossy(cmakelists)
-                .lines()
-                .any(|line| line.starts_with("add_library("))
-            {
-                return Ok(Box::new(ProjectSpec {
-                    kind: ProjectKind::Library,
-                }));
-            }
-        }
-
-        Err("Could not identify project kind from CMakeLists.txt (or could not find it)".into())
+        Ok(Box::new(ProjectSpec { kind }))
     }
 }

--- a/tools/modular_translation_llm/src/recombine.rs
+++ b/tools/modular_translation_llm/src/recombine.rs
@@ -54,6 +54,7 @@ pub fn recombine_decls(
     let source_file = match project_kind {
         ProjectKind::Executable => "src/main.rs",
         ProjectKind::Library => "src/lib.rs",
+        ProjectKind::Configurable => "src/lib.rs",
     };
 
     // Create the directory structure

--- a/tools/modular_translation_llm/src/recombine.rs
+++ b/tools/modular_translation_llm/src/recombine.rs
@@ -54,7 +54,9 @@ pub fn recombine_decls(
     let source_file = match project_kind {
         ProjectKind::Executable => "src/main.rs",
         ProjectKind::Library => "src/lib.rs",
-        ProjectKind::Configurable => "src/lib.rs",
+        ProjectKind::Configurable => {
+            unreachable!("Configurable projects are not supported by this tool")
+        }
     };
 
     // Create the directory structure

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -204,7 +204,13 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
-            ProjectKind::Configurable => "configurable",
+            ProjectKind::Configurable => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "modular translation does not yet support ProjectKind::Configurable",
+                )
+                .into())
+            }
         };
 
         let request = build_request(

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -204,6 +204,7 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
+            ProjectKind::Configurable => "configurable",
         };
 
         let request = build_request(
@@ -265,6 +266,7 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
+            ProjectKind::Configurable => "configurable",
         };
 
         let type_code: Vec<String> = type_translations
@@ -341,6 +343,7 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
+            ProjectKind::Configurable => "configurable",
         };
 
         let type_code: Vec<String> = type_translations
@@ -401,6 +404,7 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
+            ProjectKind::Configurable => "configurable",
         };
 
         let request = build_request(

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -209,7 +209,7 @@ impl ModularTranslationLLM {
                     std::io::ErrorKind::Unsupported,
                     "modular translation does not yet support ProjectKind::Configurable",
                 )
-                .into())
+                .into());
             }
         };
 

--- a/tools/raw_source_to_cargo_llm/src/lib.rs
+++ b/tools/raw_source_to_cargo_llm/src/lib.rs
@@ -52,6 +52,9 @@ impl Tool for RawSourceToCargoLlm {
         let (config_prompt, builtin_prompt) = match project_kind {
             ProjectKind::Executable => (config.prompt_executable, SYSTEM_PROMPT_EXECUTABLE),
             ProjectKind::Library => (config.prompt_library, SYSTEM_PROMPT_LIBRARY),
+            ProjectKind::Configurable => {
+                return Err("raw_source_to_cargo_llm does not support Configurable projects; use translate_agentic instead".into());
+            }
         };
         let system_prompt = config_prompt
             .map(read_to_string)

--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -21,6 +21,7 @@ use tracing::{info, warn};
 
 const PROMPT_EXECUTABLE: &str = include_str!("prompt_executable.md");
 const PROMPT_LIBRARY: &str = include_str!("prompt_library.md");
+const PROMPT_CONFIGURABLE: &str = include_str!("prompt_configurable.md");
 
 pub struct TranslateAgentic;
 
@@ -56,6 +57,7 @@ impl Tool for TranslateAgentic {
         let translate_prompt = load_prompt(
             &config.prompt_executable,
             &config.prompt_library,
+            &config.prompt_configurable,
             &project_spec.kind,
         )?;
 
@@ -150,6 +152,11 @@ fn post_process(
             cargo.set_bin_driver();
             cargo.save()?;
         }
+        ProjectKind::Configurable => {
+            // The configurable prompt instructs the agent to produce both [lib] and [[bin]].
+            // Only ensure workspace is present (already added above); leave the rest intact.
+            cargo.save()?;
+        }
     }
     Ok(())
 }
@@ -158,11 +165,13 @@ fn post_process(
 fn load_prompt(
     prompt_executable: &Option<PathBuf>,
     prompt_library: &Option<PathBuf>,
+    prompt_configurable: &Option<PathBuf>,
     kind: &ProjectKind,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let (config_path, builtin) = match kind {
         ProjectKind::Executable => (prompt_executable, PROMPT_EXECUTABLE),
         ProjectKind::Library => (prompt_library, PROMPT_LIBRARY),
+        ProjectKind::Configurable => (prompt_configurable, PROMPT_CONFIGURABLE),
     };
     match config_path {
         Some(p) => Ok(fs::read_to_string(p)?),
@@ -178,6 +187,9 @@ pub struct Config {
 
     /// Override path for the library translation prompt.
     pub prompt_library: Option<PathBuf>,
+
+    /// Override path for the configurable translation prompt.
+    pub prompt_configurable: Option<PathBuf>,
 
     /// Agent timeout in seconds. Defaults to 1800 (30 minutes).
     #[serde(default = "default_timeout_secs")]

--- a/tools/translate_agentic/src/prompt_configurable.md
+++ b/tools/translate_agentic/src/prompt_configurable.md
@@ -1,0 +1,55 @@
+<!-- markdownlint-disable MD041 -->
+Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
+Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+
+This project has **build-time configurability** via CMake cache variables.
+Look at c_src/CMakeLists.txt — it uses variables to select which source files
+to compile and which parameter headers to include at build time.
+
+You MUST preserve this configurability using **Cargo features**. Each CMake cache
+variable value becomes a Cargo feature, using the **exact same name in lowercase**.
+Use `#[cfg(feature = "...")]` to conditionally compile modules and set constants.
+All combinations of features must compile.
+
+This project produces BOTH a shared library AND a binary executable.
+Your Cargo.toml must have both `[lib]` with `crate-type = ["cdylib"]` and
+`[[bin]]` with `name = "driver"` and `path = "src/main.rs"`.
+
+**This is a large project.** Do NOT try to translate everything yourself in one go.
+Instead:
+1. Analyze the C project structure and create a plan (TODO list) breaking the
+   translation into subtasks (e.g., core/shared code, each backend, entry points)
+2. For each subtask, invoke a subagent to do the translation by running:
+   ```
+   kiro-cli chat --no-interactive --trust-all-tools \
+     '<detailed prompt for this subtask>' \
+     < /dev/null
+   ```
+3. After each subagent completes, verify the work compiles before moving on
+4. Once all subtasks are done, wire up the feature gates and verify the full build
+
+Each subagent should work in the same directory and add to the existing code.
+Give each subagent a clear, focused prompt with the specific C files to translate
+and where to put the Rust output. Each subagent prompt MUST include:
+- Which specific C source files to translate
+- Which Rust file(s) to write
+- Instructions to build and verify its own work compiles with the relevant features
+- Instructions to NOT modify any files outside its scope
+
+After all subagents complete, wire up the feature gates and do a final build check.
+If a combination fails, only fix the glue code (lib.rs, mod declarations) — do NOT
+modify the backend implementation files.
+
+Requirements:
+- Do NOT use the `openssl` crate or any OpenSSL bindings. Use pure-Rust crates
+  instead (e.g., `aes` for AES-256-ECB, `sha2` for SHA-256)
+- All public C functions must use #[unsafe(no_mangle)] and extern "C"
+- Pay attention to C preprocessor macros that RENAME functions (e.g.,
+  `#define foo NAMESPACE(foo)` makes the linker symbol `PREFIX_foo`, not `foo`).
+  The Rust #[no_mangle] name must match the FINAL linker symbol, not the
+  source-level name. Check header files for namespace macros.
+- Preserve the exact C function signatures (use *const c_char, c_int, etc. from std::ffi)
+- Do NOT fix bugs in the original C code — reproduce behavior exactly
+- Use safe Rust internally where possible
+
+Do NOT modify anything in c_src/.

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -19,7 +19,7 @@ model = "codellama:7b"
 max_tokens = 10000
 
 [tools.translate_agentic]
-timeout_secs = 1800
+timeout_secs = 7200
 
 [tools.verify_fix_agentic]
 timeout_secs = 2700


### PR DESCRIPTION
`build_project_spec` now identifies `Configurable` test programs (in addition to `Executable` and `Library`), which is directed to a special path in `translate_agentic`. I did not finish an end-to-end test on P01, due to the following Kiro error, which seems like a free tier rate limit problem:

```txt
Kiro is having trouble responding right now: 
   0: Failed to send the request: An unknown error occurred: ThrottlingException
   1: An unknown error occurred: ThrottlingException
   2: unhandled error (ThrottlingException)
   3: service error
   4: unhandled error (ThrottlingException)
   5: Error { code: "ThrottlingException", message: "60-minute credit limit exceeded", aws_request_id: "362c41d9-c3d6-4940-88f8-edeb1c8d8a06" }
```

To run P01 (first configuration), do:

```bash
# Pull Test-Corpus into the project folder
# Install Kiro-cli and authenticate
cargo run --bin=benchmark --release -- --agentic --agentic-verify ./Test-Corpus/Public-Tests/P01_sphincs_plus/005_sphincs_PQCgenKAT_sign_blake_128f_simple ./out_p01_sphincs_plus_005
```