### PR TITLE
Macro translation

### DIFF
--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -48,9 +48,9 @@ fn build_parser<'a>(index: &'a Index, src_root: &Path, rel_file: &Path) -> clang
     parser
 }
 
-/// Extract top-level entities from the file at `rel_path`.
+/// Extract top-level entities from the translation unit.
 /// This includes both entities that survive preprocessing (types, functions, globals) and preprocessor directives (includes, defines, compiler args).
-fn extract_entities(parser: clang::Parser<'_>, rel_file: &Path, out: &mut RichSourceMap) {
+fn extract_entities(parser: clang::Parser<'_>, out: &mut RichSourceMap) {
     let tu = match parser.parse() {
         Ok(tu) => tu,
         Err(e) => {
@@ -73,7 +73,7 @@ fn extract_entities(parser: clang::Parser<'_>, rel_file: &Path, out: &mut RichSo
         }
 
         // Read the source text from the file
-        let Some((span, source_text)) = utils::get_span_and_text(&child, rel_file) else {
+        let Some((span, source_text)) = utils::get_span_and_text(&child) else {
             continue;
         };
 
@@ -128,7 +128,7 @@ impl Tool for ParseToAst {
             }
             tracing::info!("Parsing file: {}", rel_path.to_string_lossy());
             let parser = build_parser(&index, src_dir.path(), &rel_path);
-            extract_entities(parser, &rel_path, &mut out);
+            extract_entities(parser, &mut out);
         }
 
         debug!(

--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -68,18 +68,12 @@ fn extract_entities(parser: clang::Parser<'_>, rel_file: &Path, out: &mut RichSo
         };
 
         // Ignore imports
-        if child.is_in_system_header()
-            || child
-                .get_location()
-                .and_then(|loc| loc.get_file_location().file)
-                .is_none()
-        {
+        if child.is_in_system_header() || utils::get_file_location(&child).is_none() {
             continue;
         }
 
         // Read the source text from the file
-        let Some((span, source_text)) = utils::range_to_span_and_text(child.get_range(), rel_file)
-        else {
+        let Some((span, source_text)) = utils::get_span_and_text(&child, rel_file) else {
             continue;
         };
 

--- a/tools/c_ast/src/rsm.rs
+++ b/tools/c_ast/src/rsm.rs
@@ -121,7 +121,7 @@ impl RichSourceMap {
                 self.include_paths.push(item);
             }
             EntityKind::MacroDefinition => {
-                self.defines.push(item);
+                self.push_define(item);
             }
             EntityKind::PreprocessingDirective => {
                 self.compiler_args.push(item);
@@ -130,10 +130,14 @@ impl RichSourceMap {
     }
 
     fn push_type(&mut self, item: TopLevelEntity) {
-        Self::insert_type_into(&mut self.app_types, item);
+        Self::insert_deduplicated_decl_into(&mut self.app_types, item);
     }
 
-    fn insert_type_into(nodes: &mut Vec<TopLevelEntity>, mut item: TopLevelEntity) {
+    fn push_define(&mut self, item: TopLevelEntity) {
+        Self::insert_deduplicated_decl_into(&mut self.defines, item);
+    }
+
+    fn insert_deduplicated_decl_into(nodes: &mut Vec<TopLevelEntity>, mut item: TopLevelEntity) {
         // If an existing top-level node contains this item, attach it directly
         // as an immediate child. We do not preserve deeper sub-entity ordering.
         for node in nodes.iter_mut() {

--- a/tools/c_ast/src/utils.rs
+++ b/tools/c_ast/src/utils.rs
@@ -77,10 +77,7 @@ pub(crate) fn get_range<'tu>(
 
 /// Read source text from a libClang entity location/range.
 /// Returns None if the range is invalid or spans multiple files.
-pub(crate) fn get_span_and_text(
-    child: &clang::Entity<'_>,
-    rel_file: &Path,
-) -> Option<(SourceSpan, String)> {
+pub(crate) fn get_span_and_text(child: &clang::Entity<'_>) -> Option<(SourceSpan, String)> {
     let (start, end) = get_range(child)?;
     let start_file = get_file_location(child)?;
     let end_file = end.file?;
@@ -101,7 +98,7 @@ pub(crate) fn get_span_and_text(
     let source_text = String::from_utf8_lossy(&file_bytes[start_offset..end_offset]).to_string();
 
     let span = SourceSpan {
-        file: rel_file.to_string_lossy().to_string(),
+        file: start_path.to_string_lossy().to_string(),
         start: SourcePoint {
             line: start.line,
             column: start.column,

--- a/tools/c_ast/src/utils.rs
+++ b/tools/c_ast/src/utils.rs
@@ -1,4 +1,3 @@
-use clang::source::SourceRange;
 use std::path::Path;
 
 use crate::{ClangAST, SourcePoint, SourceSpan, TopLevelEntity};
@@ -33,17 +32,57 @@ pub(crate) fn language_args_for_file(path: &Path) -> [&'static str; 2] {
     }
 }
 
-/// Read source text from a libClang SourceRange.
+fn uses_spelling_location(child: &clang::Entity<'_>) -> bool {
+    child.get_kind() == clang::EntityKind::MacroDefinition
+}
+
+/// Returns the entity location, resolved as spelling location for macros and
+/// expansion location for all other declarations.
+pub(crate) fn get_location<'tu>(
+    child: &clang::Entity<'tu>,
+) -> Option<clang::source::Location<'tu>> {
+    let location = child.get_location()?;
+    Some(if uses_spelling_location(child) {
+        location.get_spelling_location()
+    } else {
+        location.get_expansion_location()
+    })
+}
+
+/// Returns the underlying file for the entity location.
+pub(crate) fn get_file_location<'tu>(
+    child: &clang::Entity<'tu>,
+) -> Option<clang::source::File<'tu>> {
+    get_location(child)?.file
+}
+
+/// Returns start/end locations for an entity's range, resolved as spelling
+/// locations for macros and expansion locations for all other declarations.
+pub(crate) fn get_range<'tu>(
+    child: &clang::Entity<'tu>,
+) -> Option<(clang::source::Location<'tu>, clang::source::Location<'tu>)> {
+    let range = child.get_range()?;
+    Some(if uses_spelling_location(child) {
+        (
+            range.get_start().get_spelling_location(),
+            range.get_end().get_spelling_location(),
+        )
+    } else {
+        (
+            range.get_start().get_expansion_location(),
+            range.get_end().get_expansion_location(),
+        )
+    })
+}
+
+/// Read source text from a libClang entity location/range.
 /// Returns None if the range is invalid or spans multiple files.
-pub(crate) fn range_to_span_and_text(
-    range: Option<SourceRange<'_>>,
+pub(crate) fn get_span_and_text(
+    child: &clang::Entity<'_>,
     rel_file: &Path,
 ) -> Option<(SourceSpan, String)> {
-    let range = range?;
-    let start = range.get_start().get_file_location();
-    let end = range.get_end().get_file_location();
-
-    let start_file = start.file?;
+    let (start, end) = get_range(child)?;
+    let start_file = get_file_location(child)?;
     let end_file = end.file?;
     // check if span is across multiple files
     let start_path = start_file.get_path();

--- a/tools/modular_translation_llm/src/lib.rs
+++ b/tools/modular_translation_llm/src/lib.rs
@@ -22,8 +22,9 @@ mod recombine;
 mod translation;
 mod translation_llm;
 pub use translation::{
-    InterfaceTranslationResult, RustDeclaration, TranslationResult, TypeTranslationResult,
-    translate_decls, translate_functions, translate_interface, translate_types,
+    InterfaceTranslationResult, MacroTranslationResult, RustDeclaration, TranslationResult,
+    TypeTranslationResult, translate_decls, translate_functions, translate_interface,
+    translate_macros, translate_types,
 };
 pub use translation_llm::ModularTranslationLLM;
 
@@ -105,23 +106,27 @@ impl Tool for ModularTranslationLlm {
 
         let app_types: &[TopLevelEntity] = &clang_ast.app_types;
         let app_globals: &[TopLevelEntity] = &clang_ast.app_globals;
+        let defines: &[TopLevelEntity] = &clang_ast.defines;
         let mut app_functions: Vec<TopLevelEntity> = clang_ast.app_functions.clone();
 
         annotate_visibility(&mut app_functions, &clang_ast.app_func_sigs);
         info!("Visibility annotation complete");
 
         info!(
-            "Extracted {} type declarations, {} global declarations, {} function declarations",
+            "Extracted {} macro definitions, {} type declarations, {} global declarations, {} function declarations",
+            defines.len(),
             app_types.len(),
             app_globals.len(),
             app_functions.len()
         );
 
         // Translation flow:
+        // Macros (MacroDefinition) - establish macro translations
         // Types (TypedefDecl, RecordDecl, EnumDecl) - establish data layout
         // Interface (FunctionDecl and VarDecl signatures) - with type context
         // Functions and Globals (FunctionDecl, VarDecl) - with type/interface context
         let translation_result = translation::translate_decls(
+            defines,
             app_types,
             app_globals,
             &app_functions,

--- a/tools/modular_translation_llm/src/prompts/func_translation/system_prompt.txt
+++ b/tools/modular_translation_llm/src/prompts/func_translation/system_prompt.txt
@@ -1,6 +1,7 @@
 You are one pass in a C to Rust translation tool.
 You translate functions and globals. 
 Type declarations (typedefs, structs, enums) and interface signatures (function and global variable signatures) have already been translated and will be provided to you as context.
+Macro translations are also provided as context.
 
 You translate one function or global at a time in isolation. 
 You do not translate comments. 

--- a/tools/modular_translation_llm/src/prompts/macros/structured_schema.json
+++ b/tools/modular_translation_llm/src/prompts/macros/structured_schema.json
@@ -1,0 +1,13 @@
+{
+    "name": "macros",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "macros": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        },
+        "required": ["macros"]
+    }
+}

--- a/tools/modular_translation_llm/src/prompts/macros/system_prompt.txt
+++ b/tools/modular_translation_llm/src/prompts/macros/system_prompt.txt
@@ -28,8 +28,8 @@ return as JSON
 Example output:
 
 { "macros": [
-  "const MAX_LEN: i32 = 1024;",
-  "fn add(a: i32, b: i32) -> i32 { a + b }",
+  "const MAX_LEN: usize = 1024;",
+  "#[inline]\nfn add<T>(a: T, b: T) -> T\nwhere\n    T: std::ops::Add<Output = T>,\n{\n    a + b\n}",
   "macro_rules! str_ {\n    ($x:tt) => {\n        stringify!($x)\n    };\n}",
   "macro_rules! cat {\n    ($a:ident, $b:ident) => {\n        concat!(stringify!($a), stringify!($b))\n    };\n}"
 ] }

--- a/tools/modular_translation_llm/src/prompts/macros/system_prompt.txt
+++ b/tools/modular_translation_llm/src/prompts/macros/system_prompt.txt
@@ -1,0 +1,35 @@
+You are a code translation tool performing the macros pass in a C-to-Rust translation pipeline.
+
+In this pass, you translate C macro definitions into Rust code snippets. You translate one macro at a time in isolation. Do not include comments. Preserve names. Keep output simple and valid Rust where possible.
+
+Prefer `const`, `static`, `type`, `fn`, or `const fn` over `macro_rules!` when semantics are preserved.
+
+Use `macro_rules!` for fundamentally syntactic macros, including stringification, token-pasting analogs, variadics, or call-site syntax shaping.
+
+When asked to generate a structured JSON response, always return valid JSON only. Do not include markdown formatting.
+
+For each input declaration, return one translated Rust code string in the same order.
+
+Example input:
+
+Please translate the following C macro definitions to Rust:
+
+Project kind: executable
+
+{ "declarations": [
+  { "source": "#define MAX_LEN 1024" },
+  { "source": "#define ADD(a, b) ((a) + (b))" },
+  { "source": "#define STR(x) #x" },
+  { "source": "#define CAT(a, b) a##b" }
+] }
+
+return as JSON
+
+Example output:
+
+{ "macros": [
+  "const MAX_LEN: i32 = 1024;",
+  "fn add(a: i32, b: i32) -> i32 { a + b }",
+  "macro_rules! str_ {\n    ($x:tt) => {\n        stringify!($x)\n    };\n}",
+  "macro_rules! cat {\n    ($a:ident, $b:ident) => {\n        concat!(stringify!($a), stringify!($b))\n    };\n}"
+] }

--- a/tools/modular_translation_llm/src/recombine.rs
+++ b/tools/modular_translation_llm/src/recombine.rs
@@ -40,13 +40,22 @@ pub fn recombine_decls(
         translation_result.translations.len()
     );
 
-    // Concatenate all Rust code
-    let rust_code = translation_result
+    // Concatenate translated macros first, then translated declarations.
+    let macro_code = translation_result.macros.join("\n\n");
+    let decl_code = translation_result
         .translations
         .iter()
         .map(|decl| decl.rust_code.as_str())
         .collect::<Vec<_>>()
         .join("\n\n");
+
+    let rust_code = if macro_code.is_empty() {
+        decl_code
+    } else if decl_code.is_empty() {
+        macro_code
+    } else {
+        format!("{macro_code}\n\n{decl_code}")
+    };
 
     let source_content = prepend_dependency_imports(&translation_result.translations, rust_code);
 

--- a/tools/modular_translation_llm/src/translation.rs
+++ b/tools/modular_translation_llm/src/translation.rs
@@ -39,11 +39,56 @@ pub struct InterfaceTranslationResult {
     pub signatures: Vec<String>,
 }
 
+/// Result of the macros translation containing translated Rust macro outputs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MacroTranslationResult {
+    pub macros: Vec<String>,
+}
+
 /// Result of the translation containing both declarations and Cargo.toml
 #[derive(Debug, Deserialize)]
 pub struct TranslationResult {
+    pub macros: Vec<String>,
     pub translations: Vec<RustDeclaration>,
     pub cargo_toml: String,
+}
+
+/// Translates macro definitions to Rust using an LLM.
+///
+/// This function translates C preprocessor macro definitions before all other passes.
+/// The output is a list of Rust code strings corresponding to each macro.
+pub fn translate_macros(
+    macro_definitions: &[TopLevelEntity],
+    raw_source: &RawSource,
+    project_kind: &ProjectKind,
+    modular_llm: &ModularTranslationLLM,
+) -> Result<MacroTranslationResult, Box<dyn std::error::Error>> {
+    debug!(
+        "Starting macro translation for {} definitions",
+        macro_definitions.len()
+    );
+
+    if macro_definitions.is_empty() {
+        return Ok(MacroTranslationResult { macros: Vec::new() });
+    }
+
+    let translation_result =
+        modular_llm.translate_macros(macro_definitions, raw_source, project_kind)?;
+
+    if translation_result.macros.len() != macro_definitions.len() {
+        error!(
+            "Macro translation: LLM returned {} translations but expected {}",
+            translation_result.macros.len(),
+            macro_definitions.len()
+        );
+    }
+
+    info!(
+        "Macro translation complete: successfully translated {} definitions",
+        translation_result.macros.len()
+    );
+
+    Ok(translation_result)
 }
 
 /// Translates type declarations to Rust using an LLM.
@@ -99,6 +144,7 @@ pub fn translate_functions(
     function_and_global_decls: &[&TopLevelEntity],
     raw_source: &RawSource,
     project_kind: &ProjectKind,
+    macro_translations: &MacroTranslationResult,
     type_translations: &TypeTranslationResult,
     interface_translations: &InterfaceTranslationResult,
     modular_llm: &ModularTranslationLLM,
@@ -120,6 +166,7 @@ pub fn translate_functions(
             decl,
             raw_source,
             project_kind,
+            macro_translations,
             type_translations,
             interface_translations,
         )?;
@@ -191,6 +238,7 @@ fn collect_dependencies(translations: &[RustDeclaration]) -> Vec<String> {
 ///
 /// Returns the combined translated declarations and a generated Cargo.toml manifest.
 pub fn translate_decls(
+    defines: &[TopLevelEntity],
     app_types: &[TopLevelEntity],
     app_globals: &[TopLevelEntity],
     app_functions: &[TopLevelEntity],
@@ -198,11 +246,12 @@ pub fn translate_decls(
     project_kind: &ProjectKind,
     config: &Config,
 ) -> Result<TranslationResult, Box<dyn std::error::Error>> {
-    let total_decls = app_types.len() + app_globals.len() + app_functions.len();
+    let total_decls = defines.len() + app_types.len() + app_globals.len() + app_functions.len();
 
     info!(
-        "Starting translation of {} declarations ({} types, {} globals, {} functions)",
+        "Starting translation of {} declarations ({} macros, {} types, {} globals, {} functions)",
         total_decls,
+        defines.len(),
         app_types.len(),
         app_globals.len(),
         app_functions.len()
@@ -213,6 +262,9 @@ pub fn translate_decls(
     }
 
     let modular_llm = ModularTranslationLLM::build(config)?;
+
+    // Translate macros first
+    let macro_result = translate_macros(defines, raw_source, project_kind, &modular_llm)?;
 
     // Translate types
     let type_result = translate_types(app_types, raw_source, project_kind, &modular_llm)?;
@@ -240,6 +292,7 @@ pub fn translate_decls(
             &function_and_global_decls,
             raw_source,
             project_kind,
+            &macro_result,
             &type_result,
             &interface_result,
             &modular_llm,
@@ -260,6 +313,12 @@ pub fn translate_decls(
     let usage_by_call = modular_llm.usage_by_call();
     let usage_totals = modular_llm.usage_totals();
 
+    info!(
+        "token usage [macros] - prompt: {}, output: {}, total: {}",
+        usage_by_call.macros.prompt_tokens,
+        usage_by_call.macros.output_tokens,
+        usage_by_call.macros.total_tokens
+    );
     info!(
         "token usage [types] - prompt: {}, output: {}, total: {}",
         usage_by_call.types.prompt_tokens,
@@ -291,6 +350,7 @@ pub fn translate_decls(
     );
 
     Ok(TranslationResult {
+        macros: macro_result.macros,
         translations: combined_translations,
         cargo_toml,
     })

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -11,17 +11,22 @@ use std::sync::Mutex;
 use tracing::warn;
 
 use crate::Config;
-use crate::translation::{InterfaceTranslationResult, RustDeclaration, TypeTranslationResult};
+use crate::translation::{
+    InterfaceTranslationResult, MacroTranslationResult, RustDeclaration, TypeTranslationResult,
+};
 
 fn declaration_source_text(decl: &TopLevelEntity) -> Result<String, Box<dyn std::error::Error>> {
     Ok(decl.source_text.clone())
 }
 
-/// Structured output JSON schema for Pass 1 (types).
+/// Structured output JSON schema for the macro pass.
+const STRUCTURED_OUTPUT_SCHEMA_MACROS: &str = include_str!("prompts/macros/structured_schema.json");
+
+/// Structured output JSON schema for the type pass.
 const STRUCTURED_OUTPUT_SCHEMA_TYPES: &str =
     include_str!("prompts/type_translation/structured_schema.json");
 
-/// Structured output JSON schema for Pass 2 (functions).
+/// Structured output JSON schema for the function pass.
 const STRUCTURED_OUTPUT_SCHEMA_FUNCTIONS: &str =
     include_str!("prompts/func_translation/structured_schema.json");
 
@@ -33,10 +38,13 @@ const STRUCTURED_OUTPUT_SCHEMA_INTERFACE: &str =
 const STRUCTURED_OUTPUT_SCHEMA_CARGO_TOML: &str =
     include_str!("prompts/cargo_toml/structured_schema.json");
 
-/// System prompt for Pass 1 (types).
+/// System prompt for the macro pass.
+const SYSTEM_PROMPT_MACROS: &str = include_str!("prompts/macros/system_prompt.txt");
+
+/// System prompt for the type pass.
 const SYSTEM_PROMPT_TYPES: &str = include_str!("prompts/type_translation/system_prompt.txt");
 
-/// System prompt for Pass 2 (functions).
+/// System prompt for the function pass.
 const SYSTEM_PROMPT_FUNCTIONS: &str = include_str!("prompts/func_translation/system_prompt.txt");
 
 /// System prompt for the interface pass.
@@ -63,15 +71,23 @@ struct InterfaceResult {
     pub signatures: Vec<String>,
 }
 
+/// Result of macro pass response.
+#[derive(Debug, Deserialize)]
+struct MacrosResult {
+    pub macros: Vec<String>,
+}
+
 /// LLM abstraction layer for modular translation.
 /// Has support for 4 different types of LLM calls with different system prompts
 // and structured output schemas:
 /// - types_llm: for translating type declarations
+/// - macros_llm: for translating macro definitions
 /// - interface_llm: for translating function and global variable signatures in a single batch
 /// - functions_llm: for translating function and global variable declarations one-by-one
 /// - cargo_toml_llm: for generating Cargo.toml based on the list of dependencies used in the
 //    translated code
 pub struct ModularTranslationLLM {
+    macros_llm: HarvestLLM,
     types_llm: HarvestLLM,
     interface_llm: HarvestLLM,
     functions_llm: HarvestLLM,
@@ -81,6 +97,7 @@ pub struct ModularTranslationLLM {
 
 #[derive(Debug, Clone, Copy)]
 enum LLMCallKind {
+    Macros,
     Types,
     Interface,
     Functions,
@@ -89,6 +106,7 @@ enum LLMCallKind {
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ModularLLMUsageTotals {
+    pub macros: LLMUsageTotals,
     pub types: LLMUsageTotals,
     pub interface: LLMUsageTotals,
     pub functions: LLMUsageTotals,
@@ -98,15 +116,18 @@ pub struct ModularLLMUsageTotals {
 impl ModularLLMUsageTotals {
     pub fn total(&self) -> LLMUsageTotals {
         LLMUsageTotals {
-            prompt_tokens: self.types.prompt_tokens
+            prompt_tokens: self.macros.prompt_tokens
+                + self.types.prompt_tokens
                 + self.interface.prompt_tokens
                 + self.functions.prompt_tokens
                 + self.cargo_toml.prompt_tokens,
-            output_tokens: self.types.output_tokens
+            output_tokens: self.macros.output_tokens
+                + self.types.output_tokens
                 + self.interface.output_tokens
                 + self.functions.output_tokens
                 + self.cargo_toml.output_tokens,
-            total_tokens: self.types.total_tokens
+            total_tokens: self.macros.total_tokens
+                + self.types.total_tokens
                 + self.interface.total_tokens
                 + self.functions.total_tokens
                 + self.cargo_toml.total_tokens,
@@ -118,6 +139,11 @@ impl ModularTranslationLLM {
     /// Initializes seperate HarvestLLM instances for each type of translation task with the
     // appropriate system prompts and structured output schemas.
     pub fn build(config: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+        let macros_llm = HarvestLLM::build(
+            &config.llm,
+            STRUCTURED_OUTPUT_SCHEMA_MACROS,
+            SYSTEM_PROMPT_MACROS,
+        )?;
         let types_llm = HarvestLLM::build(
             &config.llm,
             STRUCTURED_OUTPUT_SCHEMA_TYPES,
@@ -140,6 +166,7 @@ impl ModularTranslationLLM {
         )?;
 
         Ok(Self {
+            macros_llm,
             types_llm,
             interface_llm,
             functions_llm,
@@ -155,6 +182,7 @@ impl ModularTranslationLLM {
             .expect("usage mutex poisoned in modular translation");
 
         match call_kind {
+            LLMCallKind::Macros => totals_by_call.macros.add_usage(usage),
             LLMCallKind::Types => totals_by_call.types.add_usage(usage),
             LLMCallKind::Interface => totals_by_call.interface.add_usage(usage),
             LLMCallKind::Functions => totals_by_call.functions.add_usage(usage),
@@ -171,6 +199,58 @@ impl ModularTranslationLLM {
 
     pub fn usage_totals(&self) -> LLMUsageTotals {
         self.usage_by_call().total()
+    }
+
+    /// Translates macro definitions to Rust using the macros_llm.
+    pub fn translate_macros(
+        &self,
+        macro_definitions: &[TopLevelEntity],
+        _raw_source: &RawSource,
+        project_kind: &ProjectKind,
+    ) -> Result<MacroTranslationResult, Box<dyn std::error::Error>> {
+        let mut macro_sources = Vec::new();
+
+        for decl in macro_definitions {
+            let source_text = declaration_source_text(decl)?;
+            macro_sources.push(DeclarationInput {
+                source: format!("#define {}", source_text.trim()),
+            });
+        }
+
+        #[derive(Serialize)]
+        struct RequestWithContext {
+            project_kind: String,
+            declarations: Vec<DeclarationInput>,
+        }
+
+        let project_kind_str = match project_kind {
+            ProjectKind::Executable => "executable",
+            ProjectKind::Library => "library",
+        };
+
+        let request = build_request(
+            "Please translate the following C macro definitions to Rust:",
+            &RequestWithContext {
+                project_kind: project_kind_str.to_string(),
+                declarations: macro_sources.clone(),
+            },
+        )?;
+
+        let (response, usage) = self.macros_llm.invoke(&request)?;
+        self.record_usage(LLMCallKind::Macros, usage.as_ref());
+        let macro_result: MacrosResult = serde_json::from_str(&response)?;
+
+        for (decl, translation) in macro_sources.iter().zip(macro_result.macros.iter()) {
+            crate::info!(
+                "Macro Translation complete:\n {} \n==>\n {}",
+                decl.source,
+                translation
+            );
+        }
+
+        Ok(MacroTranslationResult {
+            macros: macro_result.macros,
+        })
     }
 
     /// Translates type declarations to Rust using the types_llm.
@@ -245,6 +325,7 @@ impl ModularTranslationLLM {
         decl: &TopLevelEntity,
         _raw_source: &RawSource,
         project_kind: &ProjectKind,
+        macro_translations: &MacroTranslationResult,
         type_translations: &TypeTranslationResult,
         interface_translations: &InterfaceTranslationResult,
     ) -> Result<RustDeclaration, Box<dyn std::error::Error>> {
@@ -257,6 +338,7 @@ impl ModularTranslationLLM {
         #[derive(Serialize)]
         struct RequestWithContext {
             project_kind: String,
+            macro_translations: Vec<String>,
             type_translations: Vec<String>,
             interface_translations: Vec<String>,
             declaration: DeclarationInput,
@@ -274,9 +356,10 @@ impl ModularTranslationLLM {
             .collect();
 
         let request = build_request(
-            "Please translate the following C function or global variable declaration to Rust. The type declarations and function/global signatures have already been translated and are provided for context:",
+            "Please translate the following C function or global variable declaration to Rust. Macro translations, type declarations, and function/global signatures have already been translated and are provided for context:",
             &RequestWithContext {
                 project_kind: project_kind_str.to_string(),
+                macro_translations: macro_translations.macros.clone(),
                 type_translations: type_code,
                 interface_translations: interface_translations.signatures.clone(),
                 declaration: decl_source.clone(),


### PR DESCRIPTION
This PR adds a new pass for translating macros. 
This pass: 
1. occurs before any other passes (i.e., it happens before we translate types).
2. When possible, translates to non-macro constructs (`const`, `static`, `fn`, etc)
3. As a fallback, it can generate `macro_rules!` for constructs that fundamentally can't be implemented with standard language features (stringification, token-pasting, etc)
4. Translates all macros together in 1 call.

This PR also:
1. Provides macro translations as context to other passes
2. does some minor refactoring of the `c_ast` code to account for the fact that it now contains preprocessor info.