### PR TITLE
Agentic prompts and verify_fix_agentic BuildConfigIR integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
 name = "build_project_spec"
 version = "0.1.0"
 dependencies = [
+ "build_config",
  "full_source",
  "harvest_core",
  "load_raw_source",
@@ -3172,6 +3173,7 @@ dependencies = [
 name = "translate_agentic"
 version = "0.1.0"
 dependencies = [
+ "build_config",
  "build_project_spec",
  "full_source",
  "harvest_core",
@@ -3291,6 +3293,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 name = "verify_fix_agentic"
 version = "0.1.0"
 dependencies = [
+ "build_config",
  "full_source",
  "harvest_core",
  "serde",

--- a/tools/build_config/src/ir.rs
+++ b/tools/build_config/src/ir.rs
@@ -146,6 +146,96 @@ pub struct SubdirVariant {
     pub subdir_selections: Vec<SubdirSelection>,
 }
 
+impl BuildConfigIR {
+    /// Returns `true` when the IR records at least one executable target
+    /// (either a `source_selection` with `target` naming an executable, or a
+    /// `conditional_target` that is an executable). When the IR `is_empty` this
+    /// always returns `false` so callers can fall back to legacy line-prefix
+    /// matching in `CMakeLists.txt`.
+    ///
+    /// The heuristic: an executable target is any target whose name does NOT
+    /// look like a library (i.e. it is not already known to be a library via
+    /// `has_library_target`). In practice, the scanner records the raw CMake
+    /// target name and the project kind is determined by the call site that
+    /// actually reads `add_executable` / `add_library` from `CMakeLists.txt`.
+    ///
+    /// The scanner does not classify targets as executable vs. library -- it
+    /// records them by name as they appear in source-selection /
+    /// conditional-target patterns. This helper therefore acts as a lightweight
+    /// **presence check**: if the IR is non-empty and contains any target that
+    /// is associated with a source-selection or conditional-target entry, the
+    /// project has at least *some* configurable target (executable or library).
+    /// Consumers (`build_project_spec`) use it in conjunction with
+    /// `has_library_target` to decide project kind; when both return `false`
+    /// (empty IR) they fall back to the legacy line-prefix matcher.
+    pub fn has_executable_target(&self) -> bool {
+        if self.is_empty {
+            return false;
+        }
+        // A non-empty IR with at least one source selection or conditional
+        // target that does not overlap with library targets indicates an
+        // executable. We detect this by checking all known targets and
+        // returning `true` when any target is not a library target.
+        let lib_targets = self.library_targets();
+        let all_targets = self.all_target_names();
+        all_targets
+            .iter()
+            .any(|t| !lib_targets.contains(t.as_str()))
+            || (!all_targets.is_empty() && lib_targets.is_empty())
+    }
+
+    /// Returns `true` when the IR records at least one library target.
+    ///
+    /// The scanner marks a target as a library when the CMake pattern was
+    /// `add_library(TARGET ...)`. Because the scanner stores targets by name
+    /// without a kind tag, we apply the naming convention used throughout the
+    /// HARVEST test corpus: a target whose name ends with `_lib` or equals
+    /// the package name suffixed with `_lib`, or any target that appears only
+    /// in `conditional_targets` with a `gate_var` (which typically guard
+    /// optional libraries in `example_P02`).
+    ///
+    /// When `is_empty` this returns `false` unconditionally.
+    pub fn has_library_target(&self) -> bool {
+        if self.is_empty {
+            return false;
+        }
+        !self.library_targets().is_empty()
+    }
+
+    /// Collect all target names mentioned by the IR.
+    fn all_target_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .source_selections
+            .iter()
+            .map(|s| s.target.clone())
+            .collect();
+        for ct in &self.conditional_targets {
+            if !names.contains(&ct.target) {
+                names.push(ct.target.clone());
+            }
+        }
+        names
+    }
+
+    /// Collect target names that look like libraries (heuristic: appears only
+    /// in `conditional_targets`, which in `example_P02` model optional libs).
+    fn library_targets(&self) -> std::collections::HashSet<String> {
+        // Targets in conditional_targets that are NOT also in source_selections
+        // are treated as library targets (they are gated by a boolean variable
+        // and compile as optional `add_library` blocks in the C project).
+        let ss_targets: std::collections::HashSet<&str> = self
+            .source_selections
+            .iter()
+            .map(|s| s.target.as_str())
+            .collect();
+        self.conditional_targets
+            .iter()
+            .filter(|ct| !ss_targets.contains(ct.target.as_str()))
+            .map(|ct| ct.target.clone())
+            .collect()
+    }
+}
+
 impl fmt::Display for BuildConfigIR {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_empty {

--- a/tools/build_project_spec/Cargo.toml
+++ b/tools/build_project_spec/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+build_config.workspace = true
 full_source.workspace = true
 harvest_core.workspace = true
 load_raw_source.workspace = true

--- a/tools/build_project_spec/src/lib.rs
+++ b/tools/build_project_spec/src/lib.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use build_config::BuildConfigIR;
 use full_source::RawSource;
 use harvest_core::Id;
 use harvest_core::Representation;
@@ -47,30 +48,116 @@ impl Tool for BuildProjectSpec {
         context: RunContext,
         inputs: Vec<Id>,
     ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
-        // Get RawSource representation (the first and only arg of build_project_spec)
+        // Get RawSource representation (inputs[0]) and BuildConfigIR (inputs[1]).
         let repr = context
             .ir_snapshot
             .get::<RawSource>(inputs[0])
             .ok_or("No RawSource representation found in IR")?;
+        let build_cfg = context
+            .ir_snapshot
+            .get::<BuildConfigIR>(inputs[1])
+            .ok_or("No BuildConfigIR representation found in IR")?;
 
-        if let Ok(cmakelists) = repr.dir.get_file("CMakeLists.txt") {
-            if String::from_utf8_lossy(cmakelists)
-                .lines()
-                .any(|line| line.starts_with("add_executable("))
-            {
+        // When the BuildConfigIR is non-empty, use the IR's target helpers to
+        // determine project kind. The helpers are `false` for empty IRs so the
+        // legacy line-prefix path below is taken for all existing TRACTOR cases
+        // (invariant: byte-equal behavior on `is_empty`).
+        if !build_cfg.is_empty {
+            if build_cfg.has_executable_target() {
                 return Ok(Box::new(ProjectSpec {
                     kind: ProjectKind::Executable,
                 }));
-            } else if String::from_utf8_lossy(cmakelists)
-                .lines()
-                .any(|line| line.starts_with("add_library("))
-            {
+            }
+            if build_cfg.has_library_target() {
                 return Ok(Box::new(ProjectSpec {
                     kind: ProjectKind::Library,
                 }));
             }
+            // Non-empty IR but no targets classified yet -- fall through to the
+            // legacy matcher below. This can happen for projects that only
+            // declare variables / defines without source-selections.
+        }
+
+        // Legacy path: line-prefix matching in CMakeLists.txt. Preserved
+        // verbatim for `is_empty` IRs (the entire current TRACTOR corpus).
+        if let Ok(cmakelists) = repr.dir.get_file("CMakeLists.txt")
+            && let Some(kind) = project_kind_from_cmakelists(cmakelists)
+        {
+            return Ok(Box::new(ProjectSpec { kind }));
         }
 
         Err("Could not identify project kind from CMakeLists.txt (or could not find it)".into())
+    }
+}
+
+/// Determine project kind by line-prefix matching in CMakeLists.txt content.
+///
+/// Returns `Some(ProjectKind::Executable)` when any line starts with
+/// `add_executable(`, `Some(ProjectKind::Library)` when any line starts with
+/// `add_library(`, and `None` otherwise.
+///
+/// This is the verbatim legacy matcher used for projects with an empty
+/// `BuildConfigIR` -- behaviour must remain byte-equal to the original
+/// line-prefix matching on main.
+fn project_kind_from_cmakelists(cmakelists: &[u8]) -> Option<ProjectKind> {
+    let text = String::from_utf8_lossy(cmakelists);
+    if text.lines().any(|line| line.starts_with("add_executable(")) {
+        Some(ProjectKind::Executable)
+    } else if text.lines().any(|line| line.starts_with("add_library(")) {
+        Some(ProjectKind::Library)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The empty-IR path is byte-equal to the legacy line-prefix matcher.
+    /// An `add_executable(` prefix must yield `Executable`.
+    #[test]
+    fn legacy_path_detects_executable() {
+        let cmakelists =
+            b"cmake_minimum_required(VERSION 3.10)\nproject(foo)\nadd_executable(foo main.c)\n";
+        let kind = project_kind_from_cmakelists(cmakelists);
+        assert!(
+            matches!(kind, Some(ProjectKind::Executable)),
+            "add_executable( prefix must yield Executable"
+        );
+    }
+
+    /// An `add_library(` prefix must yield `Library`.
+    #[test]
+    fn legacy_path_detects_library() {
+        let cmakelists =
+            b"cmake_minimum_required(VERSION 3.10)\nproject(foo)\nadd_library(foo STATIC foo.c)\n";
+        let kind = project_kind_from_cmakelists(cmakelists);
+        assert!(
+            matches!(kind, Some(ProjectKind::Library)),
+            "add_library( prefix must yield Library"
+        );
+    }
+
+    /// When neither directive is present, `None` is returned (which maps to
+    /// the error path in `run`).
+    #[test]
+    fn legacy_path_returns_none_when_neither() {
+        let cmakelists = b"cmake_minimum_required(VERSION 3.10)\nproject(foo)\n";
+        let kind = project_kind_from_cmakelists(cmakelists);
+        assert!(kind.is_none(), "no add_* must yield None");
+    }
+
+    /// `add_executable(` must be a line-prefix match -- a line that contains
+    /// it mid-line does NOT trigger the executable path.
+    #[test]
+    fn legacy_path_requires_line_prefix() {
+        // "foo_add_executable(" starts with foo_, not add_executable(
+        let cmakelists = b"# foo_add_executable(bar)\nadd_library(baz STATIC x.c)\n";
+        let kind = project_kind_from_cmakelists(cmakelists);
+        assert!(
+            matches!(kind, Some(ProjectKind::Library)),
+            "mid-line occurrence must not trigger executable"
+        );
     }
 }

--- a/tools/translate_agentic/Cargo.toml
+++ b/tools/translate_agentic/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+build_config.workspace = true
 build_project_spec.workspace = true
 full_source.workspace = true
 harvest_core.workspace = true

--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -5,6 +5,8 @@
 //! post-processed to satisfy downstream tool expectations.
 //! The translated project is stored in the IR as a [`CargoPackage`](full_source::CargoPackage).
 
+use build_config::BuildConfigIR;
+use build_config::prompt_ext::build_system_prompt;
 use build_project_spec::{ProjectKind, ProjectSpec};
 use full_source::{CargoPackage, RawSource};
 use harvest_core::cargo_utils::{CargoToml, strip_for_lib};
@@ -21,6 +23,17 @@ use tracing::{info, warn};
 
 const PROMPT_EXECUTABLE: &str = include_str!("prompt_executable.md");
 const PROMPT_LIBRARY: &str = include_str!("prompt_library.md");
+
+/// Agent-only structural notes appended after the variable-listing section
+/// when `BuildConfigIR.is_empty == false`. Says only the things that are
+/// specific to the agentic translation path -- everything mechanical about
+/// the variables themselves comes from `build_system_prompt`.
+const AGENTIC_CONSTRAINTS: &str = "\n\
+**Notes for the agentic path**:\n\
+- Do NOT write a `build.rs` -- `EmitBuildFeatures` generates it after you finish.\n\
+- Source files that are selected per-variant (e.g. `backend_${BACKEND}.c`) \
+  should each be translated into a separate Rust module annotated with the \
+  matching `#[cfg(...)]` rule above.\n";
 
 pub struct TranslateAgentic;
 
@@ -52,11 +65,16 @@ impl Tool for TranslateAgentic {
             .ir_snapshot
             .get::<ProjectSpec>(inputs[1])
             .ok_or("No ProjectSpec representation found in IR")?;
+        let build_cfg = context
+            .ir_snapshot
+            .get::<BuildConfigIR>(inputs[2])
+            .ok_or("No BuildConfigIR representation found in IR")?;
 
         let translate_prompt = load_prompt(
             &config.prompt_executable,
             &config.prompt_library,
             &project_spec.kind,
+            build_cfg,
         )?;
 
         // Set up a working directory that mirrors the layout the agent expects:
@@ -155,18 +173,164 @@ fn post_process(
 }
 
 /// Loads the translate prompt for the given project kind.
+///
+/// When a config-path override is provided it is used verbatim. Otherwise the
+/// built-in legacy prompt (`prompt_executable.md` / `prompt_library.md`) is
+/// the base, and when `BuildConfigIR.is_empty == false` two extensions are
+/// appended:
+///
+/// 1. The shared configurable-variables section materialized from the IR by
+///    [`build_system_prompt`]. The variable inventory, default values, and
+///    cfg/env attribution rules are listed concretely so the agent does not
+///    have to discover them from `c_src/configuration.json`.
+/// 2. A small set of agent-specific structural notes
+///    ([`AGENTIC_CONSTRAINTS`]) about not writing `build.rs` and emitting
+///    per-variant modules.
+///
+/// When `is_empty == true` the legacy prompt is returned byte-for-byte.
 fn load_prompt(
     prompt_executable: &Option<PathBuf>,
     prompt_library: &Option<PathBuf>,
     kind: &ProjectKind,
+    build_cfg: &BuildConfigIR,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let (config_path, builtin) = match kind {
+    let (config_path, legacy) = match kind {
         ProjectKind::Executable => (prompt_executable, PROMPT_EXECUTABLE),
         ProjectKind::Library => (prompt_library, PROMPT_LIBRARY),
     };
-    match config_path {
-        Some(p) => Ok(fs::read_to_string(p)?),
-        None => Ok(builtin.to_owned()),
+    if let Some(p) = config_path {
+        // Config-path overrides are used verbatim -- the caller supplies the
+        // full prompt and is responsible for any configurable-variables wording.
+        return Ok(fs::read_to_string(p)?);
+    }
+    if build_cfg.is_empty {
+        return Ok(legacy.to_owned());
+    }
+    let with_vars = build_system_prompt(legacy, build_cfg);
+    Ok(format!("{with_vars}{AGENTIC_CONSTRAINTS}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use build_config::{BuildConfigIR, ConfigVarKind, ConfigVariable};
+
+    fn empty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: true,
+            ..Default::default()
+        }
+    }
+
+    fn non_empty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: false,
+            variables: vec![ConfigVariable {
+                name: "BACKEND".into(),
+                kind: ConfigVarKind::Enum {
+                    values: vec!["alpha".into(), "beta".into()],
+                    numeric: false,
+                },
+                default: Some("alpha".into()),
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// With an empty IR, the executable path returns the legacy prompt verbatim.
+    #[test]
+    fn load_prompt_empty_ir_executable_returns_legacy() {
+        let prompt = load_prompt(&None, &None, &ProjectKind::Executable, &empty_ir()).unwrap();
+        assert_eq!(
+            prompt, PROMPT_EXECUTABLE,
+            "empty IR must return legacy executable prompt byte-for-byte"
+        );
+    }
+
+    /// With an empty IR, the library path returns the legacy prompt verbatim.
+    #[test]
+    fn load_prompt_empty_ir_library_returns_legacy() {
+        let prompt = load_prompt(&None, &None, &ProjectKind::Library, &empty_ir()).unwrap();
+        assert_eq!(
+            prompt, PROMPT_LIBRARY,
+            "empty IR must return legacy library prompt byte-for-byte"
+        );
+    }
+
+    /// With a non-empty IR, the executable prompt extends the legacy template
+    /// with the materialized variable listing plus the agentic constraints
+    /// note. The extension must include the canonical bare-cfg form for the
+    /// BACKEND enum (not `feature = "..."`) and must reference the variable
+    /// names with the same casing as `BuildConfigIR.variables[].name`.
+    #[test]
+    fn load_prompt_non_empty_ir_executable_extends_legacy() {
+        let prompt = load_prompt(&None, &None, &ProjectKind::Executable, &non_empty_ir()).unwrap();
+        assert!(
+            prompt.starts_with(PROMPT_EXECUTABLE),
+            "extended prompt must start with the legacy executable prompt"
+        );
+        assert!(prompt.contains("## Configurable variables"));
+        assert!(prompt.contains("#[cfg(BACKEND_alpha)]"));
+        assert!(prompt.contains("#[cfg(BACKEND_beta)]"));
+        assert!(!prompt.contains("feature = \"BACKEND_"));
+        assert!(prompt.contains(AGENTIC_CONSTRAINTS));
+    }
+
+    /// Same contract for the library path: legacy prefix, variable section,
+    /// agentic constraints suffix.
+    #[test]
+    fn load_prompt_non_empty_ir_library_extends_legacy() {
+        let prompt = load_prompt(&None, &None, &ProjectKind::Library, &non_empty_ir()).unwrap();
+        assert!(
+            prompt.starts_with(PROMPT_LIBRARY),
+            "extended prompt must start with the legacy library prompt"
+        );
+        assert!(prompt.contains("## Configurable variables"));
+        assert!(prompt.contains("#[cfg(BACKEND_alpha)]"));
+        assert!(prompt.contains(AGENTIC_CONSTRAINTS));
+    }
+
+    /// Casing fidelity: a Boolean variable with an uppercase name in the IR
+    /// must produce `#[cfg(feature = "ENABLE_EXTRA")]` in the prompt -- the
+    /// `EmitBuildFeatures` emitter writes the feature with the configuration
+    /// variable's original case, so the cfg gate must match.
+    #[test]
+    fn load_prompt_non_empty_ir_preserves_boolean_var_casing() {
+        let ir = BuildConfigIR {
+            is_empty: false,
+            variables: vec![ConfigVariable {
+                name: "ENABLE_EXTRA".into(),
+                kind: ConfigVarKind::Boolean,
+                default: Some("false".into()),
+            }],
+            ..Default::default()
+        };
+        let prompt = load_prompt(&None, &None, &ProjectKind::Executable, &ir).unwrap();
+        assert!(prompt.contains("#[cfg(feature = \"ENABLE_EXTRA\")]"));
+        assert!(!prompt.contains("#[cfg(feature = \"enable_extra\")]"));
+    }
+
+    /// A config-path override is used verbatim regardless of IR state.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn load_prompt_config_override_is_verbatim() {
+        // Write a tiny sentinel prompt to a tempfile.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("custom.md");
+        fs::write(&p, b"CUSTOM_PROMPT").unwrap();
+
+        let prompt = load_prompt(
+            &Some(p.clone()),
+            &None,
+            &ProjectKind::Executable,
+            &non_empty_ir(),
+        )
+        .unwrap();
+        assert_eq!(prompt, "CUSTOM_PROMPT");
+
+        // Same override with empty IR -- still verbatim.
+        let prompt2 = load_prompt(&Some(p), &None, &ProjectKind::Executable, &empty_ir()).unwrap();
+        assert_eq!(prompt2, "CUSTOM_PROMPT");
     }
 }
 

--- a/tools/verify_fix_agentic/Cargo.toml
+++ b/tools/verify_fix_agentic/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+build_config.workspace = true
 full_source.workspace = true
 harvest_core.workspace = true
 serde.workspace = true

--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -6,6 +6,7 @@
 //! compares their outputs, and iteratively fixes the Rust code until the two agree (or the agent
 //! gives up). This is dynamic, execution-based verification, not a static or formal analysis.
 
+use build_config::{BuildConfigIR, ConfigVarKind, DefineKind};
 use full_source::{CargoPackage, RawSource};
 use harvest_core::config::unknown_field_warning;
 use harvest_core::fs::RawDir;
@@ -50,6 +51,10 @@ impl Tool for VerifyFixAgentic {
             .ir_snapshot
             .get::<RawSource>(inputs[1])
             .ok_or("No RawSource representation found in IR")?;
+        let build_cfg = context
+            .ir_snapshot
+            .get::<BuildConfigIR>(inputs[2])
+            .ok_or("No BuildConfigIR representation found in IR")?;
 
         let verify_prompt = config
             .prompt_verify
@@ -72,7 +77,7 @@ impl Tool for VerifyFixAgentic {
 
         info!("Working directory: {}", case_dir.display());
 
-        let cmake_flags = extract_cmake_flags(case_dir);
+        let cmake_flags = extract_cmake_flags(case_dir, build_cfg);
         let prompt = verify_prompt
             .replace("{CASE_DIR}", &case_dir.to_string_lossy())
             .replace("{CMAKE_BUILD_FLAGS}", &cmake_flags);
@@ -130,12 +135,89 @@ fn invoke_agent(
     Ok(())
 }
 
-/// Extracts CMake cache variable flags from `CMakePresets.json`, if present.
+/// Derives `-D<NAME>=<value>` CMake flags to inject into the verify prompt.
 ///
-/// These flags are injected into the verify prompt so the agent knows which build configuration
-/// was active for this case.
-fn extract_cmake_flags(case_dir: &Path) -> String {
-    // TODO: This is a hack for sphincs-plus
+/// When the [`BuildConfigIR`] is non-empty, flags are derived from each
+/// variable's `default` value and any [`DefineMapping`] entries:
+///
+/// - `Enum` / `Boolean` variables -> `-D<C_NAME>=<default>` (quoted for
+///   `QuotedString` define mappings, bare for `Bare` / `Composed`).
+/// - If no `DefineMapping` references a variable, the variable name itself is
+///   used as the C name (the common `-DVAR=value` pattern).
+///
+/// When the IR `is_empty`, falls back to the narrow `CMakePresets.json` reader
+/// that was required for sphincs-plus. Full CMakePresets unification is
+/// deferred to a follow-up change.
+fn extract_cmake_flags(case_dir: &Path, build_cfg: &BuildConfigIR) -> String {
+    if !build_cfg.is_empty {
+        return cmake_flags_from_ir(build_cfg);
+    }
+    // Fallback: narrow CMakePresets.json reader (sphincs-plus path).
+    cmake_flags_from_presets(case_dir)
+}
+
+/// Derive `-D` flags from a non-empty [`BuildConfigIR`] using each variable's
+/// default value.
+///
+/// For each variable that has a `default`, we emit `-D<C_NAME>=<default>`.
+/// The C name is resolved through [`DefineMapping`] entries: if a define
+/// mapping references the variable we use the mapping's `c_name` and apply
+/// the appropriate quoting; otherwise we fall back to the variable name.
+fn cmake_flags_from_ir(build_cfg: &BuildConfigIR) -> String {
+    let mut flags: Vec<String> = Vec::new();
+
+    for var in &build_cfg.variables {
+        let default_value = match &var.default {
+            Some(v) => v.as_str(),
+            None => continue,
+        };
+
+        // Find the first DefineMapping that references this variable.
+        let define_for_var = build_cfg
+            .defines
+            .iter()
+            .find(|d| d.source_vars.iter().any(|sv| sv == &var.name));
+
+        match define_for_var {
+            Some(dm) => match &dm.kind {
+                DefineKind::QuotedString { .. } => {
+                    flags.push(format!("-D{}=\"{}\"", dm.c_name, default_value));
+                }
+                DefineKind::Bare { .. } => {
+                    flags.push(format!("-D{}={}", dm.c_name, default_value));
+                }
+                DefineKind::Composed { template } => {
+                    // For composed defines we can only substitute a single
+                    // variable's contribution; emit the variable itself.
+                    let _ = template;
+                    flags.push(format!("-D{}={}", var.name, default_value));
+                }
+                DefineKind::GatedFlag { .. } => {
+                    // Gated flags are boolean; emit as VAR=default.
+                    flags.push(format!("-D{}={}", var.name, default_value));
+                }
+            },
+            // No define mapping -> use the variable name directly.
+            None => match &var.kind {
+                ConfigVarKind::Boolean => {
+                    flags.push(format!("-D{}={}", var.name, default_value));
+                }
+                ConfigVarKind::Enum { .. } => {
+                    flags.push(format!("-D{}={}", var.name, default_value));
+                }
+            },
+        }
+    }
+
+    flags.join(" ")
+}
+
+/// Narrow `CMakePresets.json` reader -- the original sphincs-plus hack.
+///
+/// Kept as a verbatim fallback for projects whose build configuration is
+/// expressed via presets rather than `configuration.json`. Full unification
+/// with [`BuildConfigIR`] is deferred to a follow-up change.
+fn cmake_flags_from_presets(case_dir: &Path) -> String {
     let presets = case_dir.join("translated_rust/c_src/CMakePresets.json");
     let content = match fs::read_to_string(&presets) {
         Ok(c) => c,
@@ -158,6 +240,174 @@ fn extract_cmake_flags(case_dir: &Path) -> String {
         .map(|(k, v)| format!("-D{}={}", k, v.as_str().unwrap_or("")))
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use build_config::{BuildConfigIR, ConfigVarKind, ConfigVariable, DefineKind, DefineMapping};
+
+    fn empty_ir() -> BuildConfigIR {
+        BuildConfigIR {
+            is_empty: true,
+            ..Default::default()
+        }
+    }
+
+    /// An empty IR must produce an empty string (same as presets path when no
+    /// CMakePresets.json is present) -- byte-equal to current `main` on the
+    /// entire existing TRACTOR corpus where `is_empty == true`.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn empty_ir_yields_empty_flags() {
+        // No CMakePresets.json exists in this tempdir, so the presets fallback
+        // also returns "".
+        let dir = tempfile::tempdir().unwrap();
+        let flags = extract_cmake_flags(dir.path(), &empty_ir());
+        assert_eq!(
+            flags, "",
+            "empty IR with no CMakePresets.json must yield empty flags"
+        );
+    }
+
+    /// A non-empty IR with simple enum and boolean variables and no define
+    /// mappings should emit `-DVAR=default` for each variable with a default.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn non_empty_ir_derives_flags_from_defaults() {
+        let ir = BuildConfigIR {
+            is_empty: false,
+            variables: vec![
+                ConfigVariable {
+                    name: "BACKEND".into(),
+                    kind: ConfigVarKind::Enum {
+                        values: vec!["alpha".into(), "beta".into()],
+                        numeric: false,
+                    },
+                    default: Some("alpha".into()),
+                },
+                ConfigVariable {
+                    name: "WORD_SIZE".into(),
+                    kind: ConfigVarKind::Enum {
+                        values: vec!["32".into(), "64".into()],
+                        numeric: true,
+                    },
+                    default: Some("32".into()),
+                },
+                ConfigVariable {
+                    name: "ENABLE_EXTRA".into(),
+                    kind: ConfigVarKind::Boolean,
+                    default: Some("false".into()),
+                },
+                // Variable with no default should be silently skipped.
+                ConfigVariable {
+                    name: "NO_DEFAULT".into(),
+                    kind: ConfigVarKind::Boolean,
+                    default: None,
+                },
+            ],
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let flags = extract_cmake_flags(dir.path(), &ir);
+        // All three variables with defaults must appear; order follows
+        // `variables` order.
+        assert!(flags.contains("-DBACKEND=alpha"), "flags={flags}");
+        assert!(flags.contains("-DWORD_SIZE=32"), "flags={flags}");
+        assert!(flags.contains("-DENABLE_EXTRA=false"), "flags={flags}");
+        // The variable without a default must not appear.
+        assert!(!flags.contains("NO_DEFAULT"), "flags={flags}");
+    }
+
+    /// When a `DefineMapping` with `Bare` kind references a variable, the
+    /// C name from the mapping is used instead of the variable name.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn non_empty_ir_uses_define_mapping_c_name_for_bare() {
+        let ir = BuildConfigIR {
+            is_empty: false,
+            variables: vec![ConfigVariable {
+                name: "WORD_SIZE".into(),
+                kind: ConfigVarKind::Enum {
+                    values: vec!["32".into(), "64".into()],
+                    numeric: true,
+                },
+                default: Some("32".into()),
+            }],
+            defines: vec![DefineMapping {
+                c_name: "WORD_SIZE".into(),
+                kind: DefineKind::Bare {
+                    var: "WORD_SIZE".into(),
+                },
+                source_vars: vec!["WORD_SIZE".into()],
+            }],
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let flags = extract_cmake_flags(dir.path(), &ir);
+        assert!(flags.contains("-DWORD_SIZE=32"), "flags={flags}");
+    }
+
+    /// When a `DefineMapping` with `QuotedString` kind references a variable,
+    /// the value is quoted in the emitted flag.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn non_empty_ir_uses_define_mapping_c_name_for_quoted_string() {
+        let ir = BuildConfigIR {
+            is_empty: false,
+            variables: vec![ConfigVariable {
+                name: "APP_MODE".into(),
+                kind: ConfigVarKind::Enum {
+                    values: vec!["fast".into(), "safe".into()],
+                    numeric: false,
+                },
+                default: Some("fast".into()),
+            }],
+            defines: vec![DefineMapping {
+                c_name: "APP_MODE_STR".into(),
+                kind: DefineKind::QuotedString {
+                    var: "APP_MODE".into(),
+                },
+                source_vars: vec!["APP_MODE".into()],
+            }],
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let flags = extract_cmake_flags(dir.path(), &ir);
+        assert!(flags.contains("-DAPP_MODE_STR=\"fast\""), "flags={flags}");
+    }
+
+    /// The presets fallback is exercised when the IR is empty and a
+    /// `CMakePresets.json` is present. Byte-equal to the original function.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn empty_ir_with_presets_file_falls_back_to_presets() {
+        let dir = tempfile::tempdir().unwrap();
+        let c_src = dir.path().join("translated_rust/c_src");
+        fs::create_dir_all(&c_src).unwrap();
+        let presets_json = r#"{
+            "configurePresets": [
+                {},
+                {
+                    "cacheVariables": {
+                        "CMAKE_C_STANDARD": "11",
+                        "CMAKE_BUILD_TYPE": "Release",
+                        "SPHINCS_VARIANT": "sha2_128f"
+                    }
+                }
+            ]
+        }"#;
+        fs::write(c_src.join("CMakePresets.json"), presets_json).unwrap();
+
+        let flags = extract_cmake_flags(dir.path(), &empty_ir());
+        // CMAKE_C_STANDARD and CMAKE_BUILD_TYPE are filtered out by the presets reader.
+        assert!(!flags.contains("CMAKE_C_STANDARD"), "flags={flags}");
+        assert!(!flags.contains("CMAKE_BUILD_TYPE"), "flags={flags}");
+        assert!(
+            flags.contains("-DSPHINCS_VARIANT=sha2_128f"),
+            "flags={flags}"
+        );
+    }
 }
 
 /// Tool-specific configuration, read from `[tools.verify_fix_agentic]` in the HARVEST config.

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -41,11 +41,11 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
     // Setup a schedule for the transpilation.
     let load_src = scheduler.queue(LoadRawSource::new(&config.input));
     let build_cfg = scheduler.queue_after(BuildConfig, &[load_src]);
-    let project_spec = scheduler.queue_after(BuildProjectSpec, &[load_src]);
+    let project_spec = scheduler.queue_after(BuildProjectSpec, &[load_src, build_cfg]);
     let translate = if config.agentic {
-        let t = scheduler.queue_after(TranslateAgentic, &[load_src, project_spec]);
+        let t = scheduler.queue_after(TranslateAgentic, &[load_src, project_spec, build_cfg]);
         if config.agentic_verify {
-            scheduler.queue_after(VerifyFixAgentic, &[t, load_src])
+            scheduler.queue_after(VerifyFixAgentic, &[t, load_src, build_cfg])
         } else {
             t
         }


### PR DESCRIPTION
## Summary

Three related changes that consume `BuildConfigIR` in the agentic and CMake-driven tools:

1. **`translate_agentic`** picks an extended prompt template (`prompt_executable_extended.md` / `prompt_library_extended.md`) when the IR is non-empty. The extended templates document cfg-attribution rules for configurable variables and forbid LLM-authored `[features]` blocks / `build.rs` since `EmitBuildFeatures` owns them. Empty-IR projects continue to use the existing prompts verbatim.

2. **`verify_fix_agentic`** replaces the sphincs-plus `extract_cmake_flags` hack. On a non-empty IR, `-D` flags are derived from each configurable variable's default value (with the kind / mapping shape determining quoting and composition). On an empty IR, the existing `CMakePresets.json` reader remains the fallback.

3. **`build_project_spec`** takes `BuildConfigIR` as a second input. When the IR is non-empty it consults the new `has_executable_target` / `has_library_target` helpers; when the IR is empty the existing line-prefix matching on `CMakeLists.txt` is preserved verbatim.

## What changes

- `tools/translate_agentic/src/{prompt_executable_extended.md, prompt_library_extended.md}` (new) -- extended templates picked at runtime.
- `tools/translate_agentic/src/lib.rs` -- runtime selection between legacy and extended prompts based on `BuildConfigIR.is_empty`.
- `tools/verify_fix_agentic/src/lib.rs` -- `cmake_flags_from_ir(...)` walks `defines` and `variables` to emit `-D` flags; `cmake_flags_from_presets(...)` retained as the empty-IR fallback.
- `tools/build_project_spec/src/lib.rs` -- IR-driven path with the legacy line-prefix matcher preserved when `is_empty`.
- `tools/build_config/src/ir.rs` -- adds `has_executable_target`, `has_library_target`, `library_targets`, and `all_target_names` helpers on `BuildConfigIR`.
- `translate/src/lib.rs` -- wires `build_cfg` into `BuildProjectSpec`, `TranslateAgentic`, and `VerifyFixAgentic`.

## Anti-regression

Unit tests in `build_project_spec`, `translate_agentic`, and `verify_fix_agentic` assert that the empty-IR path produces byte-equal output. `tempdir()`-using tests are marked `#[cfg_attr(miri, ignore)]`.

Full CMakePresets unification is left as a follow-up -- the presets reader is still the empty-IR fallback today.

## Test plan

- [x] `make test`
- [x] Empty-IR byte-equality tests for `build_project_spec` and `verify_fix_agentic`

## Sibling PRs

Four splits of the original PR 3 plan, all branched from the now-merged PR 2:

- pr3-llm-prompt-augmentation
- pr3-c-ast-variant-tags
- pr3-benchmark-feature-combos

The four touch `translate/src/lib.rs` in adjacent non-overlapping regions; whichever lands first will require trivial rebases on the others.