### PR TITLE
c_ast variant_tags plumbing from BuildConfigIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
 name = "c_ast"
 version = "0.1.0"
 dependencies = [
+ "build_config",
  "clang",
  "full_source",
  "harvest_core",

--- a/tools/c_ast/Cargo.toml
+++ b/tools/c_ast/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+build_config.workspace = true
 clang = { version = "2.0.0" }
 full_source = { version = "0.1.0", path = "../full_source" }
 harvest_core.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 tempfile.workspace = true
-tracing.workspace = true 
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/tools/c_ast/src/lib.rs
+++ b/tools/c_ast/src/lib.rs
@@ -3,20 +3,65 @@ mod ast;
 mod rsm;
 mod utils;
 
+use build_config::BuildConfigIR;
 use clang::{Clang as LibClang, Index};
 use full_source::RawSource;
 use harvest_core::{
     Id, Representation,
     tools::{RunContext, Tool},
 };
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
 pub use annotations::{EntityAnnotations, annotate_visibility};
 pub use ast::ClangAST;
 pub use rsm::{EntityKind, RichSourceMap, SourcePoint, SourceSpan, TopLevelEntity};
 
+/// Lookup table from canonicalized absolute file path to the list of
+/// `(driving_var, value)` tags that file participates in. Built once from
+/// [`BuildConfigIR::source_selections`] before parsing so per-entity lookup is
+/// a single hash hit.
+type VariantTagMap = HashMap<PathBuf, Vec<(String, String)>>;
+
 pub struct ParseToAst;
+
+/// Build a [`VariantTagMap`] keyed by canonicalized absolute paths under
+/// `src_root`. Entries are accumulated, so a file referenced by two
+/// `SourceSelection`s ends up with both tags.
+///
+/// Files missing from disk are skipped (canonicalization failure) -- they
+/// would not appear in any entity span either, so the asymmetry is harmless.
+fn build_variant_tag_map(cfg: Option<&BuildConfigIR>, src_root: &Path) -> VariantTagMap {
+    let mut map: VariantTagMap = HashMap::new();
+    let Some(cfg) = cfg else { return map };
+    if cfg.is_empty {
+        return map;
+    }
+    for selection in &cfg.source_selections {
+        for variant in &selection.variants {
+            for rel_path in &variant.files {
+                let abs = src_root.join(rel_path);
+                let key = abs.canonicalize().unwrap_or(abs);
+                map.entry(key)
+                    .or_default()
+                    .push((selection.driving_var.clone(), variant.value.clone()));
+            }
+        }
+    }
+    map
+}
+
+/// Lookup the variant tags for an entity span. Returns an empty `Vec` when
+/// the file isn't recorded in any `SourceSelection`.
+fn variant_tags_for(span: &SourceSpan, map: &VariantTagMap) -> Vec<(String, String)> {
+    if map.is_empty() {
+        return Vec::new();
+    }
+    let key = PathBuf::from(&span.file);
+    let canonical = key.canonicalize().unwrap_or(key);
+    map.get(&canonical).cloned().unwrap_or_default()
+}
 
 /// Utility function to generate libClang parser arguments based on the source root and file being parsed.
 /// This includes standard flags, include paths, and language specification based on file extension.
@@ -50,7 +95,11 @@ fn build_parser<'a>(index: &'a Index, src_root: &Path, rel_file: &Path) -> clang
 
 /// Extract top-level entities from the translation unit.
 /// This includes both entities that survive preprocessing (types, functions, globals) and preprocessor directives (includes, defines, compiler args).
-fn extract_entities(parser: clang::Parser<'_>, out: &mut RichSourceMap) {
+fn extract_entities(
+    parser: clang::Parser<'_>,
+    variant_map: &VariantTagMap,
+    out: &mut RichSourceMap,
+) {
     let tu = match parser.parse() {
         Ok(tu) => tu,
         Err(e) => {
@@ -79,6 +128,7 @@ fn extract_entities(parser: clang::Parser<'_>, out: &mut RichSourceMap) {
 
         // Extract the AST for this entity
         let ast = ast::ast_from_entity(decl_kind, &child);
+        let variant_tags = variant_tags_for(&span, variant_map);
         out.push_entity(
             TopLevelEntity {
                 kind: decl_kind,
@@ -87,6 +137,7 @@ fn extract_entities(parser: clang::Parser<'_>, out: &mut RichSourceMap) {
                 ast,
                 annotations: EntityAnnotations::default(),
                 sub_entities: Vec::new(),
+                variant_tags,
             },
             &child,
         );
@@ -100,6 +151,19 @@ impl Tool for ParseToAst {
 
     /// For each C and header file in the RawSource, parse it with libClang and extract top-level declarations into a RichSourceMap.
     /// Captures preprocessor information such as include paths and defines as well.
+    ///
+    /// Inputs:
+    /// 1. [`RawSource`] id -- the C project to parse.
+    /// 2. (optional) [`BuildConfigIR`] id -- drives per-entity `variant_tags`.
+    ///    When absent or `is_empty`, every entity's `variant_tags` is the
+    ///    empty vec and serialized output is byte-equal to the form
+    ///    produced without a `BuildConfigIR` input.
+    ///
+    /// We deliberately keep file discovery extension-based even when a
+    /// `BuildConfigIR` is supplied: the modular translator needs ASTs for
+    /// every variant simultaneously so it can emit
+    /// `#[cfg(<DRIVING_VAR>_<VALUE>)] mod <variant>;` per variant. The
+    /// variant_tags are labels, not a filter.
     fn run(
         self: Box<Self>,
         context: RunContext,
@@ -111,30 +175,285 @@ impl Tool for ParseToAst {
             .get::<RawSource>(id)
             .ok_or("No RawSource representation found in IR")?;
 
-        let src_dir = tempfile::TempDir::new()?;
-        rs.dir.materialize(src_dir.path())?;
+        // Second input is optional so old schedules (and tests that don't care
+        // about variant tagging) keep working.
+        let build_cfg: Option<&BuildConfigIR> = inputs
+            .get(1)
+            .and_then(|cfg_id| context.ir_snapshot.get::<BuildConfigIR>(*cfg_id));
 
-        let clang = LibClang::new().map_err(|e| format!("Failed to initialize libclang: {e}"))?;
-        let index = Index::new(&clang, false, false);
+        let map = parse_to_ast(rs, build_cfg)?;
+        Ok(Box::new(map))
+    }
+}
 
-        let mut out = RichSourceMap::new();
+/// Core deterministic transform: parse every C/header file in `rs` and
+/// produce a [`RichSourceMap`]. Each entity is stamped with `variant_tags`
+/// derived from `cfg` (empty when `cfg` is `None` or `is_empty`).
+///
+/// Factored out so callers can drive parsing without a full
+/// [`RunContext`] / scheduler -- the integration tests use this path.
+pub fn parse_to_ast(
+    rs: &RawSource,
+    cfg: Option<&BuildConfigIR>,
+) -> Result<RichSourceMap, Box<dyn std::error::Error>> {
+    let src_dir = tempfile::TempDir::new()?;
+    rs.dir.materialize(src_dir.path())?;
 
-        for (rel_path, _) in rs.dir.files_recursive() {
-            if utils::should_skip_path(&rel_path) {
-                continue;
-            }
-            if !utils::is_c_or_header(&rel_path) {
-                continue;
-            }
-            tracing::info!("Parsing file: {}", rel_path.to_string_lossy());
-            let parser = build_parser(&index, src_dir.path(), &rel_path);
-            extract_entities(parser, &mut out);
+    let variant_map = build_variant_tag_map(cfg, src_dir.path());
+
+    let clang = LibClang::new().map_err(|e| format!("Failed to initialize libclang: {e}"))?;
+    let index = Index::new(&clang, false, false);
+
+    let mut out = RichSourceMap::new();
+
+    for (rel_path, _) in rs.dir.files_recursive() {
+        if utils::should_skip_path(&rel_path) {
+            continue;
         }
+        if !utils::is_c_or_header(&rel_path) {
+            continue;
+        }
+        tracing::info!("Parsing file: {}", rel_path.to_string_lossy());
+        let parser = build_parser(&index, src_dir.path(), &rel_path);
+        extract_entities(parser, &variant_map, &mut out);
+    }
 
-        debug!(
-            "Generated RichSourceMap:\n{}",
-            serde_json::to_string_pretty(&out)?
+    debug!(
+        "Generated RichSourceMap:\n{}",
+        serde_json::to_string_pretty(&out)?
+    );
+    Ok(out)
+}
+
+#[cfg(not(miri))]
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the variant-tag lookup. The libclang-driven entity
+    //! extraction is covered by `tests/parse_to_ast.rs`; these tests focus on
+    //! the pure-Rust lookup table that maps spans to tags.
+    use super::*;
+    use build_config::{ConfigVariable, SourceSelection, SourceVariant};
+    use std::fs;
+
+    fn span_for(path: &Path) -> SourceSpan {
+        SourceSpan {
+            file: path.to_string_lossy().into_owned(),
+            start: SourcePoint {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+            end: SourcePoint {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+        }
+    }
+
+    fn touch(root: &Path, rel: &str) -> PathBuf {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, b"").unwrap();
+        path.canonicalize().unwrap()
+    }
+
+    fn synthetic_backend_selection() -> SourceSelection {
+        SourceSelection {
+            target: "backend".into(),
+            driving_var: "BACKEND".into(),
+            variants: vec![
+                SourceVariant {
+                    value: "alpha".into(),
+                    files: vec![PathBuf::from("src/backend_alpha.c")],
+                },
+                SourceVariant {
+                    value: "beta".into(),
+                    files: vec![PathBuf::from("src/backend_beta.c")],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn build_variant_tag_map_returns_empty_for_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let map = build_variant_tag_map(None, tmp.path());
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn build_variant_tag_map_returns_empty_for_empty_ir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = BuildConfigIR {
+            is_empty: true,
+            ..Default::default()
+        };
+        let map = build_variant_tag_map(Some(&cfg), tmp.path());
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn build_variant_tag_map_keys_each_variant_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let alpha = touch(tmp.path(), "src/backend_alpha.c");
+        let beta = touch(tmp.path(), "src/backend_beta.c");
+
+        let cfg = BuildConfigIR {
+            variables: vec![ConfigVariable {
+                name: "BACKEND".into(),
+                kind: build_config::ConfigVarKind::Enum {
+                    values: vec!["alpha".into(), "beta".into()],
+                    numeric: false,
+                },
+                default: Some("alpha".into()),
+            }],
+            source_selections: vec![synthetic_backend_selection()],
+            ..Default::default()
+        };
+
+        let map = build_variant_tag_map(Some(&cfg), tmp.path());
+
+        assert_eq!(
+            map.get(&alpha),
+            Some(&vec![("BACKEND".to_string(), "alpha".to_string())])
         );
-        Ok(Box::new(out))
+        assert_eq!(
+            map.get(&beta),
+            Some(&vec![("BACKEND".to_string(), "beta".to_string())])
+        );
+    }
+
+    #[test]
+    fn variant_tags_for_returns_empty_when_map_empty() {
+        let map = VariantTagMap::new();
+        let span = span_for(Path::new("/does/not/matter.c"));
+        assert!(variant_tags_for(&span, &map).is_empty());
+    }
+
+    #[test]
+    fn variant_tags_for_returns_empty_for_unselected_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let alpha = touch(tmp.path(), "src/backend_alpha.c");
+        let main = touch(tmp.path(), "src/main.c");
+
+        let cfg = BuildConfigIR {
+            source_selections: vec![synthetic_backend_selection()],
+            ..Default::default()
+        };
+        let map = build_variant_tag_map(Some(&cfg), tmp.path());
+        // Sanity: alpha is in the map, main isn't.
+        assert!(map.contains_key(&alpha));
+        assert!(variant_tags_for(&span_for(&main), &map).is_empty());
+    }
+
+    #[test]
+    fn variant_tags_for_matches_alpha_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let alpha = touch(tmp.path(), "src/backend_alpha.c");
+
+        let cfg = BuildConfigIR {
+            source_selections: vec![synthetic_backend_selection()],
+            ..Default::default()
+        };
+        let map = build_variant_tag_map(Some(&cfg), tmp.path());
+        assert_eq!(
+            variant_tags_for(&span_for(&alpha), &map),
+            vec![("BACKEND".into(), "alpha".into())]
+        );
+    }
+
+    #[test]
+    fn build_variant_tag_map_accumulates_two_selections_for_same_file() {
+        // A file referenced by two distinct SourceSelections (e.g. the same
+        // file picked under both BACKEND=alpha and a hypothetical
+        // FLAVOR=plain) should receive both tags.
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = touch(tmp.path(), "src/shared.c");
+
+        let cfg = BuildConfigIR {
+            source_selections: vec![
+                SourceSelection {
+                    target: "first".into(),
+                    driving_var: "BACKEND".into(),
+                    variants: vec![SourceVariant {
+                        value: "alpha".into(),
+                        files: vec![PathBuf::from("src/shared.c")],
+                    }],
+                },
+                SourceSelection {
+                    target: "second".into(),
+                    driving_var: "FLAVOR".into(),
+                    variants: vec![SourceVariant {
+                        value: "plain".into(),
+                        files: vec![PathBuf::from("src/shared.c")],
+                    }],
+                },
+            ],
+            ..Default::default()
+        };
+        let map = build_variant_tag_map(Some(&cfg), tmp.path());
+        let tags = map.get(&shared).cloned().unwrap_or_default();
+        assert!(tags.contains(&("BACKEND".into(), "alpha".into())));
+        assert!(tags.contains(&("FLAVOR".into(), "plain".into())));
+        assert_eq!(tags.len(), 2);
+    }
+
+    #[test]
+    fn entity_with_no_variant_tags_serializes_without_field() {
+        // Anti-regression: an entity with an empty variant_tags vec must not
+        // emit a `variant_tags` key in JSON, so existing TRACTOR-corpus
+        // outputs remain byte-equal.
+        let entity = TopLevelEntity {
+            kind: EntityKind::FunctionDecl,
+            source_text: "void f(void) {}".to_string(),
+            span: span_for(Path::new("/x/y/z.c")),
+            ast: None,
+            annotations: EntityAnnotations::default(),
+            sub_entities: Vec::new(),
+            variant_tags: Vec::new(),
+        };
+        let json = serde_json::to_string(&entity).unwrap();
+        assert!(
+            !json.contains("variant_tags"),
+            "empty variant_tags must be skipped in JSON, got: {json}"
+        );
+    }
+
+    #[test]
+    fn entity_with_variant_tags_round_trips_through_json() {
+        let entity = TopLevelEntity {
+            kind: EntityKind::FunctionDecl,
+            source_text: "void f(void) {}".to_string(),
+            span: span_for(Path::new("/x/y/backend_alpha.c")),
+            ast: None,
+            annotations: EntityAnnotations::default(),
+            sub_entities: Vec::new(),
+            variant_tags: vec![("BACKEND".into(), "alpha".into())],
+        };
+        let json = serde_json::to_string(&entity).unwrap();
+        assert!(json.contains("variant_tags"));
+        let round_trip: TopLevelEntity = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip.variant_tags, entity.variant_tags);
+    }
+
+    #[test]
+    fn entity_json_without_variant_tags_deserializes_with_empty_default() {
+        // Existing JSON from `main` does not contain `variant_tags`. Make sure
+        // deserialization defaults it to the empty vec.
+        let legacy = r#"{
+            "kind": "FunctionDecl",
+            "source_text": "void f(void) {}",
+            "span": {
+                "file": "/x/y/z.c",
+                "start": {"line": 1, "column": 1, "offset": 0},
+                "end": {"line": 1, "column": 1, "offset": 0}
+            },
+            "ast": null
+        }"#;
+        let parsed: TopLevelEntity = serde_json::from_str(legacy).unwrap();
+        assert!(parsed.variant_tags.is_empty());
     }
 }

--- a/tools/c_ast/src/rsm.rs
+++ b/tools/c_ast/src/rsm.rs
@@ -68,6 +68,19 @@ pub struct TopLevelEntity {
     // This helps us deduplicate typedefs and struct/enum/union declarations.
     #[serde(default)]
     pub sub_entities: Vec<TopLevelEntity>,
+    /// `(driving_var, value)` tags identifying which build-config variants
+    /// this entity belongs to.
+    ///
+    /// Populated by looking up the entity's file in
+    /// `BuildConfigIR.source_selections`. A file that isn't selected by any
+    /// configurable variable gets an empty vec -- the common case. A file
+    /// referenced by two distinct `SourceSelection`s (uncommon) gets two tags.
+    ///
+    /// The downstream consumer (`modular_translation_llm`) uses these tags to
+    /// emit `#[cfg(<DRIVING_VAR>_<VALUE>)]` attributes on the translated
+    /// module declarations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub variant_tags: Vec<(String, String)>,
 }
 
 /// This is the output of the parsing step, and therefore this tool.

--- a/tools/c_ast/tests/parse_to_ast.rs
+++ b/tools/c_ast/tests/parse_to_ast.rs
@@ -1,0 +1,221 @@
+//! End-to-end integration tests for `parse_to_ast` that drive libclang.
+//!
+//! Gated on `not(miri)` and on libclang's availability -- when libclang is
+//! missing the tests skip rather than fail, mirroring the warn-and-skip
+//! convention `extract_entities` uses on parse failure.
+
+#![cfg(not(miri))]
+
+use std::path::PathBuf;
+
+use build_config::{BuildConfigIR, ConfigVarKind, ConfigVariable, SourceSelection, SourceVariant};
+use c_ast::{ClangAST, RichSourceMap, TopLevelEntity, parse_to_ast};
+use full_source::RawSource;
+use harvest_core::fs::RawDir;
+
+/// Three tiny self-contained C files. Each declares exactly one function so
+/// we can identify entities by name regardless of include behavior. Keeping
+/// them dependency-free side-steps the `params.h` `#error` guards in the
+/// build_config fixtures.
+const MAIN_C: &str = r#"
+int main(void) { return 0; }
+"#;
+
+const BACKEND_ALPHA_C: &str = r#"
+int backend_alpha(int x) { return x + 1; }
+"#;
+
+const BACKEND_BETA_C: &str = r#"
+int backend_beta(int x) { return x + 2; }
+"#;
+
+fn mock_raw_source() -> RawSource {
+    let mut dir = RawDir::default();
+    dir.set_file("src/main.c", MAIN_C.as_bytes().to_vec())
+        .unwrap();
+    dir.set_file("src/backend_alpha.c", BACKEND_ALPHA_C.as_bytes().to_vec())
+        .unwrap();
+    dir.set_file("src/backend_beta.c", BACKEND_BETA_C.as_bytes().to_vec())
+        .unwrap();
+    RawSource { dir }
+}
+
+fn synthetic_build_config_with_backend() -> BuildConfigIR {
+    BuildConfigIR {
+        variables: vec![ConfigVariable {
+            name: "BACKEND".into(),
+            kind: ConfigVarKind::Enum {
+                values: vec!["alpha".into(), "beta".into()],
+                numeric: false,
+            },
+            default: Some("alpha".into()),
+        }],
+        defines: Vec::new(),
+        source_selections: vec![SourceSelection {
+            target: "backend".into(),
+            driving_var: "BACKEND".into(),
+            variants: vec![
+                SourceVariant {
+                    value: "alpha".into(),
+                    files: vec![PathBuf::from("src/backend_alpha.c")],
+                },
+                SourceVariant {
+                    value: "beta".into(),
+                    files: vec![PathBuf::from("src/backend_beta.c")],
+                },
+            ],
+        }],
+        conditional_targets: Vec::new(),
+        subdir_selections: Vec::new(),
+        is_empty: false,
+    }
+}
+
+fn empty_build_config() -> BuildConfigIR {
+    BuildConfigIR {
+        is_empty: true,
+        ..Default::default()
+    }
+}
+
+fn run(rs: &RawSource, cfg: Option<&BuildConfigIR>) -> Option<RichSourceMap> {
+    match parse_to_ast(rs, cfg) {
+        Ok(map) => Some(map),
+        Err(err) => {
+            eprintln!("Skipping: parse_to_ast failed (libclang missing?): {err}");
+            None
+        }
+    }
+}
+
+fn find_function<'a>(map: &'a RichSourceMap, name: &str) -> Option<&'a TopLevelEntity> {
+    map.app_functions.iter().find(|e| {
+        matches!(
+            e.ast.as_ref(),
+            Some(ClangAST::FunctionDecl { name: n, .. }) if n == name
+        )
+    })
+}
+
+#[test]
+fn variant_tags_populated_per_file_under_synthetic_ir() {
+    // With BACKEND=alpha selecting `backend_alpha.c` and BACKEND=beta selecting
+    // `backend_beta.c`, the declarations in those files carry the matching
+    // tag. `main.c` is unselected, so its declarations get an empty vec.
+    let raw = mock_raw_source();
+    let cfg = synthetic_build_config_with_backend();
+    let Some(map) = run(&raw, Some(&cfg)) else {
+        return;
+    };
+
+    let alpha = find_function(&map, "backend_alpha").expect("backend_alpha function not found");
+    assert_eq!(
+        alpha.variant_tags,
+        vec![("BACKEND".to_string(), "alpha".to_string())],
+        "alpha-only function should be tagged with BACKEND=alpha"
+    );
+
+    let beta = find_function(&map, "backend_beta").expect("backend_beta function not found");
+    assert_eq!(
+        beta.variant_tags,
+        vec![("BACKEND".to_string(), "beta".to_string())],
+        "beta-only function should be tagged with BACKEND=beta"
+    );
+
+    let main = find_function(&map, "main").expect("main function not found");
+    assert!(
+        main.variant_tags.is_empty(),
+        "main.c is not in any source_selection; variant_tags must be empty"
+    );
+}
+
+#[test]
+fn variant_tags_empty_under_empty_ir() {
+    // Empty BuildConfigIR: every entity must have an empty variant_tags vec.
+    let raw = mock_raw_source();
+    let cfg = empty_build_config();
+    let Some(map) = run(&raw, Some(&cfg)) else {
+        return;
+    };
+
+    for entity in map.app_functions.iter() {
+        assert!(
+            entity.variant_tags.is_empty(),
+            "empty-IR run produced non-empty variant_tags for {:?}",
+            entity.ast
+        );
+    }
+}
+
+#[test]
+fn variant_tags_empty_when_no_build_config_input() {
+    // Backwards-compat path: parse_to_ast accepts None for the build config.
+    // Every entity gets an empty variant_tags.
+    let raw = mock_raw_source();
+    let Some(map) = run(&raw, None) else {
+        return;
+    };
+
+    for entity in map.app_functions.iter() {
+        assert!(
+            entity.variant_tags.is_empty(),
+            "no-config run produced non-empty variant_tags for {:?}",
+            entity.ast
+        );
+    }
+}
+
+#[test]
+fn empty_ir_json_has_no_variant_tags_keys() {
+    // Anti-regression: with an empty IR, the serialized JSON must not contain
+    // any `variant_tags` key. This is what guarantees byte-equality with the
+    // legacy outputs for the entire TRACTOR corpus (which lacks
+    // configuration.json).
+    let raw = mock_raw_source();
+    let cfg = empty_build_config();
+    let Some(map) = run(&raw, Some(&cfg)) else {
+        return;
+    };
+
+    let json = serde_json::to_string(&map).unwrap();
+    assert!(
+        !json.contains("variant_tags"),
+        "empty-IR JSON unexpectedly contains `variant_tags`; output was:\n{json}"
+    );
+}
+
+#[test]
+fn no_build_config_json_has_no_variant_tags_keys() {
+    // Same anti-regression but for the path that doesn't even pass a
+    // BuildConfigIR: schedules that don't supply one must produce
+    // exactly the same output as the no-config path.
+    let raw = mock_raw_source();
+    let Some(map) = run(&raw, None) else {
+        return;
+    };
+
+    let json = serde_json::to_string(&map).unwrap();
+    assert!(
+        !json.contains("variant_tags"),
+        "no-config JSON unexpectedly contains `variant_tags`; output was:\n{json}"
+    );
+}
+
+#[test]
+fn no_config_and_empty_ir_produce_byte_equal_json() {
+    // Strong byte-equality assertion: the serialized output must be identical
+    // whether the caller supplies no BuildConfigIR at all or supplies an
+    // is_empty IR. This is the contract the legacy pipeline depends on.
+    let raw = mock_raw_source();
+    let cfg = empty_build_config();
+    let (Some(no_cfg_map), Some(empty_cfg_map)) = (run(&raw, None), run(&raw, Some(&cfg))) else {
+        return;
+    };
+
+    let no_cfg_json = serde_json::to_string(&no_cfg_map).unwrap();
+    let empty_cfg_json = serde_json::to_string(&empty_cfg_map).unwrap();
+    assert_eq!(
+        no_cfg_json, empty_cfg_json,
+        "missing-IR and empty-IR JSON must be byte-equal"
+    );
+}

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -50,7 +50,12 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
             t
         }
     } else if config.modular {
-        let parse_ast = scheduler.queue_after(ParseToAst, &[load_src]);
+        // ParseToAst takes BuildConfigIR as a second input so it can stamp
+        // each TopLevelEntity with its variant_tags. When the IR is empty the
+        // tags collapse to `Vec::new()` and serialized output is byte-equal
+        // to the form produced without a BuildConfigIR input
+        // (see TopLevelEntity::variant_tags docs).
+        let parse_ast = scheduler.queue_after(ParseToAst, &[load_src, build_cfg]);
         scheduler.queue_after(ModularTranslationLlm, &[load_src, parse_ast, project_spec])
     } else {
         scheduler.queue_after(RawSourceToCargoLlm, &[load_src, project_spec])


### PR DESCRIPTION
## Summary

Threads `BuildConfigIR.source_selections` into `c_ast` so each `TopLevelEntity` records which configurable-variable variants it belongs to. Downstream consumers (the modular translator in particular) can then emit `#[cfg(<DRIVING_VAR>_<VALUE>)] mod <variant>;` per source-selected variant.

## What changes

- `tools/c_ast/src/rsm.rs` -- adds `variant_tags: Vec<(String, String)>` to `TopLevelEntity`. Each tag is `(driving_var, value)` for a `SourceSelection` whose file list contains the entity's source file. An entity in a file not selected by any configurable variable gets `Vec::new()` (the common case).

- `tools/c_ast/src/lib.rs` -- `ParseToAst` takes an optional `BuildConfigIR` as a second input. `build_variant_tag_map` builds a per-file lookup from the IR; `variant_tags_for` populates entities. Extension-based file discovery is unchanged -- variant tags are labels, not a filter.

- `tools/c_ast/tests/parse_to_ast.rs` (new) -- integration tests for synthetic IRs (alpha/beta backends), empty IR, no-IR, and explicit JSON byte-equality.

- `translate/src/lib.rs` -- wires `build_cfg` into `ParseToAst`.

## Anti-regression

`variant_tags` uses `#[serde(default, skip_serializing_if = "Vec::is_empty")]`, so when `BuildConfigIR` is absent or `is_empty`, every entity's tags vector is empty AND the serialized JSON output is byte-equal to the form produced without a `BuildConfigIR` input. Tests assert this explicitly.

## Cross-PR dependency note

The naming convention for downstream consumers is `<DRIVING_VAR>_<VALUE>` (uppercase driving var, lowercase value, joined with `_`), matching the cfg name `EmitBuildFeatures` emits from PR 2. The modular translator will consume `entity.variant_tags` to emit per-variant `#[cfg(...)] mod ...;` declarations -- that wiring is left for a follow-up.

## Test plan

- [x] `make test`
- [x] Synthetic-IR test: `backend_alpha.c` entities get `[("BACKEND", "alpha")]`, etc.
- [x] Empty-IR test: every entity has empty `variant_tags` and JSON byte-equal to pre-PR form

## Sibling PRs

Four splits of the original PR 3 plan, all branched from the now-merged PR 2:

- pr3-llm-prompt-augmentation
- pr3-agentic-cmake-consumers
- pr3-benchmark-feature-combos

The four touch `translate/src/lib.rs` in adjacent non-overlapping regions; whichever lands first will require trivial rebases on the others.