### PR TITLE
Minor modular fixes

### DIFF
--- a/core/src/llm.rs
+++ b/core/src/llm.rs
@@ -149,7 +149,7 @@ impl HarvestLLM {
             .block_on(self.client.chat(request))?;
 
         let usage = response.usage();
-        let response_text = response.text().expect("no response text");
+        let response_text = response.text().ok_or("no response text")?;
 
         // Parse the response - strip markdown code fences
         let response_text = response_text

--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -76,7 +76,7 @@ fn extract_entities(parser: clang::Parser<'_>, out: &mut RichSourceMap) {
         let Some((span, source_text)) = utils::get_span_and_text(&child) else {
             continue;
         };
-        
+
         // Extract the AST for this entity
         let ast = ast::ast_from_entity(decl_kind, &child);
         out.push_entity(

--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -22,7 +22,7 @@ pub struct ParseToAst;
 /// This includes standard flags, include paths, and language specification based on file extension.
 fn generate_parse_args(src_root: &Path, rel_file: &Path) -> Vec<String> {
     let mut parser_arg_values = vec!["-std=gnu11".to_string()];
-    parser_arg_values.push(format!("-I{}", src_root.to_string_lossy()));
+    parser_arg_values.push(format!("-I{}/include", src_root.to_string_lossy()));
     parser_arg_values.extend(
         utils::language_args_for_file(rel_file)
             .iter()
@@ -76,7 +76,7 @@ fn extract_entities(parser: clang::Parser<'_>, out: &mut RichSourceMap) {
         let Some((span, source_text)) = utils::get_span_and_text(&child) else {
             continue;
         };
-
+        
         // Extract the AST for this entity
         let ast = ast::ast_from_entity(decl_kind, &child);
         out.push_entity(

--- a/tools/c_ast/src/utils.rs
+++ b/tools/c_ast/src/utils.rs
@@ -62,6 +62,7 @@ pub(crate) fn get_range<'tu>(
     child: &clang::Entity<'tu>,
 ) -> Option<(clang::source::Location<'tu>, clang::source::Location<'tu>)> {
     let range = child.get_range()?;
+
     Some(if uses_spelling_location(child) {
         (
             range.get_start().get_spelling_location(),
@@ -84,7 +85,20 @@ pub(crate) fn get_span_and_text(child: &clang::Entity<'_>) -> Option<(SourceSpan
     // check if span is across multiple files
     let start_path = start_file.get_path();
     let end_path = end_file.get_path();
-    if start_path != end_path {
+    // Canonicalize before comparing: clang can return different path representations
+    // for the same physical file (e.g. with `..` components) depending on how the
+    // file was reached, which would otherwise produce false multi-file positives.
+    let start_canonical = start_path
+        .canonicalize()
+        .unwrap_or_else(|_| start_path.clone());
+    let end_canonical = end_path.canonicalize().unwrap_or_else(|_| end_path.clone());
+    if start_canonical != end_canonical {
+        tracing::info!(
+            "Skipping entity {:?} because it spans multiple files: {:?} to {:?}",
+            child.get_display_name(),
+            start_canonical,
+            end_canonical
+        );
         return None;
     }
 
@@ -93,12 +107,19 @@ pub(crate) fn get_span_and_text(child: &clang::Entity<'_>) -> Option<(SourceSpan
     let start_offset = start.offset as usize;
     let end_offset = end.offset as usize;
     if start_offset > end_offset || end_offset > file_bytes.len() {
+        tracing::warn!(
+            "Invalid source range for entity {:?}: start offset {}, end offset {}, file size {}",
+            child.get_display_name(),
+            start_offset,
+            end_offset,
+            file_bytes.len()
+        );
         return None;
     }
     let source_text = String::from_utf8_lossy(&file_bytes[start_offset..end_offset]).to_string();
 
     let span = SourceSpan {
-        file: start_path.to_string_lossy().to_string(),
+        file: start_canonical.to_string_lossy().to_string(),
         start: SourcePoint {
             line: start.line,
             column: start.column,


### PR DESCRIPTION
This PR fixes 2 minor issues affecting B02:
1. Previously, if an llm returned a response with no text, Harvest panicked. Now it returns `Err` and recovers.
2. Harvest compares whether AST nodes correspond to the same source text by, in part, comparing their sourcespan. Previously, identical paths represented in different ways (lib.h vs. ../include/lib.h) were consider unequal because these paths were not canonicalized. Harvest now canonicalizes paths when comparing source spans.
 