### PR TITLE
benchmark --feature-combos flag

### DIFF
--- a/benchmark/src/cli.rs
+++ b/benchmark/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::harness::feature_combo::FeatureCombos;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -52,4 +53,18 @@ pub struct Args {
     /// Cannot be used together with --filter.
     #[arg(long, conflicts_with = "filter")]
     pub exclude: Option<String>,
+
+    /// Feature combination mode for testing translated crates.
+    ///
+    /// - `default` (default): exercise only the C build's default feature selection.
+    ///   Produces the same results as previous `benchmark` runs; no behavior change for
+    ///   the existing TRACTOR corpus.
+    /// - `all`: iterate the full Cartesian product of feature combinations declared in
+    ///   the translated crate's `[features]` block. Errors if the product exceeds 1024
+    ///   combinations; use `--feature-combos N` to cap instead.
+    /// - `N` (positive integer): sample exactly N combinations drawn evenly from the
+    ///   full Cartesian product (deterministic, evenly-spaced indices). If the full
+    ///   product is smaller than N, all combinations are tested.
+    #[arg(long, default_value = "default", value_name = "MODE")]
+    pub feature_combos: FeatureCombos,
 }

--- a/benchmark/src/harness/feature_combo.rs
+++ b/benchmark/src/harness/feature_combo.rs
@@ -1,0 +1,607 @@
+//! Feature-combination enumeration for translated Rust crates.
+//!
+//! This module is responsible for:
+//!
+//! 1. Parsing `--feature-combos {default|all|N}` from the CLI.
+//! 2. Reading the translated crate's `Cargo.toml [features]` block to discover
+//!    which feature *groups* exist (each `VAR_value` feature belongs to the group
+//!    `VAR`; boolean features are singleton groups).
+//! 3. Enumerating (or sampling) the Cartesian product of groups.
+//!
+//! ## Feature group discovery
+//!
+//! `EmitBuildFeatures` writes features in the pattern `VAR_value` for
+//! enum variables and bare `VAR` for booleans.  We reconstruct groups by
+//! collecting all features that share the same prefix before the last `_`
+//! component, *provided* more than one feature in the set shares that prefix.
+//! Singleton features (no shared prefix) become their own groups with two
+//! variants: enabled and disabled.
+//!
+//! The `default` feature key is not a group; it is the combination selected
+//! when `--feature-combos default` is used.
+//!
+//! ## Combo string format
+//!
+//! Each combo is represented as a comma-separated, sorted list of the
+//! enabled features, e.g. `"BACKEND_alpha,WORD_SIZE_64"`.  The special
+//! string `"default"` is used when `--feature-combos default` is in effect.
+//!
+//! ## Sampling strategy (for `--feature-combos N`)
+//!
+//! When the full Cartesian product has P entries and N < P, we select
+//! exactly N entries by taking evenly-spaced indices:
+//!
+//! ```text
+//! indices = { floor(i * P / N) | i in 0..N }
+//! ```
+//!
+//! This is deterministic (no RNG), covers the full range, and distributes
+//! selections evenly.  For N >= P, all P entries are returned.
+
+use crate::error::HarvestResult;
+use harvest_core::cargo_utils::CargoToml;
+use std::path::Path;
+use std::str::FromStr;
+
+/// Hard cap on the full Cartesian product size when `--feature-combos all` is used.
+/// If the product exceeds this, `all` errors and the user must pass an explicit `N`.
+const ALL_HARD_CAP: usize = 1024;
+
+// ---------------------------------------------------------------------------
+// CLI value type
+// ---------------------------------------------------------------------------
+
+/// The value for `--feature-combos`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeatureCombos {
+    /// Only exercise the C build's default feature selection (no-op for crates
+    /// without `[features]`).  This is the default and preserves backward
+    /// compatibility with the existing TRACTOR corpus runs.
+    Default,
+    /// Exercise the full Cartesian product (capped at [`ALL_HARD_CAP`]).
+    All,
+    /// Sample at most `N` combos from the Cartesian product.
+    N(usize),
+}
+
+impl FromStr for FeatureCombos {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(FeatureCombos::Default),
+            "all" => Ok(FeatureCombos::All),
+            other => other
+                .parse::<usize>()
+                .map(|n| {
+                    if n == 0 {
+                        Err("--feature-combos N must be a positive integer".to_string())
+                    } else {
+                        Ok(FeatureCombos::N(n))
+                    }
+                })
+                .map_err(|_| {
+                    format!(
+                        "invalid --feature-combos value '{}': expected 'default', 'all', or a positive integer",
+                        other
+                    )
+                })?,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Combo enumeration
+// ---------------------------------------------------------------------------
+
+/// A single feature combination: the set of features to pass via
+/// `--no-default-features --features=<combo>`.
+///
+/// The `label` is the human-readable string used in `results.csv`
+/// (`feature_combo` column).  The `features` list is sorted and passed
+/// verbatim to `cargo build --features`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureCombo {
+    /// Comma-separated sorted list of enabled feature names, or `"default"`.
+    pub label: String,
+    /// The `--features` argument (empty = use defaults), paired with
+    /// `no_default_features` flag.
+    pub features: Vec<String>,
+    /// When `true`, pass `--no-default-features` to cargo.
+    pub no_default_features: bool,
+}
+
+impl FeatureCombo {
+    /// The single "default" combo: use Cargo's default features.
+    pub fn default_combo() -> Self {
+        FeatureCombo {
+            label: "default".to_string(),
+            features: Vec::new(),
+            no_default_features: false,
+        }
+    }
+}
+
+/// Enumerate the feature combos to test for a translated crate.
+///
+/// Reads the `Cargo.toml` at `cargo_toml_path`, groups the `[features]`
+/// entries into logical variables (enum groups vs. booleans), then expands
+/// and optionally caps the Cartesian product.
+///
+/// Returns `Err` only when `mode == All` and the product would exceed
+/// [`ALL_HARD_CAP`].  All other edge cases (no `[features]`, parse errors)
+/// fall back gracefully to a single `default` combo.
+pub fn enumerate_combos(
+    cargo_toml_path: &Path,
+    mode: &FeatureCombos,
+) -> HarvestResult<Vec<FeatureCombo>> {
+    // For the default mode, skip all parsing -- no behavior change.
+    if matches!(mode, FeatureCombos::Default) {
+        return Ok(vec![FeatureCombo::default_combo()]);
+    }
+
+    let cargo = match CargoToml::open(cargo_toml_path) {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!(
+                "feature_combo: failed to open {}: {}; falling back to default combo",
+                cargo_toml_path.display(),
+                e
+            );
+            return Ok(vec![FeatureCombo::default_combo()]);
+        }
+    };
+
+    let all_features = cargo.feature_names();
+
+    // No features -> single default combo.
+    if all_features.is_empty() {
+        return Ok(vec![FeatureCombo::default_combo()]);
+    }
+
+    // Group features into logical variables.
+    let groups = group_features(&all_features);
+
+    // Cartesian product.
+    let product = cartesian_product(&groups);
+
+    let cap = match mode {
+        FeatureCombos::Default => unreachable!(),
+        FeatureCombos::All => {
+            if product.len() > ALL_HARD_CAP {
+                return Err(format!(
+                    "--feature-combos all: Cartesian product has {} combinations, which exceeds \
+                     the hard cap of {}. Use --feature-combos N to sample instead.",
+                    product.len(),
+                    ALL_HARD_CAP
+                )
+                .into());
+            }
+            product.len()
+        }
+        FeatureCombos::N(n) => *n,
+    };
+
+    let selected = sample_combos(product, cap);
+
+    Ok(selected
+        .into_iter()
+        .map(|features| {
+            let mut sorted = features.clone();
+            sorted.sort();
+            let label = if sorted.is_empty() {
+                "none".to_string()
+            } else {
+                sorted.join(",")
+            };
+            FeatureCombo {
+                label,
+                features: sorted,
+                no_default_features: true,
+            }
+        })
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Feature grouping
+// ---------------------------------------------------------------------------
+
+/// A logical feature group: a set of mutually-exclusive values derived from
+/// the same `VAR` prefix.
+///
+/// For enum variables (`VAR_value1`, `VAR_value2`, ...) the group contains all
+/// enum variant feature names.  In each combo, exactly one member is selected.
+///
+/// For boolean variables (`VAR` with no underscore-suffix siblings) the group
+/// has two variants: `[Some("VAR")]` (enabled) and `[None]` (disabled).
+#[derive(Debug, Clone)]
+pub struct FeatureGroup {
+    /// Variant sets.  Each inner `Vec` is the list of features to enable for
+    /// that variant.  Empty inner vec = no features enabled (boolean-off case).
+    pub variants: Vec<Vec<String>>,
+}
+
+/// Reconstruct logical feature groups from a flat list of feature names.
+///
+/// Algorithm:
+/// 1. Collect all features that share a common `PREFIX_` prefix into enum groups.
+///    A prefix is only treated as an enum prefix when *two or more* features
+///    share it (otherwise a single `FOO_BAR` is treated as a boolean).
+/// 2. Features that do not belong to any multi-member enum group are treated
+///    as boolean flags: each produces a two-variant group (on / off).
+pub fn group_features(features: &[String]) -> Vec<FeatureGroup> {
+    use std::collections::BTreeMap;
+
+    // Count features per prefix (everything before the last '_').
+    let mut prefix_count: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for f in features {
+        if let Some(pos) = f.rfind('_') {
+            let prefix = &f[..pos];
+            prefix_count
+                .entry(prefix.to_string())
+                .or_default()
+                .push(f.clone());
+        }
+    }
+
+    // Collect the set of features claimed by an enum group (prefix with >= 2 members).
+    let mut claimed: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut groups: Vec<FeatureGroup> = Vec::new();
+
+    // Sort prefix entries for deterministic ordering.
+    let mut prefix_entries: Vec<(String, Vec<String>)> = prefix_count.into_iter().collect();
+    prefix_entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (_, mut members) in prefix_entries {
+        if members.len() < 2 {
+            continue;
+        }
+        members.sort();
+        for m in &members {
+            claimed.insert(m.clone());
+        }
+        // Each member is one variant of the enum group.
+        let variants: Vec<Vec<String>> = members.into_iter().map(|m| vec![m]).collect();
+        groups.push(FeatureGroup { variants });
+    }
+
+    // Remaining features (not claimed by any enum group) are booleans.
+    let mut booleans: Vec<String> = features
+        .iter()
+        .filter(|f| !claimed.contains(*f))
+        .cloned()
+        .collect();
+    booleans.sort();
+    for b in booleans {
+        groups.push(FeatureGroup {
+            variants: vec![vec![b], vec![]],
+        });
+    }
+
+    groups
+}
+
+// ---------------------------------------------------------------------------
+// Cartesian product
+// ---------------------------------------------------------------------------
+
+/// Compute the Cartesian product of all feature groups.
+///
+/// Returns a `Vec` of feature-name sets (each set is a `Vec<String>`).
+/// An empty input produces `[vec![]]` (one combo: the empty set).
+pub fn cartesian_product(groups: &[FeatureGroup]) -> Vec<Vec<String>> {
+    if groups.is_empty() {
+        return vec![vec![]];
+    }
+    let mut result: Vec<Vec<String>> = vec![vec![]];
+    for group in groups {
+        let mut next: Vec<Vec<String>> = Vec::new();
+        for existing in &result {
+            for variant in &group.variants {
+                let mut combo = existing.clone();
+                combo.extend_from_slice(variant);
+                next.push(combo);
+            }
+        }
+        result = next;
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Sampling
+// ---------------------------------------------------------------------------
+
+/// Select up to `cap` entries from `product` using evenly-spaced indices.
+///
+/// Sampling strategy: for a product of size P and a cap of N,
+/// select indices `floor(i * P / N)` for `i` in `0..min(N, P)`.
+/// This is deterministic, requires no RNG, and distributes the selected
+/// entries evenly across the full range.
+///
+/// When `cap >= product.len()`, the full product is returned unchanged.
+pub fn sample_combos(product: Vec<Vec<String>>, cap: usize) -> Vec<Vec<String>> {
+    let p = product.len();
+    if cap >= p {
+        return product;
+    }
+    (0..cap).map(|i| product[i * p / cap].clone()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- FeatureCombos::from_str ----
+
+    #[test]
+    fn parse_default() {
+        assert_eq!(
+            "default".parse::<FeatureCombos>().unwrap(),
+            FeatureCombos::Default
+        );
+    }
+
+    #[test]
+    fn parse_all() {
+        assert_eq!("all".parse::<FeatureCombos>().unwrap(), FeatureCombos::All);
+    }
+
+    #[test]
+    fn parse_positive_integer() {
+        assert_eq!("5".parse::<FeatureCombos>().unwrap(), FeatureCombos::N(5));
+    }
+
+    #[test]
+    fn parse_zero_is_error() {
+        assert!("0".parse::<FeatureCombos>().is_err());
+    }
+
+    #[test]
+    fn parse_invalid_is_error() {
+        assert!("foo".parse::<FeatureCombos>().is_err());
+    }
+
+    // ---- group_features ----
+
+    #[test]
+    fn group_enum_two_values() {
+        let features = vec!["BACKEND_alpha".to_string(), "BACKEND_beta".to_string()];
+        let groups = group_features(&features);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].variants.len(), 2);
+        assert_eq!(groups[0].variants[0], vec!["BACKEND_alpha"]);
+        assert_eq!(groups[0].variants[1], vec!["BACKEND_beta"]);
+    }
+
+    #[test]
+    fn group_singleton_becomes_boolean() {
+        // A single feature with an underscore but no sibling is a boolean.
+        let features = vec!["ENABLE_EXTRA".to_string()];
+        let groups = group_features(&features);
+        assert_eq!(groups.len(), 1);
+        // Two variants: on and off.
+        assert_eq!(groups[0].variants.len(), 2);
+        let on_variant = &groups[0].variants[0];
+        let off_variant = &groups[0].variants[1];
+        assert!(on_variant.contains(&"ENABLE_EXTRA".to_string()));
+        assert!(off_variant.is_empty());
+    }
+
+    #[test]
+    fn group_bare_boolean() {
+        let features = vec!["MYFEATURE".to_string()];
+        let groups = group_features(&features);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].variants.len(), 2);
+    }
+
+    #[test]
+    fn group_mixed_enum_and_bool() {
+        let features = vec![
+            "BACKEND_alpha".to_string(),
+            "BACKEND_beta".to_string(),
+            "ENABLE_EXTRA".to_string(),
+        ];
+        let groups = group_features(&features);
+        // One enum group (BACKEND) + one boolean group (ENABLE_EXTRA)
+        assert_eq!(groups.len(), 2);
+    }
+
+    // ---- cartesian_product ----
+
+    #[test]
+    fn product_empty_groups() {
+        let result = cartesian_product(&[]);
+        assert_eq!(result, vec![vec![] as Vec<String>]);
+    }
+
+    #[test]
+    fn product_two_groups_two_values_each() {
+        // Mimics BACKEND={alpha,beta} x WORD_SIZE={32,64} => 4 combos.
+        let groups = vec![
+            FeatureGroup {
+                variants: vec![
+                    vec!["BACKEND_alpha".to_string()],
+                    vec!["BACKEND_beta".to_string()],
+                ],
+            },
+            FeatureGroup {
+                variants: vec![
+                    vec!["WORD_SIZE_32".to_string()],
+                    vec!["WORD_SIZE_64".to_string()],
+                ],
+            },
+        ];
+        let product = cartesian_product(&groups);
+        assert_eq!(product.len(), 4);
+        // Check all expected combos present.
+        let expected: Vec<Vec<String>> = vec![
+            vec!["BACKEND_alpha".to_string(), "WORD_SIZE_32".to_string()],
+            vec!["BACKEND_alpha".to_string(), "WORD_SIZE_64".to_string()],
+            vec!["BACKEND_beta".to_string(), "WORD_SIZE_32".to_string()],
+            vec!["BACKEND_beta".to_string(), "WORD_SIZE_64".to_string()],
+        ];
+        for exp in &expected {
+            assert!(
+                product.iter().any(|c| {
+                    let mut sorted_c = c.clone();
+                    sorted_c.sort();
+                    let mut sorted_e = exp.clone();
+                    sorted_e.sort();
+                    sorted_c == sorted_e
+                }),
+                "missing combo {:?}",
+                exp
+            );
+        }
+    }
+
+    #[test]
+    fn product_deterministic_order() {
+        // Two runs with same input must produce identical results.
+        let groups = vec![
+            FeatureGroup {
+                variants: vec![vec!["A_x".to_string()], vec!["A_y".to_string()]],
+            },
+            FeatureGroup {
+                variants: vec![vec!["B_1".to_string()], vec!["B_2".to_string()]],
+            },
+        ];
+        let p1 = cartesian_product(&groups);
+        let p2 = cartesian_product(&groups);
+        assert_eq!(p1, p2);
+    }
+
+    // ---- sample_combos ----
+
+    #[test]
+    fn sample_no_cap_returns_all() {
+        let product: Vec<Vec<String>> = (0..10).map(|i| vec![i.to_string()]).collect();
+        let sampled = sample_combos(product.clone(), 20);
+        assert_eq!(sampled, product);
+    }
+
+    #[test]
+    fn sample_cap_gives_correct_count() {
+        let product: Vec<Vec<String>> = (0..100).map(|i| vec![i.to_string()]).collect();
+        let sampled = sample_combos(product, 7);
+        assert_eq!(sampled.len(), 7);
+    }
+
+    #[test]
+    fn sample_deterministic() {
+        let product: Vec<Vec<String>> = (0..100).map(|i| vec![i.to_string()]).collect();
+        let s1 = sample_combos(product.clone(), 10);
+        let s2 = sample_combos(product, 10);
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn sample_covers_first_and_last() {
+        // First index is always 0*P/N = 0; last is floor((N-1)*P/N).
+        let product: Vec<Vec<String>> = (0..100).map(|i| vec![i.to_string()]).collect();
+        let sampled = sample_combos(product, 10);
+        assert_eq!(sampled[0], vec!["0"]);
+    }
+
+    // ---- enumerate_combos: in-memory via temp Cargo.toml ----
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn enumerate_default_mode_skips_parsing() {
+        // Even a non-existent path is fine when mode is Default.
+        let combos = enumerate_combos(
+            Path::new("/nonexistent/Cargo.toml"),
+            &FeatureCombos::Default,
+        )
+        .unwrap();
+        assert_eq!(combos.len(), 1);
+        assert_eq!(combos[0].label, "default");
+        assert!(!combos[0].no_default_features);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn enumerate_all_two_by_two() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            r#"
+[package]
+name = "test"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["BACKEND_alpha", "WORD_SIZE_32"]
+BACKEND_alpha = []
+BACKEND_beta = []
+WORD_SIZE_32 = []
+WORD_SIZE_64 = []
+"#
+        )
+        .unwrap();
+        let combos = enumerate_combos(tmp.path(), &FeatureCombos::All).unwrap();
+        assert_eq!(combos.len(), 4, "expected 4 combos, got {:?}", combos);
+        // All combos must have no_default_features = true.
+        assert!(combos.iter().all(|c| c.no_default_features));
+        // Labels are sorted comma-separated.
+        let labels: Vec<&str> = combos.iter().map(|c| c.label.as_str()).collect();
+        for label in &labels {
+            // Each label should contain exactly two features.
+            assert_eq!(label.split(',').count(), 2, "unexpected label: {}", label);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn enumerate_sampling_cap() {
+        use std::io::Write;
+        // 4 combos from 2x2 features, cap at 2.
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            r#"
+[package]
+name = "test"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["A_x", "B_1"]
+A_x = []
+A_y = []
+B_1 = []
+B_2 = []
+"#
+        )
+        .unwrap();
+        let combos = enumerate_combos(tmp.path(), &FeatureCombos::N(2)).unwrap();
+        assert_eq!(combos.len(), 2);
+        // Deterministic: run twice gives same result.
+        let combos2 = enumerate_combos(tmp.path(), &FeatureCombos::N(2)).unwrap();
+        assert_eq!(combos, combos2);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn enumerate_no_features_returns_default() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"
+        )
+        .unwrap();
+        let combos = enumerate_combos(tmp.path(), &FeatureCombos::All).unwrap();
+        assert_eq!(combos.len(), 1);
+        assert_eq!(combos[0].label, "default");
+    }
+}

--- a/benchmark/src/harness/mod.rs
+++ b/benchmark/src/harness/mod.rs
@@ -1,6 +1,7 @@
 /// This module `harness` is intended to contain code that is specific to a particular set of benchmarks,
 /// for example, parsing code for benchmark-specific configs.
 /// Currently, that is just the MITLL tractor benchmarks.
+pub mod feature_combo;
 pub mod library;
 
 use crate::runner;

--- a/benchmark/src/io.rs
+++ b/benchmark/src/io.rs
@@ -22,11 +22,32 @@ pub fn log_found_programs(program_dirs: &[PathBuf], input_dir: &Path) -> Harvest
     Ok(())
 }
 
-/// Write CSV results to file
+/// Write CSV results to file.
+///
+/// # Schema (column order is frozen -- do not reorder without bumping a version)
+///
+/// | # | Column | Description |
+/// |---|--------|-------------|
+/// | 0 | `program_name` | Directory name of the benchmark case |
+/// | 1 | `translation_success` | Whether translation produced a Cargo package |
+/// | 2 | `rust_build_success` | Whether `cargo build` succeeded |
+/// | 3 | `total_tests` | Number of test vectors |
+/// | 4 | `passed_tests` | Number of test vectors that passed (default combo) |
+/// | 5 | `skipped_tests` | Number of test vectors skipped |
+/// | 6 | `success_rate` | Pass rate for the default combo (%) |
+/// | 7 | `error_message` | First build/translation error, if any |
+/// | 8 | `feature_combo` | Comma-separated enabled features, or `"default"` |
+/// | 9 | `combo_passed` | Whether all test vectors passed for this combo |
+///
+/// Columns 8-9 are written once per `ComboResult` entry.  For the legacy
+/// `--feature-combos default` mode there is exactly one row per program with
+/// `feature_combo="default"`.  For `all`/`N` mode there is one row per combo.
+/// Downstream tooling should group by `program_name` and aggregate `combo_passed`
+/// to compute the strict-all-combos pass rate.
 pub fn write_csv_results(file_path: &PathBuf, results: &[ProgramEvalStats]) -> HarvestResult<()> {
     let mut wtr = csv::Writer::from_path(file_path)?;
 
-    // Write header
+    // Write header -- column positions must not change (see schema above).
     wtr.write_record([
         "program_name",
         "translation_success",
@@ -36,20 +57,50 @@ pub fn write_csv_results(file_path: &PathBuf, results: &[ProgramEvalStats]) -> H
         "skipped_tests",
         "success_rate",
         "error_message",
+        "feature_combo",
+        "combo_passed",
     ])?;
 
-    // Write data
+    // Write data -- one row per (program, combo) pair.
     for result in results {
-        wtr.write_record([
-            &result.program_name,
-            &result.translation_success.to_string(),
-            &result.rust_build_success.to_string(),
-            &result.total_tests.to_string(),
-            &result.passed_tests.to_string(),
-            &result.skipped_tests.to_string(),
-            &format!("{:.2}", result.success_rate()),
-            result.error_message.as_deref().unwrap_or(""),
-        ])?;
+        // Ensure there is always at least one combo row (the default).
+        let combos: &[_] = if result.combo_results.is_empty() {
+            // Pre-build / translation failure: emit a single "default" row.
+            &[]
+        } else {
+            result.combo_results.as_slice()
+        };
+
+        if combos.is_empty() {
+            // No combo results recorded (e.g. build failed before testing).
+            wtr.write_record([
+                &result.program_name,
+                &result.translation_success.to_string(),
+                &result.rust_build_success.to_string(),
+                &result.total_tests.to_string(),
+                &result.passed_tests.to_string(),
+                &result.skipped_tests.to_string(),
+                &format!("{:.2}", result.success_rate()),
+                result.error_message.as_deref().unwrap_or(""),
+                "default",
+                "false",
+            ])?;
+        } else {
+            for combo in combos {
+                wtr.write_record([
+                    &result.program_name,
+                    &result.translation_success.to_string(),
+                    &result.rust_build_success.to_string(),
+                    &result.total_tests.to_string(),
+                    &result.passed_tests.to_string(),
+                    &result.skipped_tests.to_string(),
+                    &format!("{:.2}", result.success_rate()),
+                    result.error_message.as_deref().unwrap_or(""),
+                    &combo.feature_combo,
+                    &combo.combo_passed.to_string(),
+                ])?;
+            }
+        }
     }
 
     wtr.flush()?;

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -8,6 +8,7 @@ mod runner;
 mod stats;
 use crate::cli::Args;
 use crate::error::HarvestResult;
+use crate::harness::feature_combo::{enumerate_combos, FeatureCombo, FeatureCombos};
 use crate::harness::{
     cleanup_benchmarks, parse_benchmark_dir, parse_test_vectors, validate_binary_output,
 };
@@ -19,7 +20,7 @@ use crate::ir_utils::{
     all_cargo_packages, cargo_build_result, raw_cargo_package, raw_source, write_output_result,
 };
 use crate::logger::TeeLogger;
-use crate::stats::{ProgramEvalStats, SummaryStats, TestResult};
+use crate::stats::{ComboResult, ProgramEvalStats, SummaryStats, TestResult};
 use clap::Parser;
 use harvest_core::utils::get_version;
 use harvest_core::HarvestIR;
@@ -27,6 +28,7 @@ use harvest_translate::{transpile, util::set_user_only_umask};
 use regex::Regex;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 
 /// Encapsulate important results from transpilation
@@ -149,6 +151,7 @@ pub fn run_all_benchmarks(
     agentic: bool,
     agentic_verify: bool,
     repair_passes: usize,
+    feature_combos: &FeatureCombos,
 ) -> HarvestResult<Vec<ProgramEvalStats>> {
     // Process all examples
     let mut results = Vec::new();
@@ -168,12 +171,89 @@ pub fn run_all_benchmarks(
             agentic,
             agentic_verify,
             repair_passes,
+            feature_combos,
         );
 
         results.push(result);
     }
 
     Ok(results)
+}
+
+/// Build the translated crate with a specific feature combination and return the
+/// path to the compiled binary (for executable crates).
+///
+/// When `combo.no_default_features` is `false` (the `default` combo), a plain
+/// `cargo build --release` is run -- identical to the pre-feature-combo behavior.
+/// When `no_default_features` is `true`, `--no-default-features --features=...`
+/// is appended so only the explicitly listed features are active.
+///
+/// Returns `None` (and logs a warning) for library crates -- callers must handle
+/// the library path differently.
+fn build_with_features(project_dir: &Path, combo: &FeatureCombo) -> HarvestResult<Option<PathBuf>> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
+        .arg("--release")
+        .current_dir(project_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if combo.no_default_features {
+        cmd.arg("--no-default-features");
+        if !combo.features.is_empty() {
+            cmd.arg("--features").arg(combo.features.join(","));
+        }
+    }
+
+    log::info!(
+        "Building combo '{}' in {}",
+        combo.label,
+        project_dir.display()
+    );
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to spawn cargo build: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("cargo build failed for combo '{}': {}", combo.label, stderr).into());
+    }
+
+    // Find the binary produced by this build.  We look for a single executable
+    // in target/release/ (excluding .d / .rlib / subdirectories).
+    let release_dir = project_dir.join("target").join("release");
+    let bin = find_release_binary(&release_dir);
+    Ok(bin)
+}
+
+/// Find the executable binary in a `target/release/` directory.
+/// Returns the first file that looks like a plain executable (not a dep file,
+/// not a subdirectory, not a `.d`/`.rlib` file).
+fn find_release_binary(release_dir: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(release_dir).ok()?;
+    let mut candidates: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let path = e.path();
+            if !path.is_file() {
+                return None;
+            }
+            let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+            // Skip known non-binary extensions.
+            if matches!(ext, "d" | "rlib" | "rmeta" | "pdb" | "exp" | "lib") {
+                return None;
+            }
+            // Skip files whose stem starts with a dot.
+            let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+            if stem.starts_with('.') {
+                return None;
+            }
+            Some(path)
+        })
+        .collect();
+    candidates.sort();
+    candidates.into_iter().next()
 }
 
 /// Run list of tests and output result/errors
@@ -245,7 +325,7 @@ fn run_test_validation(
     (test_results, error_messages)
 }
 
-/// Run all benchmarks for a single program
+/// Run all benchmarks for a single program, including feature-combo iteration.
 #[allow(clippy::too_many_arguments)]
 fn benchmark_single_program(
     program_dir: &Path,
@@ -256,6 +336,7 @@ fn benchmark_single_program(
     agentic: bool,
     agentic_verify: bool,
     repair_passes: usize,
+    feature_combos: &FeatureCombos,
 ) -> ProgramEvalStats {
     let program_name = program_dir
         .file_name()
@@ -341,48 +422,179 @@ fn benchmark_single_program(
         return result;
     }
 
-    // Library and executable validation differ.
-    let (test_results, error_messages) = match (is_lib, translation_result.rust_binary_path) {
-        (true, _) => {
-            match harness::library::run_library_validation(
-                &program_name,
-                program_dir,
-                &output_dir,
-                &test_cases,
-                timeout,
-            ) {
-                Ok(r) => r,
-                Err(e) => {
-                    let error_msg = format!("Library validation failed: {}", e);
-                    log::error!("{}", error_msg);
-                    result.error_message = Some(error_msg);
-                    return result;
-                }
+    // For library projects, feature-combo testing is not supported:
+    // the library validation flow rebuilds via `cargo build` without feature
+    // flags, and per-combo cdylib rebuilds are not wired into the cando2 harness.
+    // Library crates are validated once using the default combo.
+    if is_lib {
+        let (test_results, error_messages) = match harness::library::run_library_validation(
+            &program_name,
+            program_dir,
+            &output_dir,
+            &test_cases,
+            timeout,
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                let error_msg = format!("Library validation failed: {}", e);
+                log::error!("{}", error_msg);
+                result.error_message = Some(error_msg);
+                return result;
+            }
+        };
+
+        let passed = test_results
+            .iter()
+            .filter(|t| t.passed && !t.skipped)
+            .count();
+        let skipped = test_results.iter().filter(|t| t.skipped).count();
+
+        result.passed_tests = passed;
+        result.skipped_tests = skipped;
+        result.test_results = test_results;
+        result.combo_results.push(ComboResult {
+            feature_combo: "default".to_string(),
+            combo_passed: result.failed_tests() == 0,
+        });
+
+        log_program_summary(&result);
+
+        if !error_messages.is_empty() {
+            let error_file_path = output_dir.join("results.err");
+            if let Err(e) = write_error_file(&error_file_path, &error_messages) {
+                log::info!("Warning: Failed to write error file: {}", e);
             }
         }
-        (false, Some(binary_path)) if binary_path.exists() => {
-            run_test_validation(&binary_path, &test_cases, timeout, &output_dir)
-        }
-        (_, binary_path) => {
-            let error = format!(
-                "Rust build reported success, but expected output artifact was not found at {:?}",
-                binary_path
-            );
-            log::error!("{}", error);
-            result.error_message = Some(error);
+
+        return result;
+    }
+
+    // --- Executable path: iterate feature combos ---
+
+    // Enumerate the combos to test.
+    let cargo_toml_path = output_dir.join("Cargo.toml");
+    let combos = match enumerate_combos(&cargo_toml_path, feature_combos) {
+        Ok(c) => c,
+        Err(e) => {
+            let error_msg = format!("Feature-combo enumeration failed: {}", e);
+            log::error!("{}", error_msg);
+            result.error_message = Some(error_msg);
             return result;
         }
     };
 
-    result.passed_tests = test_results
-        .iter()
-        .filter(|t| t.passed && !t.skipped)
-        .count();
-    result.skipped_tests = test_results.iter().filter(|t| t.skipped).count();
-    result.test_results = test_results;
+    log::info!("Feature combos to test: {}", combos.len());
+
+    // For the `default` combo (no_default_features == false), use the binary
+    // that was already built by transpile.  For non-default combos, rebuild.
+    let initial_binary = translation_result.rust_binary_path;
+
+    let mut all_error_messages: Vec<String> = Vec::new();
+    let mut first_combo_test_results: Option<(Vec<TestResult>, usize, usize)> = None;
+
+    for (combo_idx, combo) in combos.iter().enumerate() {
+        log::info!(
+            "Testing combo {} of {}: '{}'",
+            combo_idx + 1,
+            combos.len(),
+            combo.label
+        );
+
+        // Get or build the binary for this combo.
+        let binary_path: PathBuf = if !combo.no_default_features {
+            // Default combo: reuse the binary produced by transpile.
+            match &initial_binary {
+                Some(p) if p.exists() => p.clone(),
+                other => {
+                    let error = format!(
+                        "Rust build reported success, but expected output artifact \
+                         was not found at {:?}",
+                        other
+                    );
+                    log::error!("{}", error);
+                    result.error_message = Some(error);
+                    return result;
+                }
+            }
+        } else {
+            // Non-default combo: rebuild with the requested features.
+            match build_with_features(&output_dir, combo) {
+                Ok(Some(p)) => p,
+                Ok(None) => {
+                    let error = format!(
+                        "cargo build succeeded for combo '{}' but no binary was found",
+                        combo.label
+                    );
+                    log::warn!("{}", error);
+                    result.combo_results.push(ComboResult {
+                        feature_combo: combo.label.clone(),
+                        combo_passed: false,
+                    });
+                    all_error_messages.push(error);
+                    continue;
+                }
+                Err(e) => {
+                    let error = format!("Build failed for combo '{}': {}", combo.label, e);
+                    log::warn!("{}", error);
+                    result.combo_results.push(ComboResult {
+                        feature_combo: combo.label.clone(),
+                        combo_passed: false,
+                    });
+                    all_error_messages.push(error);
+                    continue;
+                }
+            }
+        };
+
+        let (test_results, error_messages) =
+            run_test_validation(&binary_path, &test_cases, timeout, &output_dir);
+
+        let combo_passed =
+            error_messages.is_empty() && test_results.iter().all(|t| t.passed || t.skipped);
+
+        result.combo_results.push(ComboResult {
+            feature_combo: combo.label.clone(),
+            combo_passed,
+        });
+
+        // For the primary (default / first) combo, also populate the
+        // top-level aggregate stats that `SummaryStats` and logging use.
+        if first_combo_test_results.is_none() {
+            let passed = test_results
+                .iter()
+                .filter(|t| t.passed && !t.skipped)
+                .count();
+            let skipped = test_results.iter().filter(|t| t.skipped).count();
+            first_combo_test_results = Some((test_results, passed, skipped));
+        }
+
+        all_error_messages.extend(error_messages);
+    }
+
+    // Populate top-level aggregate stats from the first combo.
+    if let Some((test_results, passed, skipped)) = first_combo_test_results {
+        result.passed_tests = passed;
+        result.skipped_tests = skipped;
+        result.test_results = test_results;
+    }
 
     // Print summary for this example
-    log::info!("\nResults for {}:", program_name);
+    log_program_summary(&result);
+
+    // Write error messages to results.err file in the output directory if it was created
+    if !all_error_messages.is_empty() {
+        let error_file_path = output_dir.join("results.err");
+        if let Err(e) = write_error_file(&error_file_path, &all_error_messages) {
+            log::info!("Warning: Failed to write error file: {}", e);
+        }
+    }
+
+    result
+}
+
+/// Log the per-program summary line.
+fn log_program_summary(result: &ProgramEvalStats) {
+    log::info!("\nResults for {}:", result.program_name);
     log::info!(
         "  Translation: {}",
         status_emoji(result.translation_success)
@@ -395,16 +607,14 @@ fn benchmark_single_program(
         result.skipped_tests,
         result.success_rate()
     );
-
-    // Write error messages to results.err file in the output directory if it was created
-    if !error_messages.is_empty() {
-        let error_file_path = output_dir.join("results.err");
-        if let Err(e) = write_error_file(&error_file_path, &error_messages) {
-            log::info!("Warning: Failed to write error file: {}", e);
-        }
+    if result.combo_results.len() > 1 {
+        let all_pass = result.combo_results.iter().all(|c| c.combo_passed);
+        log::info!(
+            "  Feature combos: {} tested, {} strict aggregate pass",
+            result.combo_results.len(),
+            if all_pass { "[OK]" } else { "[FAIL]" }
+        );
     }
-
-    result
 }
 
 fn main() -> HarvestResult<()> {
@@ -505,6 +715,7 @@ fn run(args: Args) -> HarvestResult<()> {
         args.agentic,
         args.agentic_verify,
         args.repair_passes,
+        &args.feature_combos,
     )?;
     let csv_output_path = args.output_dir.join("results.csv");
     write_csv_results(&csv_output_path, &results)?;

--- a/benchmark/src/stats.rs
+++ b/benchmark/src/stats.rs
@@ -8,6 +8,19 @@ pub struct TestResult {
     pub skipped: bool,
 }
 
+/// Result for a single feature combination run on a program.
+///
+/// When `--feature-combos default` is in effect there is exactly one entry
+/// per program with `feature_combo = "default"`.  When `all` or `N` is used,
+/// there is one entry per exercised combination.
+#[derive(Debug, Clone, Serialize)]
+pub struct ComboResult {
+    /// Human-readable combo label (e.g. `"BACKEND_alpha,WORD_SIZE_64"` or `"default"`).
+    pub feature_combo: String,
+    /// `true` iff all test vectors passed for this combo.
+    pub combo_passed: bool,
+}
+
 /// Statistics for running many tests on a single program
 #[derive(Debug, Serialize)]
 pub struct ProgramEvalStats {
@@ -20,6 +33,11 @@ pub struct ProgramEvalStats {
     pub error_message: Option<String>,
     // Store individual test results with filenames and pass/fail status
     pub test_results: Vec<TestResult>,
+    /// Per-combination results (one entry per tested feature combination).
+    /// Always has at least one entry after testing completes; the entry's
+    /// `feature_combo` field is `"default"` when `--feature-combos default`
+    /// is in effect.
+    pub combo_results: Vec<ComboResult>,
 }
 
 impl ProgramEvalStats {
@@ -33,6 +51,7 @@ impl ProgramEvalStats {
             skipped_tests: 0,
             error_message: None,
             test_results: Vec::new(),
+            combo_results: Vec::new(),
         }
     }
 

--- a/core/src/cargo_utils.rs
+++ b/core/src/cargo_utils.rs
@@ -216,6 +216,42 @@ impl CargoToml {
         }
     }
 
+    /// Returns all feature names defined in `[features]`, excluding `"default"`.
+    ///
+    /// Returns an empty `Vec` when the `[features]` table is absent.
+    pub fn feature_names(&self) -> Vec<String> {
+        let Some(feat_item) = self.doc.get("features") else {
+            return Vec::new();
+        };
+        let Some(t) = feat_item.as_table() else {
+            return Vec::new();
+        };
+        let mut names: Vec<String> = t
+            .iter()
+            .filter(|(k, _)| *k != "default")
+            .map(|(k, _)| k.to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Returns the feature names listed in `[features].default`.
+    ///
+    /// Returns an empty `Vec` when the `default` key is absent or empty.
+    pub fn default_feature_names(&self) -> Vec<String> {
+        let Some(arr) = self
+            .doc
+            .get("features")
+            .and_then(|f| f.get("default"))
+            .and_then(|d| d.as_array())
+        else {
+            return Vec::new();
+        };
+        arr.iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect()
+    }
+
     /// Sets `[features].default` to the given list.
     pub fn set_default_features(&mut self, features: &[String]) {
         let feat = self

--- a/doc/Benchmark.md
+++ b/doc/Benchmark.md
@@ -12,11 +12,12 @@ Arguments:
   <OUTPUT_DIR>  Path to the output directory for all translated Rust projects
 
 Options:
-  -c, --config <CONFIG>    Set a configuration value; format $NAME=$VALUE
-      --timeout <TIMEOUT>  Timeout in seconds for running test cases [default: 10]
-      --filter <FILTER>    Filter benchmarks by regex pattern on directory names (keeps matching directories)
-      --exclude <EXCLUDE>  Exclude benchmarks by regex pattern on directory names (removes matching directories)
-  -h, --help               Print help
+  -c, --config <CONFIG>              Set a configuration value; format $NAME=$VALUE
+      --timeout <TIMEOUT>            Timeout in seconds for running test cases [default: 10]
+      --filter <FILTER>              Filter benchmarks by regex pattern on directory names (keeps matching directories)
+      --exclude <EXCLUDE>            Exclude benchmarks by regex pattern on directory names (removes matching directories)
+      --feature-combos <MODE>        Feature combination mode [default: default]
+  -h, --help                         Print help
 ```
 
 This interface should be fairly intuitive.
@@ -29,6 +30,16 @@ The `--filter` option takes a regular expression pattern and only runs benchmark
 The `--exclude` option takes a regular expression pattern and excludes benchmarks whose directory names match the pattern.
 
 **Note:** The `--filter` and `--exclude` options are mutually exclusive and cannot be used together.
+
+#### Using the `--feature-combos` option
+
+The `--feature-combos` option controls how many feature combinations are exercised when testing translated crates that have a `[features]` block in their `Cargo.toml`.
+
+- `default` (default): Only the C build's default feature selection is tested. Behavior is identical to previous `benchmark` runs; the existing TRACTOR corpus is byte-for-byte unchanged.
+- `all`: The full Cartesian product of features is tested. The product is capped at 1024; use `--feature-combos N` if you need a larger crate.
+- `N` (positive integer): Up to N combinations are sampled evenly from the full Cartesian product (deterministic, no randomness). If the product has fewer than N entries, all are tested.
+
+For crates without a `[features]` block, all modes behave identically to `default`.
 
 **Filter examples:**
 
@@ -96,8 +107,27 @@ The output directory structure of the `OUTPUT_DIR` of `benchmark` is as follows:
 ```
 
 - `output.log`: The raw output log, which includes the model used, the token budget, and fine-grained results (every test's result, including expected vs actual output).  
-- `results.csv`: Summary statistics for the run, like build success rate and test success rate.  
+- `results.csv`: Summary statistics for the run, like build success rate and test success rate. See schema below.
 - `Cargo.toml` and `src`: The translated rust code.   
 - `c_src`: The original C source code, exactly copied from the input.  
 - `failed_tests`: Any test cases that failed (copied from the input)  
 - `results.err`: Error messages for any failing test cases.  
+
+#### `results.csv` schema
+
+Column positions are frozen -- downstream tooling depends on column order. Do not reorder without bumping a schema version.
+
+| # | Column | Description |
+|---|--------|-------------|
+| 0 | `program_name` | Directory name of the benchmark case |
+| 1 | `translation_success` | Whether translation produced a Cargo package |
+| 2 | `rust_build_success` | Whether `cargo build` succeeded |
+| 3 | `total_tests` | Number of test vectors |
+| 4 | `passed_tests` | Number of test vectors that passed (default combo) |
+| 5 | `skipped_tests` | Number of test vectors skipped |
+| 6 | `success_rate` | Pass rate for the default combo (%) |
+| 7 | `error_message` | First build/translation error, if any |
+| 8 | `feature_combo` | Comma-separated enabled features, or `"default"` |
+| 9 | `combo_passed` | Whether all test vectors passed for this combo |
+
+With `--feature-combos default` there is exactly one row per program (`feature_combo="default"`). With `all` or `N` there is one row per exercised combination. Downstream tooling should group by `program_name` and aggregate `combo_passed` for a strict all-combos pass rate.


### PR DESCRIPTION
## Summary

Adds `--feature-combos {default|all|N}` to the benchmark CLI so translated crates with a `[features]` block (i.e. those whose source project shipped a `configuration.json`) can be validated across their full cartesian product of build configurations, or a deterministic evenly-spaced sample.

## CLI

- `default` (the default value) -- behavior unchanged. One row per program in `results.csv` with `feature_combo = "default"` and `combo_passed = <existing pass bool>`. Byte-equal stdout/logs for projects without `[features]`.
- `all` -- iterate the full cartesian product of feature groups from the translated crate's `Cargo.toml`. Hard cap at 1024 combos; if exceeded, errors out and instructs the caller to use `N`.
- `N` (positive integer) -- evenly-spaced index sampling through the cartesian product enumeration. Deterministic (no RNG). Selects indices `floor(i * P / N)` for `i in 0..min(N, P)`.

## What changes

- `benchmark/src/harness/feature_combo.rs` (new) -- `FeatureCombos` CLI type, `FeatureCombo` struct, `group_features` (prefix-based enum grouping), `cartesian_product`, `sample_combos`, `enumerate_combos`. 20 unit tests covering CLI parsing, grouping, cartesian enumeration, sampling determinism, and in-memory Cargo.toml round-trips.
- `benchmark/src/stats.rs` -- `ComboResult { feature_combo, combo_passed }` and `ProgramEvalStats::combo_results`.
- `benchmark/src/io.rs` -- extends `results.csv` with `feature_combo` and `combo_passed` columns (columns 8-9); frozen schema documented in doc-comment and `doc/Benchmark.md`.
- `benchmark/src/main.rs` -- wires `feature_combos` through `run_all_benchmarks` -> `benchmark_single_program` and rebuilds per-combo via `build_with_features` (plain `cargo build --release` for default, `--no-default-features --features=...` for non-default). Library crates fall back to single default-combo validation. Refactors summary logging into `log_program_summary`.
- `core/src/cargo_utils.rs` -- adds `feature_names()` and `default_feature_names()` getters (purely additive).
- `doc/Benchmark.md` -- documents `--feature-combos`, updates CLI usage, adds `results.csv` schema table.

## Aggregates

Both strict and legacy aggregates are computable from the same CSV:
- **Legacy** (one row per program): `feature_combo = "default"`, passes if its `combo_passed` is true. Matches pre-PR behavior.
- **Strict** (one row per (program, combo)): a program passes if every combo's `combo_passed` is true.

## Anti-regression

`--feature-combos default` produces byte-identical stdout/logs to the previous benchmark for projects with no `[features]` block. The `results.csv` schema is additive only.

## Test plan

- [x] `make test`
- [x] Unit tests cover cartesian enumeration determinism, sampling determinism, CLI parsing, in-memory Cargo.toml round-trips
- [x] Manual: `cargo run --bin=benchmark -- ... --feature-combos all` against `B02_synthetic/macrodepth_add_5` (21 combos from OP x REPEAT) once PR 2 (`emit_build_features`) lands and produces `[features]` for it -- expect one row per (program, combo) in `results.csv`

## Sibling PRs

Four splits of the original PR 3 plan, all branched from the now-merged PR 2:

- pr3-llm-prompt-augmentation
- pr3-agentic-cmake-consumers
- pr3-c-ast-variant-tags

The four touch `translate/src/lib.rs` in adjacent non-overlapping regions; whichever lands first will require trivial rebases on the others. (This PR's `translate/src/lib.rs` change is minimal -- no new tool wiring -- so it's likely the cheapest to rebase.)