### PR TITLE
Doc cleanup: ASCII art in Benchmark.md and accurate TRACTOR claims

### DIFF
--- a/doc/Benchmark.md
+++ b/doc/Benchmark.md
@@ -72,38 +72,38 @@ benchmark Test-Corpus/Public-Tests output/ --exclude=".*skip.*"
 The expected directory structure of the `INPUT_DIR` of `benchmark` is as follows:
 ```
 .
-├── 001_helloworld
-│   ├── test_case
-│   │   ├── <build files>
-│   │   └── src
-│   │       └── main.c
-│   └── test_vectors
-│       ├── test1.json
-│       ├── ...
-│       └── test3.json
-├── 002_stdin_echo
-└── ...
+|-- 001_helloworld
+|   |-- test_case
+|   |   |-- <build files>
+|   |   `-- src
+|   |       `-- main.c
+|   `-- test_vectors
+|       |-- test1.json
+|       |-- ...
+|       `-- test3.json
+|-- 002_stdin_echo
+`-- ...
 ```
-This mirrors the format used in the TRACTOR benchmark repository (e.g., `Test-Corpus/Public-Tests/B01_synthetic`). The layout is mostly self-explanatory, but additional documentation can be found in the TRACTOR repository’s README.
+This mirrors the format used in the TRACTOR benchmark repository (e.g., `Test-Corpus/Public-Tests/B01_synthetic`). The layout is mostly self-explanatory, but additional documentation can be found in the TRACTOR repository's README.
 
 
 ### Output Format
 The output directory structure of the `OUTPUT_DIR` of `benchmark` is as follows:
 ```
 .
-├── output.log
-├── results.csv
-├── 001_helloworld/
-│   ├── Cargo.toml
-│   └── src
-│       └── main.rs
-│   ├── c_src
-│   │   └── main.c
-│   ├── failed_tests
-│   │   └── test01.json
-│   ├── results.err
-├── 002_stdin_echo/
-└── ...
+|-- output.log
+|-- results.csv
+|-- 001_helloworld/
+|   |-- Cargo.toml
+|   |-- src
+|   |   `-- main.rs
+|   |-- c_src
+|   |   `-- main.c
+|   |-- failed_tests
+|   |   `-- test01.json
+|   `-- results.err
+|-- 002_stdin_echo/
+`-- ...
 ```
 
 - `output.log`: The raw output log, which includes the model used, the token budget, and fine-grained results (every test's result, including expected vs actual output).  

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -65,9 +65,9 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
     };
     // EmitBuildFeatures consumes the translated CargoPackage plus the
     // BuildConfigIR and produces a (possibly mutated) CargoPackage. On
-    // is_empty IRs (the entire current TRACTOR corpus) it is a no-op pass-
-    // through, so byte-for-byte behavior is preserved for projects without
-    // a `configuration.json`.
+    // is_empty IRs (projects without a `configuration.json`, which is
+    // the vast majority of the current TRACTOR corpus) it is a no-op
+    // pass-through, so byte-for-byte behavior is preserved.
     let translate = scheduler.queue_after(EmitBuildFeatures, &[translate, build_cfg]);
     let mut current_pkg_id = translate;
     let mut current_build_id = scheduler.queue_after(TryCargoBuild, &[current_pkg_id]);
@@ -116,8 +116,8 @@ mod emit_build_features_tests {
     //! Lives here (not in `tools/emit_build_features/tests/`) because the
     //! `Scheduler`/`ToolRunner` types are private to this crate. The test
     //! confirms the no-op short-circuit when `BuildConfigIR.is_empty == true`:
-    //! the `CargoPackage` is forwarded byte-for-byte. That is the contract the
-    //! entire current TRACTOR corpus depends on.
+    //! the `CargoPackage` is forwarded byte-for-byte. That is the contract
+    //! the vast majority of the current TRACTOR corpus depends on.
     use crate::runner::ToolRunner;
     use crate::scheduler::Scheduler;
     use build_config::BuildConfigIR;


### PR DESCRIPTION
## Summary

Two small janitorial cleanups (followups #7 and #8 from the BuildConfigIR stack):

- **`doc/Benchmark.md`**: the input/output directory-tree code blocks used Unicode box-drawing (`|--`, `|`, etc., rendered as box-drawing) and one smart-quote apostrophe in "repository's README". The indents also had stray non-breaking spaces (U+00A0) mixed with regular spaces. Replaced the box-drawing with ASCII tree art (`+--`, `|`, `` `-- ``) and the smart quote with ASCII. The file is now ASCII-only.
- **`translate/src/lib.rs`**: two doc-comment locations described the `EmitBuildFeatures` no-op short-circuit as applying to "the entire current TRACTOR corpus". One project (`B02_synthetic/macrodepth_add_5/test_case`) ships a `configuration.json` and so falls outside that claim. Reworded to "the vast majority of the current TRACTOR corpus".

Both changes are doc/comment-only -- no behavior change.

## Test plan

- [x] `cargo check -p harvest_translate --tests` succeeds
- [x] `grep -nP '[^\x00-\x7F]' doc/Benchmark.md` reports nothing
- [ ] CI passes