### PR TITLE
Add Claude Code backend to the agentic translator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,7 @@ dependencies = [
  "libc",
  "load_raw_source",
  "modular_translation_llm",
+ "normalize_cargo",
  "raw_source_to_cargo_llm",
  "serde",
  "serde_json",
@@ -1955,6 +1956,15 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+]
+
+[[package]]
+name = "normalize_cargo"
+version = "0.1.0"
+dependencies = [
+ "full_source",
+ "harvest_core",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -3161,7 +3171,6 @@ dependencies = [
  "cargo_metadata",
  "full_source",
  "harvest_core",
- "toml_edit 0.23.10+spec-1.0.0",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,6 +1359,7 @@ dependencies = [
 name = "harvest-benchmark"
 version = "0.1.0"
 dependencies = [
+ "build_project_spec",
  "clap",
  "csv",
  "full_source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_project_spec", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic"]
+members = ["benchmark", "core", "tools/full_source", "tools/build_project_spec", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/normalize_cargo" ]
 resolver = "3"
 
 [workspace.dependencies]
@@ -16,6 +16,7 @@ modular_translation_llm = { path = "tools/modular_translation_llm" }
 quantize_rust_spans = { path = "tools/quantize_rust_spans" }
 translate_agentic = { path = "tools/translate_agentic" }
 verify_fix_agentic = { path = "tools/verify_fix_agentic" }
+normalize_cargo = { path = "tools/normalize_cargo" }
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -14,6 +14,7 @@ name = "benchmark"
 path = "src/main.rs"
 
 [dependencies]
+build_project_spec = { version = "0.1.0", path = "../tools/build_project_spec" }
 clap = { workspace = true }
 csv = "1.3"
 full_source = { version = "0.1.0", path = "../tools/full_source" }

--- a/benchmark/src/cli.rs
+++ b/benchmark/src/cli.rs
@@ -29,6 +29,10 @@ pub struct Args {
     #[arg(long, requires = "agentic")]
     pub agentic_verify: bool,
 
+    /// Which agent to use for agentic translation: kiro or claude (requires --agentic).
+    #[arg(long, requires = "agentic")]
+    pub agentic_agent: Option<String>,
+
     /// Set a configuration value; format $NAME=$VALUE.
     #[arg(long, short)]
     pub config: Vec<String>,

--- a/benchmark/src/harness/library.rs
+++ b/benchmark/src/harness/library.rs
@@ -148,14 +148,16 @@ pub fn run_library_validation(
 /// # Returns
 /// Path to the shared library file (.so, .dylib, or .dll)
 pub fn locate_compiled_library(output_dir: &Path, program_name: &str) -> HarvestResult<PathBuf> {
-    let pkg_name = CargoToml::open(&output_dir.join("Cargo.toml"))
+    // Use the lib name (from [lib].name) because cargo names the .so after the lib crate name,
+    // not the package name. Falls back to package_name if [lib].name is not set.
+    let lib_name = CargoToml::open(&output_dir.join("Cargo.toml"))
         .ok()
-        .and_then(|c| c.package_name())
+        .and_then(|c| c.lib_name())
         .unwrap_or_else(|| program_name.to_string());
     let target_release = output_dir.join("target").join("release");
 
-    // Construct expected library name from package name
-    let lib_stem = format!("lib{}", pkg_name.replace('-', "_"));
+    // Construct expected library name from lib crate name
+    let lib_stem = format!("lib{}", lib_name.replace('-', "_"));
 
     // Try common extensions
     for ext in LIBRARY_EXTENSIONS {

--- a/benchmark/src/harness/mod.rs
+++ b/benchmark/src/harness/mod.rs
@@ -124,7 +124,6 @@ pub fn parse_benchmark_dir(input_dir: &Path) -> HarvestResult<(PathBuf, PathBuf)
 
     // Check for required subdirectories
     let test_case_dir = input_dir.join("test_case");
-    let test_case_src_dir = test_case_dir.join("src");
     let test_vectors_dir = input_dir.join("test_vectors");
 
     if !test_case_dir.exists() || !test_case_dir.is_dir() {
@@ -135,10 +134,13 @@ pub fn parse_benchmark_dir(input_dir: &Path) -> HarvestResult<(PathBuf, PathBuf)
         .into());
     }
 
-    if !test_case_src_dir.exists() || !test_case_src_dir.is_dir() {
+    // Accept test_case/src (normal layout) or test_case/app (configurable layout).
+    let has_src = test_case_dir.join("src").is_dir();
+    let has_app = test_case_dir.join("app").is_dir();
+    if !has_src && !has_app {
         return Err(format!(
-            "Required test_case/src directory not found: {}",
-            test_case_src_dir.display()
+            "Required test_case/src or test_case/app directory not found under: {}",
+            test_case_dir.display()
         )
         .into());
     }

--- a/benchmark/src/ir_utils.rs
+++ b/benchmark/src/ir_utils.rs
@@ -36,9 +36,7 @@ pub fn raw_source(ir: &HarvestIR) -> HarvestResult<&RawDir> {
 /// Extract cargo build results from the IR.
 /// Returns the build artifacts, or an error if the build failed or results are missing/ambiguous.
 pub fn cargo_build_result(ir: &HarvestIR) -> Result<&Vec<Artifact>, String> {
-    let build_results: Vec<_> = ir
-        .get_by_representation::<CargoBuildResult>()
-        .collect();
+    let build_results: Vec<_> = ir.get_by_representation::<CargoBuildResult>().collect();
 
     match build_results.len() {
         0 => Err("No artifacts built".into()),

--- a/benchmark/src/ir_utils.rs
+++ b/benchmark/src/ir_utils.rs
@@ -34,16 +34,22 @@ pub fn raw_source(ir: &HarvestIR) -> HarvestResult<&RawDir> {
 }
 
 /// Extract cargo build results from the IR.
-/// Returns the build artifacts or an error if no results or multiple results are found.
+/// Returns the build artifacts, or an error if the build failed or results are missing/ambiguous.
 pub fn cargo_build_result(ir: &HarvestIR) -> Result<&Vec<Artifact>, String> {
     let build_results: Vec<_> = ir
         .get_by_representation::<CargoBuildResult>()
-        .map(|(_, r)| &r.artifacts)
         .collect();
 
     match build_results.len() {
         0 => Err("No artifacts built".into()),
-        1 => Ok(build_results[0]),
+        1 => {
+            let (_, r) = build_results[0];
+            if !r.success {
+                Err(format!("cargo build failed:\n{}", r.err))
+            } else {
+                Ok(&r.artifacts)
+            }
+        }
         n => Err(format!("Found {} build results, expected at most 1", n)),
     }
 }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -18,6 +18,7 @@ use crate::io::{
 use crate::ir_utils::{cargo_build_result, raw_cargo_package, raw_source};
 use crate::logger::TeeLogger;
 use crate::stats::{ProgramEvalStats, SummaryStats, TestResult};
+use build_project_spec::{detect_project_kind, ProjectKind};
 use clap::Parser;
 use harvest_core::utils::get_version;
 use harvest_core::HarvestIR;
@@ -249,11 +250,6 @@ fn benchmark_single_program(
 
     log::info!("Translating program: {}", program_name);
     log::info!("Input directory: {}", program_dir.display());
-    let is_lib = program_name.ends_with("_lib");
-    log::info!(
-        "Detected project type: {}",
-        if is_lib { "library" } else { "executable" }
-    );
 
     // Get program output directory
     let output_dir = output_root_dir.join(&program_name);
@@ -268,6 +264,16 @@ fn benchmark_single_program(
             return result;
         }
     };
+
+    // Detect project kind from the C source root (same heuristic as build_project_spec).
+    let project_kind = detect_project_kind(&test_case_dir);
+    log::info!(
+        "Detected project type: {}",
+        project_kind
+            .as_ref()
+            .map(|k| k.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    );
 
     // Parse test vectors
     let test_cases = match parse_test_vectors(test_vectors_dir) {
@@ -323,37 +329,45 @@ fn benchmark_single_program(
     }
 
     // Library and executable validation differ.
-    let (test_results, error_messages) = match (is_lib, translation_result.rust_binary_path) {
-        (true, _) => {
-            match harness::library::run_library_validation(
-                &program_name,
-                program_dir,
-                &output_dir,
-                &test_cases,
-                timeout,
-            ) {
-                Ok(r) => r,
-                Err(e) => {
-                    let error_msg = format!("Library validation failed: {}", e);
-                    log::error!("{}", error_msg);
-                    result.error_message = Some(error_msg);
-                    return result;
+    // Both Library and Configurable projects use cando2 (runner + test_vectors).
+    // Executable projects run the binary directly against test vectors.
+    // Unknown project kinds fall back to the binary path if available.
+    let use_library_validation = matches!(
+        project_kind,
+        Some(ProjectKind::Library) | Some(ProjectKind::Configurable)
+    );
+    let (test_results, error_messages) =
+        match (use_library_validation, translation_result.rust_binary_path) {
+            (true, _) => {
+                match harness::library::run_library_validation(
+                    &program_name,
+                    program_dir,
+                    &output_dir,
+                    &test_cases,
+                    timeout,
+                ) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let error_msg = format!("Library validation failed: {}", e);
+                        log::error!("{}", error_msg);
+                        result.error_message = Some(error_msg);
+                        return result;
+                    }
                 }
             }
-        }
-        (false, Some(binary_path)) if binary_path.exists() => {
-            run_test_validation(&binary_path, &test_cases, timeout, &output_dir)
-        }
-        (_, binary_path) => {
-            let error = format!(
+            (false, Some(binary_path)) if binary_path.exists() => {
+                run_test_validation(&binary_path, &test_cases, timeout, &output_dir)
+            }
+            (_, binary_path) => {
+                let error = format!(
                 "Rust build reported success, but expected output artifact was not found at {:?}",
                 binary_path
             );
-            log::error!("{}", error);
-            result.error_message = Some(error);
-            return result;
-        }
-    };
+                log::error!("{}", error);
+                result.error_message = Some(error);
+                return result;
+            }
+        };
 
     result.passed_tests = test_results
         .iter()

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -453,6 +453,8 @@ fn run(args: Args) -> HarvestResult<()> {
         "Using {} Translation",
         if args.modular {
             "Modular"
+        } else if args.agentic {
+            "Agentic"
         } else {
             "All-at-once"
         }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -68,6 +68,7 @@ impl TranspilationResult {
 }
 
 /// Translates a C source directory to a Rust Cargo project using harvest_translate
+#[allow(clippy::too_many_arguments)]
 pub fn translate_c_directory_to_rust_project(
     input_dir: &Path,
     output_dir: &Path,
@@ -75,6 +76,7 @@ pub fn translate_c_directory_to_rust_project(
     modular: bool,
     agentic: bool,
     agentic_verify: bool,
+    agentic_agent: Option<harvest_core::config::AgentKind>,
 ) -> TranspilationResult {
     let args: Arc<harvest_translate::cli::Args> = harvest_translate::cli::Args {
         input: Some(input_dir.to_path_buf()),
@@ -85,6 +87,7 @@ pub fn translate_c_directory_to_rust_project(
         modular,
         agentic,
         agentic_verify,
+        agentic_agent,
     }
     .into();
     let mut config = harvest_translate::cli::initialize(args).expect("Failed to generate config");
@@ -126,6 +129,7 @@ pub fn translate_c_directory_to_rust_project(
 }
 
 /// Run all benchmarks for a list of programs
+#[allow(clippy::too_many_arguments)]
 pub fn run_all_benchmarks(
     program_dirs: &[PathBuf],
     output_dir: &Path,
@@ -134,6 +138,7 @@ pub fn run_all_benchmarks(
     modular: bool,
     agentic: bool,
     agentic_verify: bool,
+    agentic_agent: Option<harvest_core::config::AgentKind>,
 ) -> HarvestResult<Vec<ProgramEvalStats>> {
     // Process all examples
     let mut results = Vec::new();
@@ -152,6 +157,7 @@ pub fn run_all_benchmarks(
             modular,
             agentic,
             agentic_verify,
+            agentic_agent,
         );
 
         results.push(result);
@@ -230,6 +236,7 @@ fn run_test_validation(
 }
 
 /// Run all benchmarks for a single program
+#[allow(clippy::too_many_arguments)]
 fn benchmark_single_program(
     program_dir: &Path,
     output_root_dir: &Path,
@@ -238,6 +245,7 @@ fn benchmark_single_program(
     modular: bool,
     agentic: bool,
     agentic_verify: bool,
+    agentic_agent: Option<harvest_core::config::AgentKind>,
 ) -> ProgramEvalStats {
     let program_name = program_dir
         .file_name()
@@ -293,6 +301,7 @@ fn benchmark_single_program(
         modular,
         agentic,
         agentic_verify,
+        agentic_agent,
     );
 
     result.translation_success = translation_result.translation_success;
@@ -477,6 +486,14 @@ fn run(args: Args) -> HarvestResult<()> {
     log_found_programs(&program_dirs, &args.input_dir)?;
 
     // Process all programs
+    let agentic_agent = args
+        .agentic_agent
+        .as_deref()
+        .map(|s| match s.to_lowercase().as_str() {
+            "kiro" => harvest_core::config::AgentKind::Kiro,
+            "claude" => harvest_core::config::AgentKind::Claude,
+            other => panic!("unknown agent kind: {other}"),
+        });
     let results = run_all_benchmarks(
         &program_dirs,
         &args.output_dir,
@@ -485,6 +502,7 @@ fn run(args: Args) -> HarvestResult<()> {
         args.modular,
         args.agentic,
         args.agentic_verify,
+        agentic_agent,
     )?;
     let csv_output_path = args.output_dir.join("results.csv");
     write_csv_results(&csv_output_path, &results)?;

--- a/core/src/cargo_utils.rs
+++ b/core/src/cargo_utils.rs
@@ -57,6 +57,16 @@ impl CargoToml {
             .map(|s| s.to_string())
     }
 
+    /// Returns the `[lib].name` if explicitly set, otherwise falls back to `package_name`.
+    pub fn lib_name(&self) -> Option<String> {
+        self.doc
+            .get("lib")
+            .and_then(|l| l.get("name"))
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| self.package_name())
+    }
+
     /// Adds an empty `[workspace]` section if not already present, preventing Cargo from
     /// searching parent directories for a workspace root.
     pub fn add_workspace(&mut self) {
@@ -187,11 +197,8 @@ impl CargoToml {
         {
             pkg.insert("name", Item::Value(Value::from(&desired)));
         }
-        if let Some(lib) = self.doc.get_mut("lib").and_then(|l| l.as_table_mut())
-            && lib.get("name").and_then(|n| n.as_str()) != Some(&desired)
-        {
-            lib.insert("name", Item::Value(Value::from(&desired)));
-        }
+        // Do NOT rename [lib].name. It is referenced by `use lib_name::...` in source code.
+        // Renaming it here would break any binary targets that import the lib by its original name.
     }
 
     /// Sets `[features].default` to the given list. Reserved for multi-config support.

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,7 +1,26 @@
+use std::fmt;
 use std::{collections::HashMap, path::PathBuf};
 
 use serde::Deserialize;
 use serde_json::Value;
+
+/// Which external agent to invoke for agentic translation and verification.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentKind {
+    #[default]
+    Kiro,
+    Claude,
+}
+
+impl fmt::Display for AgentKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AgentKind::Kiro => write!(f, "kiro"),
+            AgentKind::Claude => write!(f, "claude"),
+        }
+    }
+}
 
 /// Configuration for this harvest-translate run. The sources of these configuration values (from
 /// highest-precedence to lowest-precedence) are:
@@ -39,6 +58,10 @@ pub struct Config {
     #[serde(default)]
     pub agentic_verify: bool,
 
+    /// Which external agent to use for agentic translation (requires `agentic = true`).
+    #[serde(default)]
+    pub agentic_agent: AgentKind,
+
     /// Filter describing which log messages should be output to stdout. This is in the
     /// `tracing_subscriber::filter::EnvFilter` format.
     pub log_filter: String,
@@ -65,6 +88,7 @@ impl Config {
             modular: false,
             agentic: false,
             agentic_verify: false,
+            agentic_agent: AgentKind::default(),
             log_filter: "off".to_owned(),
             tools: Default::default(),
             unknown: Default::default(),
@@ -75,8 +99,8 @@ impl Config {
     /// Printed at the start of translation and benchmarking runs to aid in reproduction of results.
     pub fn model_info(&self) -> Option<String> {
         if self.agentic {
-            let suffix = if self.agentic_verify { " + verify" } else { "" };
-            return Some(format!("agentic{suffix}"));
+            let verify = if self.agentic_verify { " + verify" } else { "" };
+            return Some(format!("agentic({}){verify}", self.agentic_agent));
         }
         let tool_name = if self.modular {
             "modular_translation_llm"

--- a/core/src/fs/mod.rs
+++ b/core/src/fs/mod.rs
@@ -672,3 +672,7 @@ fn resolve_file_path(path: &Path) -> Result<(Vec<&OsStr>, &OsStr), GetFileError>
     };
     Ok((segments, file_name))
 }
+
+pub fn temp_working_dir() -> std::io::Result<impl AsRef<Path>> {
+    TempDir::new()
+}

--- a/core/src/ir.rs
+++ b/core/src/ir.rs
@@ -76,6 +76,11 @@ impl HarvestIR {
     }
 
     /// Returns the representation with the given ID, if it is of the expected type.
+    pub fn get_representation(&self, id: Id) -> Option<&dyn Representation> {
+        self.representations.get(&id).map(|v| &**v)
+    }
+
+    /// Returns the representation with the given ID, if it is of the expected type.
     pub fn get<R: Representation>(&self, id: Id) -> Option<&R> {
         self.representations
             .get(&id)

--- a/tools/build_project_spec/src/lib.rs
+++ b/tools/build_project_spec/src/lib.rs
@@ -8,6 +8,7 @@ use harvest_core::tools::{RunContext, Tool};
 pub enum ProjectKind {
     Library,
     Executable,
+    Configurable,
 }
 
 impl Display for ProjectKind {
@@ -15,6 +16,7 @@ impl Display for ProjectKind {
         match self {
             ProjectKind::Library => write!(f, "Library"),
             ProjectKind::Executable => write!(f, "Executable"),
+            ProjectKind::Configurable => write!(f, "Configurable"),
         }
     }
 }
@@ -52,6 +54,13 @@ impl Tool for BuildProjectSpec {
             .ir_snapshot
             .get::<RawSource>(inputs[0])
             .ok_or("No RawSource representation found in IR")?;
+
+        // CMakePresets.json signals a build-time configurable project (e.g. sphincs).
+        if repr.dir.get_file("CMakePresets.json").is_ok() {
+            return Ok(Box::new(ProjectSpec {
+                kind: ProjectKind::Configurable,
+            }));
+        }
 
         if let Ok(cmakelists) = repr.dir.get_file("CMakeLists.txt") {
             if String::from_utf8_lossy(cmakelists)

--- a/tools/build_project_spec/src/lib.rs
+++ b/tools/build_project_spec/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::path::Path;
 
 use full_source::RawSource;
 use harvest_core::Id;
@@ -37,6 +38,37 @@ impl Representation for ProjectSpec {
     }
 }
 
+/// Core detection logic shared by [`detect_project_kind`] and [`BuildProjectSpec::run`].
+///
+/// Examines the top-level `CMakeLists.txt` content to classify the project:
+/// - `add_executable(` at line start -> Executable
+/// - `add_library(` at line start -> Library
+/// - `add_subdirectory(` at line start (with neither of the above) -> Configurable
+///   (e.g. sphincs, where the real targets live in sub-CMakeLists)
+fn kind_from_cmakelists(cmakelists: &[u8]) -> Option<ProjectKind> {
+    let text = String::from_utf8_lossy(cmakelists);
+    if text.lines().any(|l| l.starts_with("add_executable(")) {
+        return Some(ProjectKind::Executable);
+    }
+    if text.lines().any(|l| l.starts_with("add_library(")) {
+        return Some(ProjectKind::Library);
+    }
+    if text.lines().any(|l| l.starts_with("add_subdirectory(")) {
+        return Some(ProjectKind::Configurable);
+    }
+    None
+}
+
+/// Detect the project kind from a source directory on the filesystem.
+///
+/// Useful for callers (e.g. the benchmark harness) that need the project kind
+/// before or outside of a full tool pipeline.  Returns `None` if the kind
+/// cannot be determined.
+pub fn detect_project_kind(dir: &Path) -> Option<ProjectKind> {
+    let cmakelists = std::fs::read(dir.join("CMakeLists.txt")).ok()?;
+    kind_from_cmakelists(&cmakelists)
+}
+
 pub struct BuildProjectSpec;
 
 impl Tool for BuildProjectSpec {
@@ -49,37 +81,18 @@ impl Tool for BuildProjectSpec {
         context: RunContext,
         inputs: Vec<Id>,
     ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
-        // Get RawSource representation (the first and only arg of build_project_spec)
         let repr = context
             .ir_snapshot
             .get::<RawSource>(inputs[0])
             .ok_or("No RawSource representation found in IR")?;
 
-        // CMakePresets.json signals a build-time configurable project (e.g. sphincs).
-        if repr.dir.get_file("CMakePresets.json").is_ok() {
-            return Ok(Box::new(ProjectSpec {
-                kind: ProjectKind::Configurable,
-            }));
-        }
+        let cmakelists = repr.dir.get_file("CMakeLists.txt").map_err(
+            |_| "Could not identify project kind from CMakeLists.txt (or could not find it)",
+        )?;
+        let kind = kind_from_cmakelists(cmakelists).ok_or(
+            "CMakeLists.txt found but contains no add_executable, add_library, or add_subdirectory",
+        )?;
 
-        if let Ok(cmakelists) = repr.dir.get_file("CMakeLists.txt") {
-            if String::from_utf8_lossy(cmakelists)
-                .lines()
-                .any(|line| line.starts_with("add_executable("))
-            {
-                return Ok(Box::new(ProjectSpec {
-                    kind: ProjectKind::Executable,
-                }));
-            } else if String::from_utf8_lossy(cmakelists)
-                .lines()
-                .any(|line| line.starts_with("add_library("))
-            {
-                return Ok(Box::new(ProjectSpec {
-                    kind: ProjectKind::Library,
-                }));
-            }
-        }
-
-        Err("Could not identify project kind from CMakeLists.txt (or could not find it)".into())
+        Ok(Box::new(ProjectSpec { kind }))
     }
 }

--- a/tools/modular_translation_llm/src/recombine.rs
+++ b/tools/modular_translation_llm/src/recombine.rs
@@ -54,6 +54,7 @@ pub fn recombine_decls(
     let source_file = match project_kind {
         ProjectKind::Executable => "src/main.rs",
         ProjectKind::Library => "src/lib.rs",
+        ProjectKind::Configurable => "src/lib.rs",
     };
 
     // Create the directory structure

--- a/tools/modular_translation_llm/src/recombine.rs
+++ b/tools/modular_translation_llm/src/recombine.rs
@@ -54,7 +54,9 @@ pub fn recombine_decls(
     let source_file = match project_kind {
         ProjectKind::Executable => "src/main.rs",
         ProjectKind::Library => "src/lib.rs",
-        ProjectKind::Configurable => "src/lib.rs",
+        ProjectKind::Configurable => {
+            unreachable!("Configurable projects are not supported by this tool")
+        }
     };
 
     // Create the directory structure

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -204,7 +204,13 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
-            ProjectKind::Configurable => "configurable",
+            ProjectKind::Configurable => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "modular translation does not yet support ProjectKind::Configurable",
+                )
+                .into())
+            }
         };
 
         let request = build_request(

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -204,6 +204,7 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
+            ProjectKind::Configurable => "configurable",
         };
 
         let request = build_request(
@@ -265,6 +266,7 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
+            ProjectKind::Configurable => "configurable",
         };
 
         let type_code: Vec<String> = type_translations
@@ -341,6 +343,7 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
+            ProjectKind::Configurable => "configurable",
         };
 
         let type_code: Vec<String> = type_translations
@@ -401,6 +404,7 @@ impl ModularTranslationLLM {
         let project_kind_str = match project_kind {
             ProjectKind::Executable => "executable",
             ProjectKind::Library => "library",
+            ProjectKind::Configurable => "configurable",
         };
 
         let request = build_request(

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -209,7 +209,7 @@ impl ModularTranslationLLM {
                     std::io::ErrorKind::Unsupported,
                     "modular translation does not yet support ProjectKind::Configurable",
                 )
-                .into())
+                .into());
             }
         };
 

--- a/tools/normalize_cargo/Cargo.toml
+++ b/tools/normalize_cargo/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
-name = "try_cargo_build"
+name = "normalize_cargo"
 version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-cargo_metadata = "0.23.1"
 full_source.workspace = true
 harvest_core.workspace = true
-tracing.workspace = true
+toml_edit = { workspace = true }
 
 [lints]
 workspace = true

--- a/tools/normalize_cargo/src/lib.rs
+++ b/tools/normalize_cargo/src/lib.rs
@@ -1,0 +1,40 @@
+//! Checks if a generated Rust project builds by materializing
+//! it to a tempdir and running `cargo build --release`.
+use full_source::CargoPackage;
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use toml_edit::{DocumentMut, Item, Table, Value};
+
+pub struct NormalizeCargo;
+
+impl Tool for NormalizeCargo {
+    fn name(&self) -> &'static str {
+        "normalize_cargo"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        // Get cargo package representation (the first and only arg of try_cargo_build)
+        let mut cargo_package = context
+            .ir_snapshot
+            .get::<CargoPackage>(inputs[0])
+            .ok_or("No CargoPackage representation found in IR")?
+            .clone();
+        let raw_cargo = cargo_package.dir.get_file_mut("Cargo.toml")?;
+        let mut cargo: DocumentMut = str::from_utf8(raw_cargo)?.parse()?;
+        if cargo.get("workspace").is_none() {
+            cargo.insert("workspace", Item::Table(Table::new()));
+        }
+        if let Some(pkg) = cargo.get_mut("package").and_then(|p| p.as_table_mut()) {
+            pkg.insert("name", Item::Value(Value::from("driver")));
+        }
+
+        raw_cargo.clear();
+        raw_cargo.append(&mut cargo.to_string().as_bytes().to_vec());
+
+        Ok(Box::new(cargo_package))
+    }
+}

--- a/tools/raw_source_to_cargo_llm/src/lib.rs
+++ b/tools/raw_source_to_cargo_llm/src/lib.rs
@@ -52,6 +52,9 @@ impl Tool for RawSourceToCargoLlm {
         let (config_prompt, builtin_prompt) = match project_kind {
             ProjectKind::Executable => (config.prompt_executable, SYSTEM_PROMPT_EXECUTABLE),
             ProjectKind::Library => (config.prompt_library, SYSTEM_PROMPT_LIBRARY),
+            ProjectKind::Configurable => {
+                return Err("raw_source_to_cargo_llm does not support Configurable projects; use translate_agentic instead".into());
+            }
         };
         let system_prompt = config_prompt
             .map(read_to_string)

--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -8,7 +8,7 @@
 use build_project_spec::{ProjectKind, ProjectSpec};
 use full_source::{CargoPackage, RawSource};
 use harvest_core::cargo_utils::{CargoToml, strip_for_lib};
-use harvest_core::config::unknown_field_warning;
+use harvest_core::config::{AgentKind, unknown_field_warning};
 use harvest_core::fs::RawDir;
 use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
@@ -21,6 +21,7 @@ use tracing::{info, warn};
 
 const PROMPT_EXECUTABLE: &str = include_str!("prompt_executable.md");
 const PROMPT_LIBRARY: &str = include_str!("prompt_library.md");
+const PROMPT_CLAUDE_TRANSLATE: &str = include_str!("prompt_claude_translate.md");
 
 pub struct TranslateAgentic;
 
@@ -53,11 +54,8 @@ impl Tool for TranslateAgentic {
             .get::<ProjectSpec>(inputs[1])
             .ok_or("No ProjectSpec representation found in IR")?;
 
-        let translate_prompt = load_prompt(
-            &config.prompt_executable,
-            &config.prompt_library,
-            &project_spec.kind,
-        )?;
+        let agent = context.config.agentic_agent;
+        let translate_prompt = load_prompt(&config, &project_spec.kind, agent)?;
 
         // Set up a working directory that mirrors the layout the agent expects:
         //   case_dir/translated_rust/c_src/  <- materialized C source
@@ -70,7 +68,11 @@ impl Tool for TranslateAgentic {
         info!("Working directory: {}", case_dir.display());
 
         let translated = case_dir.join("translated_rust");
-        invoke_agent(&translated, &translate_prompt, config.timeout_secs)?;
+
+        if agent == AgentKind::Claude {
+            write_claude_sandbox(case_dir)?;
+        }
+        invoke_agent(&translated, &translate_prompt, config.timeout_secs, agent)?;
 
         if !translated.join("Cargo.toml").exists() {
             return Err("Agent did not produce a Cargo.toml".into());
@@ -101,31 +103,67 @@ fn invoke_agent(
     work_dir: &Path,
     prompt: &str,
     timeout_secs: u64,
+    agent: AgentKind,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Invoking translation agent (timeout={}s)", timeout_secs);
+    info!("Invoking translation agent ({agent}, timeout={timeout_secs}s)");
 
     let logs_dir = work_dir.parent().unwrap_or(work_dir).join("logs");
     fs::create_dir_all(&logs_dir)?;
     let log_path = logs_dir.join("translation.log");
+    let openssl_dir = std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into());
 
-    let status = Command::new("bash")
-        .arg("-c")
-        .arg(format!(
-            "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
-             --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
-        ))
-        .env("PROMPT", prompt)
-        .env("LOG", &log_path)
-        .env(
-            "OPENSSL_DIR",
-            std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into()),
-        )
-        .current_dir(work_dir)
-        .status()?;
+    let status = match agent {
+        AgentKind::Kiro => Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
+                 --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
+            ))
+            .env("PROMPT", prompt)
+            .env("LOG", &log_path)
+            .env("OPENSSL_DIR", &openssl_dir)
+            .current_dir(work_dir)
+            .status()?,
+        AgentKind::Claude => Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                 --allowedTools 'Bash(*)' 'Write' 'Edit' \
+                 --max-turns 50 \
+                 --output-format stream-json \
+                 < /dev/null 2>&1 | tee \"$LOG\"",
+            ))
+            .env("PROMPT", prompt)
+            .env("LOG", &log_path)
+            .env("OPENSSL_DIR", &openssl_dir)
+            .current_dir(work_dir)
+            .status()?,
+    };
 
     if !status.success() {
         warn!("Translation agent exited with {status}");
     }
+    Ok(())
+}
+
+/// Writes `.claude/settings.json` to sandbox Claude within the working directory.
+fn write_claude_sandbox(case_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_dir = case_dir.join(".claude");
+    fs::create_dir_all(&claude_dir)?;
+    fs::write(
+        claude_dir.join("settings.json"),
+        serde_json::json!({
+            "sandbox": {
+                "enabled": true,
+                "allowUnsandboxedCommands": false,
+                "filesystem": {
+                    "allowRead": [case_dir.to_string_lossy()],
+                    "allowWrite": [case_dir.to_string_lossy()]
+                }
+            }
+        })
+        .to_string(),
+    )?;
     Ok(())
 }
 
@@ -154,30 +192,41 @@ fn post_process(
     Ok(())
 }
 
-/// Loads the translate prompt for the given project kind.
+/// Loads the translate prompt, selecting between Kiro (per-kind) and Claude (unified) variants.
 fn load_prompt(
-    prompt_executable: &Option<PathBuf>,
-    prompt_library: &Option<PathBuf>,
+    config: &Config,
     kind: &ProjectKind,
+    agent: AgentKind,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let (config_path, builtin) = match kind {
-        ProjectKind::Executable => (prompt_executable, PROMPT_EXECUTABLE),
-        ProjectKind::Library => (prompt_library, PROMPT_LIBRARY),
-    };
-    match config_path {
-        Some(p) => Ok(fs::read_to_string(p)?),
-        None => Ok(builtin.to_owned()),
+    match agent {
+        AgentKind::Claude => match &config.prompt_claude_translate {
+            Some(p) => Ok(fs::read_to_string(p)?),
+            None => Ok(PROMPT_CLAUDE_TRANSLATE.to_owned()),
+        },
+        AgentKind::Kiro => {
+            let (config_path, builtin) = match kind {
+                ProjectKind::Executable => (&config.prompt_executable, PROMPT_EXECUTABLE),
+                ProjectKind::Library => (&config.prompt_library, PROMPT_LIBRARY),
+            };
+            match config_path {
+                Some(p) => Ok(fs::read_to_string(p)?),
+                None => Ok(builtin.to_owned()),
+            }
+        }
     }
 }
 
 /// Tool-specific configuration, read from `[tools.translate_agentic]` in the HARVEST config.
 #[derive(Debug, Deserialize)]
 pub struct Config {
-    /// Override path for the executable translation prompt.
+    /// Override path for the Kiro executable translation prompt.
     pub prompt_executable: Option<PathBuf>,
 
-    /// Override path for the library translation prompt.
+    /// Override path for the Kiro library translation prompt.
     pub prompt_library: Option<PathBuf>,
+
+    /// Override path for the Claude unified translation prompt.
+    pub prompt_claude_translate: Option<PathBuf>,
 
     /// Agent timeout in seconds. Defaults to 1800 (30 minutes).
     #[serde(default = "default_timeout_secs")]

--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -21,6 +21,7 @@ use tracing::{info, warn};
 
 const PROMPT_EXECUTABLE: &str = include_str!("prompt_executable.md");
 const PROMPT_LIBRARY: &str = include_str!("prompt_library.md");
+const PROMPT_CONFIGURABLE: &str = include_str!("prompt_configurable.md");
 
 pub struct TranslateAgentic;
 
@@ -56,6 +57,7 @@ impl Tool for TranslateAgentic {
         let translate_prompt = load_prompt(
             &config.prompt_executable,
             &config.prompt_library,
+            &config.prompt_configurable,
             &project_spec.kind,
         )?;
 
@@ -150,6 +152,11 @@ fn post_process(
             cargo.set_bin_driver();
             cargo.save()?;
         }
+        ProjectKind::Configurable => {
+            // The configurable prompt instructs the agent to produce both [lib] and [[bin]].
+            // Only ensure workspace is present (already added above); leave the rest intact.
+            cargo.save()?;
+        }
     }
     Ok(())
 }
@@ -158,11 +165,13 @@ fn post_process(
 fn load_prompt(
     prompt_executable: &Option<PathBuf>,
     prompt_library: &Option<PathBuf>,
+    prompt_configurable: &Option<PathBuf>,
     kind: &ProjectKind,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let (config_path, builtin) = match kind {
         ProjectKind::Executable => (prompt_executable, PROMPT_EXECUTABLE),
         ProjectKind::Library => (prompt_library, PROMPT_LIBRARY),
+        ProjectKind::Configurable => (prompt_configurable, PROMPT_CONFIGURABLE),
     };
     match config_path {
         Some(p) => Ok(fs::read_to_string(p)?),
@@ -178,6 +187,9 @@ pub struct Config {
 
     /// Override path for the library translation prompt.
     pub prompt_library: Option<PathBuf>,
+
+    /// Override path for the configurable translation prompt.
+    pub prompt_configurable: Option<PathBuf>,
 
     /// Agent timeout in seconds. Defaults to 1800 (30 minutes).
     #[serde(default = "default_timeout_secs")]

--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -131,7 +131,7 @@ fn invoke_agent(
                 "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
                  --allowedTools 'Bash(*)' 'Write' 'Edit' \
                  --max-turns 50 \
-                 --output-format stream-json \
+                 --output-format stream-json --verbose \
                  < /dev/null 2>&1 | tee \"$LOG\"",
             ))
             .env("PROMPT", prompt)

--- a/tools/translate_agentic/src/prompt_claude_translate.md
+++ b/tools/translate_agentic/src/prompt_claude_translate.md
@@ -1,0 +1,53 @@
+<!-- markdownlint-disable MD041 -->
+Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
+Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+
+## Step 1: Analyze BEFORE writing any code
+
+Before writing a single line of Rust, you MUST:
+1. Read `c_src/CMakeLists.txt` to understand the build system, source file selection,
+   and any build-time configurability (cache variables, options, conditional compilation)
+2. Read all header files to understand the public API, preprocessor macros, and
+   namespace/symbol renaming patterns
+3. Determine the project type:
+   - Has `main()` → needs `[[bin]]` with `name = "driver"`
+   - Exports library functions → needs `[lib]` with `crate-type = ["cdylib"]`
+   - Both → include both `[lib]` and `[[bin]]` sections
+4. Identify ALL backends/variants if the project has build-time configurability
+
+## Step 2: Plan the translation
+
+If the project has build-time configurability (CMake cache variables selecting different
+source files or parameters):
+- You MUST preserve this using **Cargo features**. Each CMake cache variable value
+  becomes a Cargo feature using the **exact same name in lowercase**.
+- Use `#[cfg(feature = "...")]` to conditionally compile modules and set constants.
+- ALL combinations of features must compile.
+- Plan which source files map to which features before writing code.
+- Do NOT hardcode a single configuration — every variant must be implemented.
+
+For large projects, break the work into phases: shared/core code first, then each
+backend or variant, then wire up feature gates.
+
+## Step 3: Translate
+
+- All public C functions must use `#[unsafe(no_mangle)]` and `extern "C"` with exact
+  C signatures (use `*const c_char`, `c_int`, etc. from `std::ffi`)
+- Pay attention to C preprocessor macros that RENAME functions (e.g.,
+  `#define foo NAMESPACE(foo)` makes the linker symbol `PREFIX_foo`, not `foo`).
+  The Rust `#[no_mangle]` name must match the FINAL linker symbol, not the
+  source-level name.
+- Do NOT fix bugs in the original C code — reproduce behavior exactly
+- Preserve the exact order of error checks and validation
+- Match C's stdin reading behavior exactly (scanf reads across newlines, fgets does not)
+- Match C's exact printf format output including spacing and newlines
+- Do NOT use the `openssl` crate or any OpenSSL bindings — use pure-Rust crates instead
+- Use safe Rust internally where possible
+
+## Step 4: Verify
+
+Run `cargo build --release` and fix any errors until it compiles.
+If the project has Cargo features, verify ALL feature combinations compile:
+run `cargo build --release --features <feature>` for each one.
+
+Do NOT modify anything in c_src/.

--- a/tools/translate_agentic/src/prompt_configurable.md
+++ b/tools/translate_agentic/src/prompt_configurable.md
@@ -1,0 +1,55 @@
+<!-- markdownlint-disable MD041 -->
+Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
+Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+
+This project has **build-time configurability** via CMake cache variables.
+Look at c_src/CMakeLists.txt — it uses variables to select which source files
+to compile and which parameter headers to include at build time.
+
+You MUST preserve this configurability using **Cargo features**. Each CMake cache
+variable value becomes a Cargo feature, using the **exact same name in lowercase**.
+Use `#[cfg(feature = "...")]` to conditionally compile modules and set constants.
+All combinations of features must compile.
+
+This project produces BOTH a shared library AND a binary executable.
+Your Cargo.toml must have both `[lib]` with `crate-type = ["cdylib"]` and
+`[[bin]]` with `name = "driver"` and `path = "src/main.rs"`.
+
+**This is a large project.** Do NOT try to translate everything yourself in one go.
+Instead:
+1. Analyze the C project structure and create a plan (TODO list) breaking the
+   translation into subtasks (e.g., core/shared code, each backend, entry points)
+2. For each subtask, invoke a subagent to do the translation by running:
+   ```
+   kiro-cli chat --no-interactive --trust-all-tools \
+     '<detailed prompt for this subtask>' \
+     < /dev/null
+   ```
+3. After each subagent completes, verify the work compiles before moving on
+4. Once all subtasks are done, wire up the feature gates and verify the full build
+
+Each subagent should work in the same directory and add to the existing code.
+Give each subagent a clear, focused prompt with the specific C files to translate
+and where to put the Rust output. Each subagent prompt MUST include:
+- Which specific C source files to translate
+- Which Rust file(s) to write
+- Instructions to build and verify its own work compiles with the relevant features
+- Instructions to NOT modify any files outside its scope
+
+After all subagents complete, wire up the feature gates and do a final build check.
+If a combination fails, only fix the glue code (lib.rs, mod declarations) — do NOT
+modify the backend implementation files.
+
+Requirements:
+- Do NOT use the `openssl` crate or any OpenSSL bindings. Use pure-Rust crates
+  instead (e.g., `aes` for AES-256-ECB, `sha2` for SHA-256)
+- All public C functions must use #[unsafe(no_mangle)] and extern "C"
+- Pay attention to C preprocessor macros that RENAME functions (e.g.,
+  `#define foo NAMESPACE(foo)` makes the linker symbol `PREFIX_foo`, not `foo`).
+  The Rust #[no_mangle] name must match the FINAL linker symbol, not the
+  source-level name. Check header files for namespace macros.
+- Preserve the exact C function signatures (use *const c_char, c_int, etc. from std::ffi)
+- Do NOT fix bugs in the original C code — reproduce behavior exactly
+- Use safe Rust internally where possible
+
+Do NOT modify anything in c_src/.

--- a/tools/try_cargo_build/src/lib.rs
+++ b/tools/try_cargo_build/src/lib.rs
@@ -19,7 +19,7 @@ pub type BuildResult = Result<Vec<PathBuf>, Vec<CompilerMessage>>;
 /// - If the project builds successfully, it returns Ok(Ok(artifact_filenames)).
 /// - If the project fails to build, it returns Ok(Err(error_message)).
 /// - If there is an error running cargo, it returns Err.
-fn try_cargo_build(project_path: &PathBuf) -> Result<CargoBuildResult, Box<dyn std::error::Error>> {
+fn try_cargo_build(project_path: &Path) -> Result<CargoBuildResult, Box<dyn std::error::Error>> {
     info!("Validating that the generated Rust project builds...");
 
     let mut cargo = CargoToml::open(&project_path.join("Cargo.toml"))?;
@@ -90,11 +90,11 @@ impl Tool for TryCargoBuild {
             .ir_snapshot
             .get::<CargoPackage>(inputs[0])
             .ok_or("No CargoPackage representation found in IR")?;
-        let output_path = context.config.output.clone();
-        cargo_package.materialize(&output_path)?;
+        let output_path = harvest_core::fs::temp_working_dir()?;
+        cargo_package.materialize(output_path.as_ref())?;
 
         // Validate that the Rust project builds
-        Ok(Box::new(try_cargo_build(&output_path)?))
+        Ok(Box::new(try_cargo_build(output_path.as_ref())?))
     }
 }
 

--- a/tools/try_cargo_build/src/lib.rs
+++ b/tools/try_cargo_build/src/lib.rs
@@ -2,7 +2,6 @@
 //! it to a tempdir and running `cargo build --release`.
 pub use cargo_metadata::{Artifact, CompilerMessage};
 use full_source::CargoPackage;
-use harvest_core::cargo_utils::CargoToml;
 use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
 use std::path::{Path, PathBuf};
@@ -21,11 +20,6 @@ pub type BuildResult = Result<Vec<PathBuf>, Vec<CompilerMessage>>;
 /// - If there is an error running cargo, it returns Err.
 fn try_cargo_build(project_path: &Path) -> Result<CargoBuildResult, Box<dyn std::error::Error>> {
     info!("Validating that the generated Rust project builds...");
-
-    let mut cargo = CargoToml::open(&project_path.join("Cargo.toml"))?;
-    cargo.add_workspace();
-    cargo.normalize_name(project_path);
-    cargo.save()?;
 
     // Run cargo build in the project directory
     let output = Command::new("cargo")

--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -154,7 +154,7 @@ fn invoke_agent(
             .arg(format!(
                 "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
                  --allowedTools 'Bash(*)' 'Write' 'Edit' \
-                 --output-format stream-json \
+                 --output-format stream-json --verbose \
                  < /dev/null 2>&1 | tee \"$LOG\"",
             ))
             .env("PROMPT", prompt)

--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -7,7 +7,7 @@
 //! gives up). This is dynamic, execution-based verification, not a static or formal analysis.
 
 use full_source::{CargoPackage, RawSource};
-use harvest_core::config::unknown_field_warning;
+use harvest_core::config::{AgentKind, unknown_field_warning};
 use harvest_core::fs::RawDir;
 use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
@@ -19,6 +19,7 @@ use std::process::Command;
 use tracing::{info, warn};
 
 const PROMPT_VERIFY: &str = include_str!("prompt_verify.md");
+const PROMPT_CLAUDE_VERIFY: &str = include_str!("prompt_claude_verify.md");
 
 pub struct VerifyFixAgentic;
 
@@ -42,6 +43,8 @@ impl Tool for VerifyFixAgentic {
         )?;
         config.validate();
 
+        let agent = context.config.agentic_agent;
+
         let cargo_package = context
             .ir_snapshot
             .get::<CargoPackage>(inputs[0])
@@ -50,13 +53,6 @@ impl Tool for VerifyFixAgentic {
             .ir_snapshot
             .get::<RawSource>(inputs[1])
             .ok_or("No RawSource representation found in IR")?;
-
-        let verify_prompt = config
-            .prompt_verify
-            .as_ref()
-            .map(fs::read_to_string)
-            .transpose()?
-            .unwrap_or_else(|| PROMPT_VERIFY.to_owned());
 
         // case_dir/
         //   translated_rust/          <- materialized CargoPackage
@@ -73,11 +69,24 @@ impl Tool for VerifyFixAgentic {
         info!("Working directory: {}", case_dir.display());
 
         let cmake_flags = extract_cmake_flags(case_dir);
-        let prompt = verify_prompt
-            .replace("{CASE_DIR}", &case_dir.to_string_lossy())
-            .replace("{CMAKE_BUILD_FLAGS}", &cmake_flags);
+        let prompt =
+            load_verify_prompt(&config, agent)?.replace("{CMAKE_BUILD_FLAGS}", &cmake_flags);
 
-        invoke_agent(case_dir, &prompt, config.timeout_secs)?;
+        // Kiro runs in case_dir (references translated_rust/ in prompt paths).
+        // Claude runs in translated_rust/ directly (references c_src/ and src/).
+        let agent_work_dir = match agent {
+            AgentKind::Kiro => {
+                let p = prompt.replace("{CASE_DIR}", &case_dir.to_string_lossy());
+                invoke_agent(case_dir, &p, config.timeout_secs, agent)?;
+                case_dir.to_path_buf()
+            }
+            AgentKind::Claude => {
+                write_claude_sandbox(case_dir)?;
+                invoke_agent(&translated, &prompt, config.timeout_secs, agent)?;
+                translated.clone()
+            }
+        };
+        let _ = agent_work_dir;
         info!("Verification complete");
 
         // Remove artifacts that should not be carried into the IR.
@@ -97,36 +106,88 @@ impl Tool for VerifyFixAgentic {
     }
 }
 
+/// Loads the verify prompt for the given agent kind.
+fn load_verify_prompt(
+    config: &Config,
+    agent: AgentKind,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match agent {
+        AgentKind::Claude => match &config.prompt_claude_verify {
+            Some(p) => Ok(fs::read_to_string(p)?),
+            None => Ok(PROMPT_CLAUDE_VERIFY.to_owned()),
+        },
+        AgentKind::Kiro => match &config.prompt_verify {
+            Some(p) => Ok(fs::read_to_string(p)?),
+            None => Ok(PROMPT_VERIFY.to_owned()),
+        },
+    }
+}
+
 /// Invokes the verification agent in `work_dir` with the given prompt and timeout.
 fn invoke_agent(
     work_dir: &Path,
     prompt: &str,
     timeout_secs: u64,
+    agent: AgentKind,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Invoking verification agent (timeout={}s)", timeout_secs);
+    info!("Invoking verification agent ({agent}, timeout={timeout_secs}s)");
 
-    let logs_dir = work_dir.join("logs");
+    let logs_dir = work_dir.parent().unwrap_or(work_dir).join("logs");
     fs::create_dir_all(&logs_dir)?;
     let log_path = logs_dir.join("verify.log");
+    let openssl_dir = std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into());
 
-    let status = Command::new("bash")
-        .arg("-c")
-        .arg(format!(
-            "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
-             --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
-        ))
-        .env("PROMPT", prompt)
-        .env("LOG", &log_path)
-        .env(
-            "OPENSSL_DIR",
-            std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into()),
-        )
-        .current_dir(work_dir)
-        .status()?;
+    let status = match agent {
+        AgentKind::Kiro => Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
+                 --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
+            ))
+            .env("PROMPT", prompt)
+            .env("LOG", &log_path)
+            .env("OPENSSL_DIR", &openssl_dir)
+            .current_dir(work_dir)
+            .status()?,
+        AgentKind::Claude => Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                 --allowedTools 'Bash(*)' 'Write' 'Edit' \
+                 --output-format stream-json \
+                 < /dev/null 2>&1 | tee \"$LOG\"",
+            ))
+            .env("PROMPT", prompt)
+            .env("LOG", &log_path)
+            .env("OPENSSL_DIR", &openssl_dir)
+            .current_dir(work_dir)
+            .status()?,
+    };
 
     if !status.success() {
         warn!("Verification agent exited with {status}");
     }
+    Ok(())
+}
+
+/// Writes `.claude/settings.json` to sandbox Claude within the working directory.
+fn write_claude_sandbox(case_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_dir = case_dir.join(".claude");
+    fs::create_dir_all(&claude_dir)?;
+    fs::write(
+        claude_dir.join("settings.json"),
+        serde_json::json!({
+            "sandbox": {
+                "enabled": true,
+                "allowUnsandboxedCommands": false,
+                "filesystem": {
+                    "allowRead": [case_dir.to_string_lossy()],
+                    "allowWrite": [case_dir.to_string_lossy()]
+                }
+            }
+        })
+        .to_string(),
+    )?;
     Ok(())
 }
 
@@ -135,7 +196,6 @@ fn invoke_agent(
 /// These flags are injected into the verify prompt so the agent knows which build configuration
 /// was active for this case.
 fn extract_cmake_flags(case_dir: &Path) -> String {
-    // TODO: This is a hack for sphincs-plus
     let presets = case_dir.join("translated_rust/c_src/CMakePresets.json");
     let content = match fs::read_to_string(&presets) {
         Ok(c) => c,
@@ -163,8 +223,11 @@ fn extract_cmake_flags(case_dir: &Path) -> String {
 /// Tool-specific configuration, read from `[tools.verify_fix_agentic]` in the HARVEST config.
 #[derive(Debug, Deserialize)]
 pub struct Config {
-    /// Override path for the verification prompt.
+    /// Override path for the Kiro verification prompt.
     pub prompt_verify: Option<PathBuf>,
+
+    /// Override path for the Claude verification prompt.
+    pub prompt_claude_verify: Option<PathBuf>,
 
     /// Agent timeout in seconds. Defaults to 2700 (45 minutes).
     #[serde(default = "default_timeout_secs")]

--- a/tools/verify_fix_agentic/src/prompt_claude_verify.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify.md
@@ -1,0 +1,41 @@
+<!-- markdownlint-disable MD041 -->
+You are testing a C-to-Rust translation for correctness. The C code is the
+ground truth — the Rust code must produce byte-identical results.
+
+- `c_src/` contains the original C source code
+- `src/` contains the Rust translation
+- The C code can be compiled as a shared library. Look at c_src/CMakeLists.txt
+  to understand the build system. Build it with:
+  ```
+  cd c_src && mkdir -p build && cd build && \
+  cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON {CMAKE_BUILD_FLAGS} && \
+  cmake --build .
+  ```
+- Find the resulting .so files in the build output
+
+Your task:
+1. Build the C code as a shared library
+2. Write Rust integration tests (in tests/) that use `libloading`
+   to load the C .so and compare C vs Rust function outputs
+3. Start with the lowest-level functions and work upward to higher-level ones.
+   Look at the C headers to identify the public API and function call hierarchy.
+4. For each function: create fixed test inputs, call both C and Rust versions,
+   assert outputs match byte-for-byte
+5. Run `cargo test` and investigate any mismatches
+6. When you find a Rust function that produces different output than C,
+   fix the Rust code in src/ and re-run until the test passes
+7. Keep going until all public functions match
+8. If the project has a main binary, run both the C binary and the Rust binary
+   with the same inputs and compare their stdout byte-for-byte. Fix any differences.
+9. Compare `nm -D` on the C .so and the Rust .so. Every symbol the C .so
+   exports, the Rust .so must also export with the exact same name. This
+   includes symbols created by preprocessor macros. If the C .so exports it,
+   the Rust .so must export it — no exceptions. Add missing exports.
+
+Add `libloading = "0.8"` to [dev-dependencies] in Cargo.toml.
+Do NOT modify anything in c_src/.
+
+IMPORTANT: Use timeouts for all commands. No single build or test command should
+run longer than 600 seconds. If a test takes too long, skip it and move on to
+the next function. Use `timeout 600 cargo test ...` or similar. Do not get stuck
+on any single step.

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -12,23 +12,24 @@ name = "translate"
 path = "src/main.rs"
 
 [dependencies]
-clap.workspace = true 
+clap.workspace = true
 config = { default-features = false, features = ["toml"], version = "0.15.18" }
 directories = "6.0.0"
-harvest_core.workspace = true 
+harvest_core.workspace = true
 libc = "0.2.177"
-serde.workspace = true 
-serde_json.workspace = true 
-thiserror.workspace = true 
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
-c_ast.workspace = true 
-load_raw_source.workspace = true 
+c_ast.workspace = true
+load_raw_source.workspace = true
 build_project_spec.workspace = true
 modular_translation_llm.workspace = true
 try_cargo_build.workspace = true
 raw_source_to_cargo_llm.workspace = true
 translate_agentic.workspace = true
 verify_fix_agentic.workspace = true
+normalize_cargo.workspace = true
 
 [lints]
 workspace = true

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -5,6 +5,7 @@ log_filter = "info"
 modular = false
 agentic = false
 agentic_verify = false
+agentic_agent = "kiro"
 
 [tools.raw_source_to_cargo_llm]
 address = "http://localhost:11434"

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -19,7 +19,7 @@ model = "codellama:7b"
 max_tokens = 10000
 
 [tools.translate_agentic]
-timeout_secs = 1800
+timeout_secs = 7200
 
 [tools.verify_fix_agentic]
 timeout_secs = 2700

--- a/translate/src/cli.rs
+++ b/translate/src/cli.rs
@@ -33,6 +33,10 @@ pub struct Args {
     #[arg(long, requires = "agentic")]
     pub agentic_verify: bool,
 
+    /// Which agent to use for agentic translation: kiro or claude (requires --agentic).
+    #[arg(long, requires = "agentic", value_parser = parse_agent_kind)]
+    pub agentic_agent: Option<harvest_core::config::AgentKind>,
+
     /// Path to the directory containing the C code to translate.
     // Should always be present unless using a subcommand like --print-config-path
     pub input: Option<PathBuf>,
@@ -57,6 +61,16 @@ pub(crate) fn unknown_field_warning(prefix: &str, unknown: &HashMap<String, Valu
         "" => eprintln!("Warning: unknown config key {name}"),
         p => eprintln!("Warning: unknown config key {p}.{name}"),
     });
+}
+
+fn parse_agent_kind(s: &str) -> Result<harvest_core::config::AgentKind, String> {
+    match s.to_lowercase().as_str() {
+        "kiro" => Ok(harvest_core::config::AgentKind::Kiro),
+        "claude" => Ok(harvest_core::config::AgentKind::Claude),
+        other => Err(format!(
+            "unknown agent kind: {other} (expected: kiro, claude)"
+        )),
+    }
 }
 
 /// Performs parsing and validation of the config; to be called by main() before executing any code
@@ -113,6 +127,12 @@ fn load_config(args: &Args, config_dir: &Path) -> Config {
     if args.agentic_verify {
         settings = settings
             .set_override("agentic_verify", "true")
+            .expect("settings override failed");
+    }
+
+    if let Some(agent) = args.agentic_agent {
+        settings = settings
+            .set_override("agentic_agent", agent.to_string())
             .expect("settings override failed");
     }
 

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -6,14 +6,14 @@ mod runner;
 mod scheduler;
 pub mod util;
 
-use build_project_spec::BuildProjectSpec;
+use build_project_spec::{BuildProjectSpec, ProjectSpec};
 use c_ast::ParseToAst;
 use harvest_core::config::Config;
 use harvest_core::utils::get_version;
 use harvest_core::{HarvestIR, diagnostics};
 use load_raw_source::LoadRawSource;
 use modular_translation_llm::ModularTranslationLlm;
-use raw_source_to_cargo_llm::RawSourceToCargoLlm;
+use normalize_cargo::NormalizeCargo;
 use runner::ToolRunner;
 use scheduler::Scheduler;
 use std::sync::Arc;
@@ -36,21 +36,26 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
     // Setup a schedule for the transpilation.
     let load_src = scheduler.queue(LoadRawSource::new(&config.input));
     let project_spec = scheduler.queue_after(BuildProjectSpec, &[load_src]);
-    let translate = if config.agentic {
-        let mut t = scheduler.queue_after(TranslateAgentic, &[load_src, project_spec]);
-        if config.agentic_verify {
-            t = scheduler.queue_after(VerifyFixAgentic, &[t, load_src]);
+    scheduler.run_all(&mut runner, &mut ir, config.clone())?;
+    let spec = ir
+        .get::<ProjectSpec>(project_spec)
+        .ok_or("No ProjectSpec representation found in IR")?;
+    let translate = match spec.kind {
+        build_project_spec::ProjectKind::Library | build_project_spec::ProjectKind::Executable => {
+            let parse_ast = scheduler.queue_after(ParseToAst, &[load_src]);
+            let t =
+                scheduler.queue_after(ModularTranslationLlm, &[load_src, parse_ast, project_spec]);
+            let t = scheduler.queue_after(NormalizeCargo, &[t]);
+            scheduler.queue_after(TryCargoBuild, &[t]);
+            t
         }
-        t
-    } else if config.modular {
-        let parse_ast = scheduler.queue_after(ParseToAst, &[load_src]);
-        let t = scheduler.queue_after(ModularTranslationLlm, &[load_src, parse_ast, project_spec]);
-        scheduler.queue_after(TryCargoBuild, &[t]);
-        t
-    } else {
-        let t = scheduler.queue_after(RawSourceToCargoLlm, &[load_src, project_spec]);
-        scheduler.queue_after(TryCargoBuild, &[t]);
-        t
+        build_project_spec::ProjectKind::Configurable => {
+            let mut t = scheduler.queue_after(TranslateAgentic, &[load_src, project_spec]);
+            if config.agentic_verify {
+                t = scheduler.queue_after(VerifyFixAgentic, &[t, load_src]);
+            }
+            t
+        }
     };
 
     // Run until all tasks are complete, respecting the dependencies declared in `queue_after`

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -37,22 +37,27 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
     let load_src = scheduler.queue(LoadRawSource::new(&config.input));
     let project_spec = scheduler.queue_after(BuildProjectSpec, &[load_src]);
     let translate = if config.agentic {
-        let t = scheduler.queue_after(TranslateAgentic, &[load_src, project_spec]);
+        let mut t = scheduler.queue_after(TranslateAgentic, &[load_src, project_spec]);
         if config.agentic_verify {
-            scheduler.queue_after(VerifyFixAgentic, &[t, load_src])
-        } else {
-            t
+            t = scheduler.queue_after(VerifyFixAgentic, &[t, load_src]);
         }
+        t
     } else if config.modular {
         let parse_ast = scheduler.queue_after(ParseToAst, &[load_src]);
-        scheduler.queue_after(ModularTranslationLlm, &[load_src, parse_ast, project_spec])
+        let t = scheduler.queue_after(ModularTranslationLlm, &[load_src, parse_ast, project_spec]);
+        scheduler.queue_after(TryCargoBuild, &[t]);
+        t
     } else {
-        scheduler.queue_after(RawSourceToCargoLlm, &[load_src, project_spec])
+        let t = scheduler.queue_after(RawSourceToCargoLlm, &[load_src, project_spec]);
+        scheduler.queue_after(TryCargoBuild, &[t]);
+        t
     };
-    let _try_build = scheduler.queue_after(TryCargoBuild, &[translate]);
 
     // Run until all tasks are complete, respecting the dependencies declared in `queue_after`
-    let result = scheduler.run_all(&mut runner, &mut ir, config);
+    let result = scheduler.run_all(&mut runner, &mut ir, config.clone());
+    ir.get_representation(translate)
+        .ok_or("No CargoPackage representation found in IR")?
+        .materialize(&config.output)?;
     drop(scheduler);
     drop(runner);
     collector.diagnostics(); // TODO: Return this value (see issue 51)


### PR DESCRIPTION
Please merge #138 before this one. That will make the diff smaller.

Added Claude Code as a backend for the agentic translator. Both Kiro and Claude passed P00 in this version. For reference, Claude burnt up ~60% of its 5-hour limit for running through P00.

Note: the part in this PR that changed the lib/package name handling might interfere with existing end-to-end and modular translation pipelines. I did not test-run those yet.