### PR TITLE
Direct-LLM prompt augmentation from BuildConfigIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,7 @@ dependencies = [
 name = "modular_translation_llm"
 version = "0.1.0"
 dependencies = [
+ "build_config",
  "build_project_spec",
  "c_ast",
  "full_source",
@@ -2283,6 +2284,7 @@ dependencies = [
 name = "raw_source_to_cargo_llm"
 version = "0.1.0"
 dependencies = [
+ "build_config",
  "build_project_spec",
  "full_source",
  "harvest_core",

--- a/tools/build_config/src/lib.rs
+++ b/tools/build_config/src/lib.rs
@@ -24,6 +24,7 @@ use tracing::debug;
 
 pub mod build_rs;
 pub mod ir;
+pub mod prompt_ext;
 pub mod scanner;
 
 pub use build_rs::render_build_rs;
@@ -31,6 +32,7 @@ pub use ir::{
     BuildConfigIR, ConditionalTarget, ConfigVarKind, ConfigVariable, DefineKind, DefineMapping,
     SourceSelection, SourceVariant,
 };
+pub use prompt_ext::build_system_prompt;
 pub use scanner::scan;
 
 /// This tool has no knobs of its own; the struct exists to absorb

--- a/tools/build_config/src/prompt_ext.rs
+++ b/tools/build_config/src/prompt_ext.rs
@@ -1,0 +1,201 @@
+//! Helpers that extend LLM system prompts with a configurable-variables
+//! section derived from a [`BuildConfigIR`].
+//!
+//! This module is shared by every translation path that needs to teach an LLM
+//! about the project's configurable variables. The extension is appended only
+//! when [`BuildConfigIR::is_empty`] is `false`, so all existing TRACTOR corpus
+//! projects (which have no `configuration.json`) continue to receive byte-
+//! identical prompts.
+
+use crate::ir::{BuildConfigIR, ConfigVarKind, DefineKind};
+
+/// Builds the final system prompt string by appending a configurable-variables
+/// section to `base_prompt` when `build_cfg.is_empty == false`.
+///
+/// # Anti-regression invariant
+///
+/// When `build_cfg.is_empty == true`, the returned `String` is byte-equal to
+/// `base_prompt`.  Tests in each consuming crate assert this so that no-config
+/// prompts can never silently drift.
+pub fn build_system_prompt(base_prompt: &str, build_cfg: &BuildConfigIR) -> String {
+    if build_cfg.is_empty {
+        return base_prompt.to_owned();
+    }
+    let extension = build_configurable_vars_section(build_cfg);
+    format!("{base_prompt}\n\n{extension}")
+}
+
+/// Renders the configurable-variables section that is appended to a system
+/// prompt when the project carries a non-empty [`BuildConfigIR`].
+pub fn build_configurable_vars_section(cfg: &BuildConfigIR) -> String {
+    let mut out = String::new();
+
+    out.push_str("## Configurable variables\n\n");
+    out.push_str(
+        "This project uses configurable variables managed by the build system. \
+        `EmitBuildFeatures` has already written the `[features]` block and `build.rs` for you -- \
+        do NOT write a `[features]` block in the Cargo.toml you produce.\n\n",
+    );
+
+    out.push_str(
+        "Apply the following rules when translating `#ifdef`/`#if` guards that test \
+        these variables:\n\n",
+    );
+
+    for var in &cfg.variables {
+        match &var.kind {
+            ConfigVarKind::Boolean => {
+                out.push_str(&format!(
+                    "- `{name}` (boolean): use `#[cfg(feature = \"{name}\")]`\n",
+                    name = var.name
+                ));
+            }
+            ConfigVarKind::Enum { values, .. } => {
+                let variants: Vec<String> = values
+                    .iter()
+                    .map(|v| format!("`#[cfg({name}_{v})]`", name = var.name))
+                    .collect();
+                out.push_str(&format!(
+                    "- `{name}` (enum, values: {values}): use bare cfg -- {variants} \
+                    (NOT `feature = ...`)\n",
+                    name = var.name,
+                    values = values.join(", "),
+                    variants = variants.join(" / "),
+                ));
+            }
+        }
+    }
+
+    if !cfg.defines.is_empty() {
+        out.push('\n');
+        out.push_str(
+            "Composed or bare defines are emitted by `build.rs` as `cargo:rustc-env` or \
+            `cargo:rustc-cfg` lines. Access them in Rust source via `env!(\"NAME\")` for \
+            string-valued defines, or via `#[cfg(NAME_value)]` for cfg-valued defines:\n\n",
+        );
+        for def in &cfg.defines {
+            match &def.kind {
+                DefineKind::QuotedString { var } | DefineKind::Bare { var } => {
+                    out.push_str(&format!(
+                        "- `{cname}` (from `{var}`): use `env!(\"{cname}\")`\n",
+                        cname = def.c_name,
+                        var = var
+                    ));
+                }
+                DefineKind::Composed { template } => {
+                    out.push_str(&format!(
+                        "- `{cname}` (composed from template `{template}`): use `env!(\"{cname}\")`\n",
+                        cname = def.c_name,
+                        template = template
+                    ));
+                }
+                DefineKind::GatedFlag { gate_var } => {
+                    out.push_str(&format!(
+                        "- `{cname}` (gated by `{gate_var}`): use `#[cfg({cname})]`\n",
+                        cname = def.c_name,
+                        gate_var = gate_var
+                    ));
+                }
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{ConfigVarKind, ConfigVariable, DefineKind, DefineMapping};
+
+    fn empty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: true,
+            ..Default::default()
+        }
+    }
+
+    fn nonempty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: false,
+            variables: vec![
+                ConfigVariable {
+                    name: "BACKEND".to_owned(),
+                    kind: ConfigVarKind::Enum {
+                        values: vec!["alpha".to_owned(), "beta".to_owned()],
+                        numeric: false,
+                    },
+                    default: Some("alpha".to_owned()),
+                },
+                ConfigVariable {
+                    name: "ENABLE_EXTRA".to_owned(),
+                    kind: ConfigVarKind::Boolean,
+                    default: Some("false".to_owned()),
+                },
+            ],
+            defines: vec![DefineMapping {
+                c_name: "BUILD_PROFILE".to_owned(),
+                kind: DefineKind::Composed {
+                    template: "{BACKEND}_{WORD_SIZE}".to_owned(),
+                },
+                source_vars: vec!["BACKEND".to_owned(), "WORD_SIZE".to_owned()],
+            }],
+            ..Default::default()
+        }
+    }
+
+    const BASE_PROMPT: &str = "You are a translator. Translate C to Rust.";
+
+    /// Anti-regression: empty IR must return the base prompt byte-for-byte.
+    #[test]
+    fn empty_ir_returns_base_unchanged() {
+        let result = build_system_prompt(BASE_PROMPT, &empty_ir());
+        assert_eq!(result, BASE_PROMPT);
+    }
+
+    /// Non-empty IR: must extend the base prompt.
+    #[test]
+    fn nonempty_ir_extends_base() {
+        let ir = nonempty_ir();
+        let result = build_system_prompt(BASE_PROMPT, &ir);
+        assert!(result.starts_with(BASE_PROMPT));
+        assert!(result.len() > BASE_PROMPT.len());
+    }
+
+    /// Section header must be present.
+    #[test]
+    fn nonempty_ir_has_section_header() {
+        let result = build_system_prompt(BASE_PROMPT, &nonempty_ir());
+        assert!(result.contains("## Configurable variables"));
+    }
+
+    /// Enum variable: bare cfg rule present, NOT feature = "...".
+    #[test]
+    fn enum_var_uses_bare_cfg() {
+        let result = build_system_prompt(BASE_PROMPT, &nonempty_ir());
+        assert!(result.contains("#[cfg(BACKEND_alpha)]"));
+        assert!(result.contains("#[cfg(BACKEND_beta)]"));
+        assert!(!result.contains("feature = \"BACKEND_"));
+    }
+
+    /// Boolean variable: feature cfg rule.
+    #[test]
+    fn boolean_var_uses_feature_cfg() {
+        let result = build_system_prompt(BASE_PROMPT, &nonempty_ir());
+        assert!(result.contains("#[cfg(feature = \"ENABLE_EXTRA\")]"));
+    }
+
+    /// Composed define: env!() rule.
+    #[test]
+    fn composed_define_uses_env() {
+        let result = build_system_prompt(BASE_PROMPT, &nonempty_ir());
+        assert!(result.contains("env!(\"BUILD_PROFILE\")"));
+    }
+
+    /// Must instruct the LLM not to write a [features] block.
+    #[test]
+    fn no_features_block_instruction() {
+        let result = build_system_prompt(BASE_PROMPT, &nonempty_ir());
+        assert!(result.contains("do NOT write a `[features]` block"));
+    }
+}

--- a/tools/modular_translation_llm/Cargo.toml
+++ b/tools/modular_translation_llm/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-c_ast.workspace = true
+build_config.workspace = true
 build_project_spec.workspace = true
+c_ast.workspace = true
 full_source.workspace = true
 harvest_core.workspace = true
-serde.workspace = true 
+serde.workspace = true
 serde_json.workspace = true
-tracing.workspace = true 
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/tools/modular_translation_llm/src/lib.rs
+++ b/tools/modular_translation_llm/src/lib.rs
@@ -6,6 +6,7 @@
 //! - Interface (FunctionDecl and VarDecl signatures) use type context
 //! - Functions and globals (FunctionDecl, VarDecl) use type/interface context
 
+use build_config::BuildConfigIR;
 use build_project_spec::{ProjectKind, ProjectSpec};
 use c_ast::{RichSourceMap, TopLevelEntity, annotate_visibility};
 use full_source::RawSource;
@@ -67,7 +68,15 @@ pub struct ModularTranslationLlm;
 fn extract_args<'a>(
     context: &'a RunContext,
     inputs: &[Id],
-) -> Result<(&'a RawSource, &'a RichSourceMap, &'a ProjectKind), Box<dyn std::error::Error>> {
+) -> Result<
+    (
+        &'a RawSource,
+        &'a RichSourceMap,
+        &'a ProjectKind,
+        &'a BuildConfigIR,
+    ),
+    Box<dyn std::error::Error>,
+> {
     let raw_source = context
         .ir_snapshot
         .get::<RawSource>(inputs[0])
@@ -80,7 +89,11 @@ fn extract_args<'a>(
         .ir_snapshot
         .get::<ProjectSpec>(inputs[2])
         .ok_or("No ProjectSpec representation found in IR")?;
-    Ok((raw_source, clang_ast, &project_spec.kind))
+    let build_cfg = context
+        .ir_snapshot
+        .get::<BuildConfigIR>(inputs[3])
+        .ok_or("No BuildConfigIR representation found in IR")?;
+    Ok((raw_source, clang_ast, &project_spec.kind, build_cfg))
 }
 
 impl Tool for ModularTranslationLlm {
@@ -102,7 +115,7 @@ impl Tool for ModularTranslationLlm {
         )?;
         config.validate();
 
-        let (raw_source, clang_ast, project_kind) = extract_args(&context, &inputs)?;
+        let (raw_source, clang_ast, project_kind, build_cfg) = extract_args(&context, &inputs)?;
 
         let app_types: &[TopLevelEntity] = &clang_ast.app_types;
         let app_globals: &[TopLevelEntity] = &clang_ast.app_globals;
@@ -132,6 +145,7 @@ impl Tool for ModularTranslationLlm {
             &app_functions,
             raw_source,
             project_kind,
+            build_cfg,
             &config,
         )
         .map_err(|e| format!("Translation failed: {}", e))?;

--- a/tools/modular_translation_llm/src/prompts/cargo_toml/system_prompt.txt
+++ b/tools/modular_translation_llm/src/prompts/cargo_toml/system_prompt.txt
@@ -7,6 +7,7 @@ Requirements:
 - Derive an appropriate package name from the context or use a generic name if none is apparent.
 - Include all necessary dependencies based on the dependency list. If a path is from the Rust standard library (e.g., "std::"), do not add it to Cargo dependencies.
 - Set project type based on project kind: binary for executables, library otherwise.
+- Do NOT include a `[features]` section. Features are managed separately by the build pipeline.
 
 Example input:
 

--- a/tools/modular_translation_llm/src/translation.rs
+++ b/tools/modular_translation_llm/src/translation.rs
@@ -8,6 +8,7 @@
 //! - No ordering constraints of function translations
 //! - Cargo.toml generated after function/global translation using aggregated dependencies
 
+use build_config::BuildConfigIR;
 use build_project_spec::ProjectKind;
 use c_ast::TopLevelEntity;
 use full_source::RawSource;
@@ -237,6 +238,7 @@ fn collect_dependencies(translations: &[RustDeclaration]) -> Vec<String> {
 /// Finally, generates a Cargo.toml manifest based on collected dependencies from all translations.
 ///
 /// Returns the combined translated declarations and a generated Cargo.toml manifest.
+#[allow(clippy::too_many_arguments)]
 pub fn translate_decls(
     defines: &[TopLevelEntity],
     app_types: &[TopLevelEntity],
@@ -244,6 +246,7 @@ pub fn translate_decls(
     app_functions: &[TopLevelEntity],
     raw_source: &RawSource,
     project_kind: &ProjectKind,
+    build_cfg: &BuildConfigIR,
     config: &Config,
 ) -> Result<TranslationResult, Box<dyn std::error::Error>> {
     let total_decls = defines.len() + app_types.len() + app_globals.len() + app_functions.len();
@@ -261,7 +264,7 @@ pub fn translate_decls(
         return Err("No declarations to translate".into());
     }
 
-    let modular_llm = ModularTranslationLLM::build(config)?;
+    let modular_llm = ModularTranslationLLM::build(config, build_cfg)?;
 
     // Translate macros first
     let macro_result = translate_macros(defines, raw_source, project_kind, &modular_llm)?;

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -1,6 +1,8 @@
 //! LLM abstraction layer for modular translation.
 //! Abstracts away all the string management needed for building dynamically generated prompts and
 //! provides a clean well-typed interface for use by the rest of the transpiler.
+use build_config::BuildConfigIR;
+use build_config::build_system_prompt;
 use build_project_spec::ProjectKind;
 use c_ast::TopLevelEntity;
 use full_source::RawSource;
@@ -136,9 +138,16 @@ impl ModularLLMUsageTotals {
 }
 
 impl ModularTranslationLLM {
-    /// Initializes seperate HarvestLLM instances for each type of translation task with the
-    // appropriate system prompts and structured output schemas.
-    pub fn build(config: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+    /// Initializes separate HarvestLLM instances for each type of translation task with the
+    /// appropriate system prompts and structured output schemas.
+    ///
+    /// When `build_cfg.is_empty == false`, the cargo_toml system prompt is extended with a
+    /// configurable-variables section that instructs the LLM not to write a `[features]` block
+    /// (since `EmitBuildFeatures` owns that) and teaches it the cfg/env rules for each variable.
+    pub fn build(
+        config: &Config,
+        build_cfg: &BuildConfigIR,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let macros_llm = HarvestLLM::build(
             &config.llm,
             STRUCTURED_OUTPUT_SCHEMA_MACROS,
@@ -159,10 +168,13 @@ impl ModularTranslationLLM {
             STRUCTURED_OUTPUT_SCHEMA_INTERFACE,
             SYSTEM_PROMPT_INTERFACE,
         )?;
+        // Build the cargo_toml system prompt programmatically: start with the static base,
+        // then append the configurable-variables section only when the IR is non-empty.
+        let cargo_toml_system_prompt = build_system_prompt(SYSTEM_PROMPT_CARGO_TOML, build_cfg);
         let cargo_toml_llm = HarvestLLM::build(
             &config.llm,
             STRUCTURED_OUTPUT_SCHEMA_CARGO_TOML,
-            SYSTEM_PROMPT_CARGO_TOML,
+            &cargo_toml_system_prompt,
         )?;
 
         Ok(Self {
@@ -516,4 +528,94 @@ struct DeclarationInput {
 struct InterfaceDeclarationInput {
     source: String,
     enforce_ffi_interface: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use build_config::{BuildConfigIR, ConfigVarKind, ConfigVariable, DefineKind, DefineMapping};
+
+    use super::SYSTEM_PROMPT_CARGO_TOML;
+    use build_config::build_system_prompt;
+
+    fn empty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: true,
+            ..Default::default()
+        }
+    }
+
+    fn nonempty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: false,
+            variables: vec![
+                ConfigVariable {
+                    name: "BACKEND".to_owned(),
+                    kind: ConfigVarKind::Enum {
+                        values: vec!["alpha".to_owned(), "beta".to_owned()],
+                        numeric: false,
+                    },
+                    default: Some("alpha".to_owned()),
+                },
+                ConfigVariable {
+                    name: "ENABLE_EXTRA".to_owned(),
+                    kind: ConfigVarKind::Boolean,
+                    default: Some("false".to_owned()),
+                },
+            ],
+            defines: vec![DefineMapping {
+                c_name: "BUILD_PROFILE".to_owned(),
+                kind: DefineKind::Composed {
+                    template: "{BACKEND}_{WORD_SIZE}".to_owned(),
+                },
+                source_vars: vec!["BACKEND".to_owned(), "WORD_SIZE".to_owned()],
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// Anti-regression: when `is_empty == true`, the cargo_toml system prompt must be
+    /// byte-equal to the static `SYSTEM_PROMPT_CARGO_TOML` constant.
+    #[test]
+    fn empty_ir_cargo_toml_prompt_is_byte_equal_to_static() {
+        let result = build_system_prompt(SYSTEM_PROMPT_CARGO_TOML, &empty_ir());
+        assert_eq!(
+            result, SYSTEM_PROMPT_CARGO_TOML,
+            "empty IR must not modify the cargo_toml prompt"
+        );
+    }
+
+    /// Non-empty IR: the cargo_toml system prompt must be extended with the
+    /// configurable-variables section and must instruct the LLM not to write a
+    /// `[features]` block.
+    #[test]
+    fn nonempty_ir_cargo_toml_prompt_contains_no_features_instruction() {
+        let result = build_system_prompt(SYSTEM_PROMPT_CARGO_TOML, &nonempty_ir());
+
+        assert!(result.starts_with(SYSTEM_PROMPT_CARGO_TOML));
+        assert!(
+            result.contains("do NOT write a `[features]` block"),
+            "cargo_toml prompt must instruct LLM not to write [features]"
+        );
+    }
+
+    /// Non-empty IR: cargo_toml prompt contains cfg/env rules for each variable.
+    #[test]
+    fn nonempty_ir_cargo_toml_prompt_has_cfg_rules() {
+        let result = build_system_prompt(SYSTEM_PROMPT_CARGO_TOML, &nonempty_ir());
+
+        assert!(result.contains("#[cfg(BACKEND_alpha)]"));
+        assert!(result.contains("#[cfg(BACKEND_beta)]"));
+        assert!(result.contains("#[cfg(feature = \"ENABLE_EXTRA\")]"));
+        assert!(result.contains("env!(\"BUILD_PROFILE\")"));
+    }
+
+    /// The static cargo_toml prompt already tells the LLM not to write a [features]
+    /// section (this is a property of the static prompt itself, not just the extension).
+    #[test]
+    fn static_cargo_toml_prompt_forbids_features_section() {
+        assert!(
+            SYSTEM_PROMPT_CARGO_TOML.contains("Do NOT include a `[features]` section"),
+            "static cargo_toml prompt must forbid [features] block"
+        );
+    }
 }

--- a/tools/raw_source_to_cargo_llm/Cargo.toml
+++ b/tools/raw_source_to_cargo_llm/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+build_config.workspace = true
+build_project_spec.workspace = true
 full_source.workspace = true
 harvest_core.workspace = true
-build_project_spec.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/tools/raw_source_to_cargo_llm/src/lib.rs
+++ b/tools/raw_source_to_cargo_llm/src/lib.rs
@@ -1,6 +1,7 @@
 //! Attempts to directly turn a C project into a Cargo project by throwing it at
 //! an LLM via the `llm` crate.
 
+use build_config::{BuildConfigIR, build_system_prompt};
 use build_project_spec::{ProjectKind, ProjectSpec};
 use full_source::{CargoPackage, RawSource};
 use harvest_core::config::unknown_field_warning;
@@ -36,7 +37,7 @@ impl Tool for RawSourceToCargoLlm {
         let config =
             Config::deserialize(context.config.tools.get("raw_source_to_cargo_llm").unwrap())?;
         debug!("LLM Configuration {config:?}");
-        // Get both inputs: RawSource and ProjectSpec
+        // Get inputs: RawSource, ProjectSpec, BuildConfigIR
         let in_dir = context
             .ir_snapshot
             .get::<RawSource>(inputs[0])
@@ -45,18 +46,25 @@ impl Tool for RawSourceToCargoLlm {
             .ir_snapshot
             .get::<ProjectSpec>(inputs[1])
             .ok_or("No ProjectSpec representation found in IR")?;
+        let build_cfg = context
+            .ir_snapshot
+            .get::<BuildConfigIR>(inputs[2])
+            .ok_or("No BuildConfigIR representation found in IR")?;
         let project_kind = &project_spec.kind;
 
-        // Use the llm crate to connect to the LLM.
-        // Select system prompt based on project kind
+        // Build the system prompt programmatically:
+        // 1. Start with the static base prompt (executable or library variant).
+        // 2. Append a configurable-variables section only when the IR is non-empty.
         let (config_prompt, builtin_prompt) = match project_kind {
             ProjectKind::Executable => (config.prompt_executable, SYSTEM_PROMPT_EXECUTABLE),
             ProjectKind::Library => (config.prompt_library, SYSTEM_PROMPT_LIBRARY),
         };
-        let system_prompt = config_prompt
+        let base_prompt = config_prompt
             .map(read_to_string)
             .transpose()?
             .unwrap_or_else(|| builtin_prompt.to_owned());
+
+        let system_prompt = build_system_prompt(&base_prompt, build_cfg);
 
         // Build LLM client using core/llm
         let llm = HarvestLLM::build(&config.llm, STRUCTURED_OUTPUT_SCHEMA, &system_prompt)?;
@@ -73,13 +81,24 @@ impl Tool for RawSourceToCargoLlm {
             .collect();
 
         #[derive(Serialize)]
-        struct RequestBody {
+        struct RequestBody<'a> {
             files: Vec<OutputFile>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            build_config: Option<&'a BuildConfigIR>,
         }
+
+        let build_config_field = if build_cfg.is_empty {
+            None
+        } else {
+            Some(build_cfg)
+        };
 
         let request = build_request(
             "Please translate the following C project into a Rust project including Cargo manifest:",
-            &RequestBody { files },
+            &RequestBody {
+                files,
+                build_config: build_config_field,
+            },
         )?;
 
         // Make the LLM call.
@@ -157,4 +176,127 @@ impl Config {
 struct OutputFile {
     contents: String,
     path: PathBuf,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use build_config::{ConfigVarKind, ConfigVariable, DefineKind, DefineMapping};
+
+    fn empty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: true,
+            ..Default::default()
+        }
+    }
+
+    fn nonempty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: false,
+            variables: vec![
+                ConfigVariable {
+                    name: "BACKEND".to_owned(),
+                    kind: ConfigVarKind::Enum {
+                        values: vec!["alpha".to_owned(), "beta".to_owned()],
+                        numeric: false,
+                    },
+                    default: Some("alpha".to_owned()),
+                },
+                ConfigVariable {
+                    name: "ENABLE_EXTRA".to_owned(),
+                    kind: ConfigVarKind::Boolean,
+                    default: Some("false".to_owned()),
+                },
+            ],
+            defines: vec![DefineMapping {
+                c_name: "BUILD_PROFILE".to_owned(),
+                kind: DefineKind::Composed {
+                    template: "{BACKEND}_{WORD_SIZE}".to_owned(),
+                },
+                source_vars: vec!["BACKEND".to_owned(), "WORD_SIZE".to_owned()],
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// Anti-regression: when `is_empty == true`, `build_system_prompt` must
+    /// return a string that is byte-equal to the static include_str! constants.
+    #[test]
+    fn empty_ir_prompt_is_byte_equal_to_static_executable() {
+        let result = build_system_prompt(SYSTEM_PROMPT_EXECUTABLE, &empty_ir());
+        assert_eq!(
+            result, SYSTEM_PROMPT_EXECUTABLE,
+            "empty IR must not modify the executable prompt"
+        );
+    }
+
+    /// Anti-regression: same check for the library prompt.
+    #[test]
+    fn empty_ir_prompt_is_byte_equal_to_static_library() {
+        let result = build_system_prompt(SYSTEM_PROMPT_LIBRARY, &empty_ir());
+        assert_eq!(
+            result, SYSTEM_PROMPT_LIBRARY,
+            "empty IR must not modify the library prompt"
+        );
+    }
+
+    /// Non-empty IR: prompt must contain the configurable-variables section.
+    #[test]
+    fn nonempty_ir_prompt_contains_cfg_rules() {
+        let ir = nonempty_ir();
+        let result = build_system_prompt(SYSTEM_PROMPT_EXECUTABLE, &ir);
+
+        // Starts with the base prompt unchanged.
+        assert!(result.starts_with(SYSTEM_PROMPT_EXECUTABLE));
+
+        // Contains the section header.
+        assert!(
+            result.contains("## Configurable variables"),
+            "prompt must contain section header"
+        );
+
+        // Enum variable: bare cfg rule.
+        assert!(
+            result.contains("#[cfg(BACKEND_alpha)]"),
+            "prompt must mention BACKEND_alpha bare cfg"
+        );
+        assert!(
+            result.contains("#[cfg(BACKEND_beta)]"),
+            "prompt must mention BACKEND_beta bare cfg"
+        );
+        // Must NOT say `feature = "BACKEND_..."` for the enum.
+        assert!(
+            !result.contains("feature = \"BACKEND_"),
+            "enum cfg rules must not use feature = ..."
+        );
+
+        // Boolean variable: feature cfg rule.
+        assert!(
+            result.contains("#[cfg(feature = \"ENABLE_EXTRA\")]"),
+            "boolean must use feature = rule"
+        );
+
+        // Composed define: env!() rule.
+        assert!(
+            result.contains("env!(\"BUILD_PROFILE\")"),
+            "composed define must use env!()"
+        );
+
+        // Explicit: no [features] block.
+        assert!(
+            result.contains("do NOT write a `[features]` block"),
+            "prompt must instruct LLM not to write [features]"
+        );
+    }
+
+    /// Non-empty IR: the extended prompt must be strictly longer than the base.
+    #[test]
+    fn nonempty_ir_prompt_is_longer_than_base() {
+        let ir = nonempty_ir();
+        let result = build_system_prompt(SYSTEM_PROMPT_EXECUTABLE, &ir);
+        assert!(
+            result.len() > SYSTEM_PROMPT_EXECUTABLE.len(),
+            "non-empty IR must extend the prompt"
+        );
+    }
 }

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -56,9 +56,12 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
         // to the form produced without a BuildConfigIR input
         // (see TopLevelEntity::variant_tags docs).
         let parse_ast = scheduler.queue_after(ParseToAst, &[load_src, build_cfg]);
-        scheduler.queue_after(ModularTranslationLlm, &[load_src, parse_ast, project_spec])
+        scheduler.queue_after(
+            ModularTranslationLlm,
+            &[load_src, parse_ast, project_spec, build_cfg],
+        )
     } else {
-        scheduler.queue_after(RawSourceToCargoLlm, &[load_src, project_spec])
+        scheduler.queue_after(RawSourceToCargoLlm, &[load_src, project_spec, build_cfg])
     };
     // EmitBuildFeatures consumes the translated CargoPackage plus the
     // BuildConfigIR and produces a (possibly mutated) CargoPackage. On
@@ -73,7 +76,7 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
         // Run until all tasks are complete, respecting the dependencies declared in `queue_after`
         scheduler.run_all(&mut runner, &mut ir, config.clone())?;
 
-        // Repair loop — skipped for agentic, which has its own repair mechanism.
+        // Repair loop -- skipped for agentic, which has its own repair mechanism.
         if !config.agentic {
             for _ in 0..config.max_repair_passes {
                 let success = ir


### PR DESCRIPTION
## Summary

Wires `BuildConfigIR` into the two direct-LLM translation paths (`raw_source_to_cargo_llm` and `modular_translation_llm`) so the prompts described to the LLM contain a configurable-variables section when the project ships a `configuration.json`. Adds the shared `build_config::prompt_ext::build_system_prompt` helper that appends the section only when `BuildConfigIR.is_empty == false`, preserving byte-identical prompts for projects without a configuration.

## What changes

- `tools/build_config/src/prompt_ext.rs` (new) -- `build_system_prompt(base, ir)` returns `base` unchanged when `ir.is_empty`, otherwise appends a section documenting the configurable variables and the cfg-attribution rules (enum vars use bare `#[cfg(VAR_value)]`, booleans use `#[cfg(feature = "VAR")]`, composed defines come from `env!("NAME")`).

- `tools/raw_source_to_cargo_llm`: takes `BuildConfigIR` as a third scheduler input. Builds the system prompt programmatically via `build_system_prompt` and includes a `build_config` field in the JSON request body when the IR is non-empty.

- `tools/modular_translation_llm`: takes `BuildConfigIR` as a fourth input. `ModularTranslationLLM::build` extends the `cargo_toml` system prompt the same way. The static `cargo_toml` prompt is updated to explicitly forbid LLM-authored `[features]` blocks since `EmitBuildFeatures` owns them.

- `translate/src/lib.rs`: wires `build_cfg` into both translation scheduler paths.

## Anti-regression

Eight unit tests in `prompt_ext` plus four each in the consuming crates assert that empty-IR prompts are byte-equal to the static `include_str!`'d base prompts. The static `system_prompt_*.txt` files are unchanged for the no-config path.

## Test plan

- [x] `make test`
- [x] Empty-IR byte-equality tests in `prompt_ext`, `raw_source_to_cargo_llm`, `modular_translation_llm`

## Sibling PRs and conflict expectations

This is one of four splits of the original PR 3 plan, all branched independently from the now-merged PR 2:

- pr3-agentic-cmake-consumers
- pr3-c-ast-variant-tags
- pr3-benchmark-feature-combos

The four PRs all touch `translate/src/lib.rs` in non-overlapping but adjacent regions (each adds `build_cfg` to a different tool's scheduler input). Whichever lands first will require trivial rebases on the others -- the resolutions are mechanical merges of the `with_input` / scheduler additions.