### PR TITLE
Add `test-clean` make target for fresh-rebuild verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test
+.PHONY: test test-clean
 test:
 	RUSTFLAGS="-D warnings" cargo build
 	RUSTFLAGS="-D warnings" cargo test
@@ -6,3 +6,12 @@ test:
 	cargo fmt --check
 	cd nightly && \
 		RUSTFLAGS="-D warnings" cargo miri test --manifest-path=../Cargo.toml
+
+# Same as `test` but runs `cargo clean` first. Use before pushing changes
+# that modify shared IR struct shapes (e.g. fields on types in
+# tools/build_config/src/ir.rs): cargo's incremental cache has been observed
+# to skip re-typechecking downstream tests when an upstream struct gains a
+# field, hiding compile errors that only surface on a CI fresh checkout.
+test-clean:
+	cargo clean
+	$(MAKE) test

--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ cargo build --release
 If you do not use rustup, you will need a sufficiently-new stable Rust compiler
 (see rust-toolchain.toml for a toolchain version that is known to work).
 
+## Running the test suite
+
+CI runs `make test`, which compiles with `-D warnings`, runs unit and
+integration tests, lints with clippy, checks formatting, and runs miri
+(from the `nightly/` sub-project).
+
+```bash
+make test
+```
+
+If your changes touch shared IR struct shapes (e.g. types in
+`tools/build_config/src/ir.rs`), prefer `make test-clean` before pushing.
+It runs `cargo clean` first to match CI's fresh-checkout behavior;
+without it, cargo's incremental cache can skip re-typechecking
+downstream tests when an upstream struct gains a field, hiding compile
+errors that only surface on CI.
+
+```bash
+make test-clean
+```
+
 ## LLM server
 
 You will also need an LLM server. This can be local, or remote. A couple options


### PR DESCRIPTION
## Summary

Followup #9 from the BuildConfigIR stack. During that stack we hit the same trap twice: local `make test` passed against a worktree but CI failed on a fresh checkout. Both times the root cause was the same -- cargo's incremental cache can skip re-typechecking a downstream test crate when an upstream struct gains a field, so a literal struct construction in a test passes locally (cache hit) and fails in CI (no cache, full rebuild).

This PR adds a small affordance to prevent the trap:

- New `make test-clean` target: runs `cargo clean` then `make test`. Matches CI's fresh-checkout behavior exactly. The existing `make test` is unchanged.
- README: brief "Running the test suite" section documenting both targets and when to prefer `test-clean` (changes that touch shared IR struct shapes, e.g. fields on types in `tools/build_config/src/ir.rs`).

No code or behavior changes.

## Test plan

- [x] `make -n test-clean` expands to `cargo clean` then the full `make test` recipe
- [ ] CI passes