### PR TITLE
Refactor cargo build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "translate_agentic",
  "try_cargo_build",
  "verify_fix_agentic",
+ "write_output",
 ]
 
 [[package]]
@@ -3611,6 +3612,15 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "write_output"
+version = "0.1.0"
+dependencies = [
+ "harvest_core",
+ "tracing",
+ "try_cargo_build",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,6 +3160,7 @@ dependencies = [
  "cargo_metadata",
  "full_source",
  "harvest_core",
+ "tempfile",
  "toml_edit 0.23.10+spec-1.0.0",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_project_spec", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic"]
+members = ["benchmark", "core", "tools/full_source", "tools/build_project_spec", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -11,6 +11,7 @@ build_project_spec = { path = "tools/build_project_spec" }
 load_raw_source = { path = "tools/load_raw_source" }
 raw_source_to_cargo_llm = { path = "tools/raw_source_to_cargo_llm" }
 try_cargo_build = { path = "tools/try_cargo_build" }
+write_output = { path = "tools/write_output" }
 c_ast = { path = "tools/c_ast" }
 modular_translation_llm = { path = "tools/modular_translation_llm" }
 quantize_rust_spans = { path = "tools/quantize_rust_spans" }

--- a/tools/try_cargo_build/Cargo.toml
+++ b/tools/try_cargo_build/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 cargo_metadata = "0.23.1"
 full_source.workspace = true
 harvest_core.workspace = true
+tempfile.workspace = true
 toml_edit = { workspace = true }
 tracing.workspace = true
 

--- a/tools/try_cargo_build/src/lib.rs
+++ b/tools/try_cargo_build/src/lib.rs
@@ -1,5 +1,5 @@
 //! Checks if a generated Rust project builds by materializing
-//! it to a tempdir and running `cargo build --release`.
+//! it to a root and running `cargo build --release`.
 pub use cargo_metadata::{Artifact, CompilerMessage};
 use full_source::CargoPackage;
 use harvest_core::cargo_utils::CargoToml;
@@ -7,6 +7,8 @@ use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
+use tempfile::TempDir;
 use tracing::info;
 
 pub struct TryCargoBuild;
@@ -19,12 +21,13 @@ pub type BuildResult = Result<Vec<PathBuf>, Vec<CompilerMessage>>;
 /// - If the project builds successfully, it returns Ok(Ok(artifact_filenames)).
 /// - If the project fails to build, it returns Ok(Err(error_message)).
 /// - If there is an error running cargo, it returns Err.
-fn try_cargo_build(project_path: &PathBuf) -> Result<CargoBuildResult, Box<dyn std::error::Error>> {
+fn try_cargo_build(root: Arc<TempDir>) -> Result<CargoBuildResult, Box<dyn std::error::Error>> {
     info!("Validating that the generated Rust project builds...");
 
+    let project_path = root.path().to_path_buf();
     let mut cargo = CargoToml::open(&project_path.join("Cargo.toml"))?;
     cargo.add_workspace();
-    cargo.normalize_name(project_path);
+    cargo.normalize_name(&project_path);
     cargo.save()?;
 
     // Run cargo build in the project directory
@@ -32,7 +35,7 @@ fn try_cargo_build(project_path: &PathBuf) -> Result<CargoBuildResult, Box<dyn s
         .arg("build")
         .arg("--release")
         .arg("--message-format=json")
-        .current_dir(project_path)
+        .current_dir(&project_path)
         .output()
         .map_err(|e| {
             format!(
@@ -72,6 +75,7 @@ fn try_cargo_build(project_path: &PathBuf) -> Result<CargoBuildResult, Box<dyn s
         diagnostics,
         success,
         err: String::from_utf8(output.stderr)?,
+        root,
     })
 }
 
@@ -90,11 +94,11 @@ impl Tool for TryCargoBuild {
             .ir_snapshot
             .get::<CargoPackage>(inputs[0])
             .ok_or("No CargoPackage representation found in IR")?;
-        let output_path = context.config.output.clone();
-        cargo_package.materialize(&output_path)?;
+        let root = Arc::new(tempfile::tempdir()?);
+        cargo_package.materialize(root.path())?;
 
         // Validate that the Rust project builds
-        Ok(Box::new(try_cargo_build(&output_path)?))
+        Ok(Box::new(try_cargo_build(root)?))
     }
 }
 
@@ -105,6 +109,14 @@ pub struct CargoBuildResult {
     pub diagnostics: Vec<CompilerMessage>,
     pub success: bool,
     pub err: String,
+    /// Keeps the root alive for the lifetime of this result.
+    pub root: Arc<TempDir>,
+}
+
+impl CargoBuildResult {
+    pub fn root_path(&self) -> &Path {
+        self.root.path()
+    }
 }
 
 impl std::fmt::Display for CargoBuildResult {

--- a/tools/write_output/Cargo.toml
+++ b/tools/write_output/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "write_output"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+harvest_core.workspace = true
+try_cargo_build = { path = "../try_cargo_build" }
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/write_output/Cargo.toml
+++ b/tools/write_output/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 harvest_core.workspace = true
-try_cargo_build = { path = "../try_cargo_build" }
+try_cargo_build.workspace = true 
 tracing.workspace = true
 
 [lints]

--- a/tools/write_output/src/lib.rs
+++ b/tools/write_output/src/lib.rs
@@ -1,0 +1,66 @@
+//! Copies a built Cargo package from its temporary build directory to the configured output path.
+
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use std::fs;
+use std::path::Path;
+use tracing::info;
+use try_cargo_build::CargoBuildResult;
+
+pub struct WriteOutput;
+
+impl Tool for WriteOutput {
+    fn name(&self) -> &'static str {
+        "write_output"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let build_result = context
+            .ir_snapshot
+            .get::<CargoBuildResult>(inputs[0])
+            .ok_or("WriteOutput: no CargoBuildResult found in IR")?;
+
+        let src = build_result.root_path();
+        let dst = &context.config.output;
+        copy_dir_all(src, dst)?;
+        info!("Output written to {}", dst.display());
+
+        Ok(Box::new(WriteOutputResult))
+    }
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &dst_path)?;
+        } else {
+            fs::copy(entry.path(), dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+pub struct WriteOutputResult;
+
+impl std::fmt::Display for WriteOutputResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "WriteOutputResult")
+    }
+}
+
+impl Representation for WriteOutputResult {
+    fn name(&self) -> &'static str {
+        "write_output_result"
+    }
+
+    fn materialize(&self, _path: &Path) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/tools/write_output/src/lib.rs
+++ b/tools/write_output/src/lib.rs
@@ -3,7 +3,7 @@
 use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tracing::info;
 use try_cargo_build::CargoBuildResult;
 
@@ -29,7 +29,7 @@ impl Tool for WriteOutput {
         copy_dir_all(src, dst)?;
         info!("Output written to {}", dst.display());
 
-        Ok(Box::new(WriteOutputResult))
+        Ok(Box::new(WriteOutputResult { path: dst.clone() }))
     }
 }
 
@@ -47,11 +47,13 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-pub struct WriteOutputResult;
+pub struct WriteOutputResult {
+    pub path: PathBuf,
+}
 
 impl std::fmt::Display for WriteOutputResult {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "WriteOutputResult")
+        write!(f, "Output written to: {}", self.path.display())
     }
 }
 

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -26,6 +26,7 @@ load_raw_source.workspace = true
 build_project_spec.workspace = true
 modular_translation_llm.workspace = true
 try_cargo_build.workspace = true
+write_output.workspace = true
 raw_source_to_cargo_llm.workspace = true
 translate_agentic.workspace = true
 verify_fix_agentic.workspace = true

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -21,6 +21,7 @@ use tracing::{error, info};
 use translate_agentic::TranslateAgentic;
 use try_cargo_build::TryCargoBuild;
 use verify_fix_agentic::VerifyFixAgentic;
+use write_output::WriteOutput;
 
 /// Performs the complete transpilation process using the scheduler.
 pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::Error>> {
@@ -49,7 +50,8 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
     } else {
         scheduler.queue_after(RawSourceToCargoLlm, &[load_src, project_spec])
     };
-    let _try_build = scheduler.queue_after(TryCargoBuild, &[translate]);
+    let try_build = scheduler.queue_after(TryCargoBuild, &[translate]);
+    let _write_output = scheduler.queue_after(WriteOutput, &[try_build]);
 
     // Run until all tasks are complete, respecting the dependencies declared in `queue_after`
     let result = scheduler.run_all(&mut runner, &mut ir, config);


### PR DESCRIPTION
This PR refactors `TryCargoBuild` in preperation for integrating our work on Repair loops. 
It makes 2 changes:
1. `TryCargoBuild` now builds to a temporary directory. This allows harvest to keep around all translation results/build attempts, with no fear of accidentally overwriting results.
2. We add a new tool `WriteOutput` that takes the result of a `TryCargoBuild` run, and writes it to the actual output directory.  