### PR TITLE
Target inventory in BuildConfigIR

### DIFF
--- a/tools/build_config/src/build_rs.rs
+++ b/tools/build_config/src/build_rs.rs
@@ -289,6 +289,7 @@ mod tests {
             source_selections: vec![],
             conditional_targets: vec![],
             subdir_selections: vec![],
+            targets: vec![],
             is_empty: false,
         }
     }

--- a/tools/build_config/src/ir.rs
+++ b/tools/build_config/src/ir.rs
@@ -29,6 +29,14 @@ pub struct BuildConfigIR {
     /// Always empty when [`Self::is_empty`] is `true`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subdir_selections: Vec<SubdirSelection>,
+    /// Every `add_executable` / `add_library` declared at the top level of
+    /// the project, regardless of whether the target's source list also
+    /// participates in a [`SourceSelection`] or [`ConditionalTarget`]. Used by
+    /// [`Self::has_executable_target`] / [`Self::has_library_target`] as the
+    /// primary inventory; the older selection-based heuristics remain as a
+    /// fallback for IRs that pre-date this field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targets: Vec<TargetDecl>,
     pub is_empty: bool,
 }
 
@@ -100,6 +108,27 @@ pub struct SourceVariant {
     pub files: Vec<PathBuf>,
 }
 
+/// One `add_executable` / `add_library` declaration, captured verbatim from
+/// CMake.
+///
+/// `files` lists only the literal paths that the declaration mentions (after
+/// expansion of `set(NAME_SOURCES ...)` accumulators) -- paths that still
+/// contain `${VAR}` placeholders are dropped, because those are tracked by
+/// the per-value variant in [`SourceSelection`] / [`SubdirSelection`].
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TargetDecl {
+    pub name: String,
+    pub kind: TargetKind,
+    pub files: Vec<PathBuf>,
+}
+
+/// Kind of an `add_*` declaration.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum TargetKind {
+    Executable,
+    Library,
+}
+
 /// A target whose entire definition lives inside `if(VAR) ... endif()`.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ConditionalTarget {
@@ -144,38 +173,36 @@ pub struct SubdirVariant {
     /// `add_subdirectory(${VAR})` calls.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subdir_selections: Vec<SubdirSelection>,
+    /// Every `add_executable` / `add_library` declared inside this variant
+    /// subtree. See [`TargetDecl`] for the `files` shape.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targets: Vec<TargetDecl>,
 }
 
 impl BuildConfigIR {
-    /// Returns `true` when the IR records at least one executable target
-    /// (either a `source_selection` with `target` naming an executable, or a
-    /// `conditional_target` that is an executable). When the IR `is_empty` this
-    /// always returns `false` so callers can fall back to legacy line-prefix
-    /// matching in `CMakeLists.txt`.
+    /// Returns `true` when the IR records at least one `add_executable`
+    /// declaration in [`Self::targets`].
     ///
-    /// The heuristic: an executable target is any target whose name does NOT
-    /// look like a library (i.e. it is not already known to be a library via
-    /// `has_library_target`). In practice, the scanner records the raw CMake
-    /// target name and the project kind is determined by the call site that
-    /// actually reads `add_executable` / `add_library` from `CMakeLists.txt`.
+    /// When [`Self::targets`] is populated (the modern path), the answer is
+    /// derived directly from the scanner's record of every `add_executable`
+    /// call. Older IRs that pre-date the `targets` field fall through to the
+    /// selection-based heuristic (a target appearing in `source_selections`
+    /// or in `conditional_targets` without being shadowed by a library).
     ///
-    /// The scanner does not classify targets as executable vs. library -- it
-    /// records them by name as they appear in source-selection /
-    /// conditional-target patterns. This helper therefore acts as a lightweight
-    /// **presence check**: if the IR is non-empty and contains any target that
-    /// is associated with a source-selection or conditional-target entry, the
-    /// project has at least *some* configurable target (executable or library).
-    /// Consumers (`build_project_spec`) use it in conjunction with
-    /// `has_library_target` to decide project kind; when both return `false`
-    /// (empty IR) they fall back to the legacy line-prefix matcher.
+    /// When [`Self::is_empty`] is `true`, this returns `false` unconditionally
+    /// so callers can fall back to legacy line-prefix matching in
+    /// `CMakeLists.txt`.
     pub fn has_executable_target(&self) -> bool {
         if self.is_empty {
             return false;
         }
-        // A non-empty IR with at least one source selection or conditional
-        // target that does not overlap with library targets indicates an
-        // executable. We detect this by checking all known targets and
-        // returning `true` when any target is not a library target.
+        if !self.targets.is_empty() {
+            return self
+                .targets
+                .iter()
+                .any(|t| matches!(t.kind, TargetKind::Executable));
+        }
+        // Fallback: selection-based heuristic for IRs that pre-date `targets`.
         let lib_targets = self.library_targets();
         let all_targets = self.all_target_names();
         all_targets
@@ -184,21 +211,25 @@ impl BuildConfigIR {
             || (!all_targets.is_empty() && lib_targets.is_empty())
     }
 
-    /// Returns `true` when the IR records at least one library target.
+    /// Returns `true` when the IR records at least one `add_library`
+    /// declaration in [`Self::targets`].
     ///
-    /// The scanner marks a target as a library when the CMake pattern was
-    /// `add_library(TARGET ...)`. Because the scanner stores targets by name
-    /// without a kind tag, we apply the naming convention used throughout the
-    /// HARVEST test corpus: a target whose name ends with `_lib` or equals
-    /// the package name suffixed with `_lib`, or any target that appears only
-    /// in `conditional_targets` with a `gate_var` (which typically guard
-    /// optional libraries in `example_P02`).
+    /// When [`Self::targets`] is populated, the answer comes directly from
+    /// the scanner. Older IRs fall through to the heuristic that treats
+    /// conditional-only targets as libraries (see [`Self::library_targets`]).
     ///
-    /// When `is_empty` this returns `false` unconditionally.
+    /// When [`Self::is_empty`] is `true`, this returns `false`.
     pub fn has_library_target(&self) -> bool {
         if self.is_empty {
             return false;
         }
+        if !self.targets.is_empty() {
+            return self
+                .targets
+                .iter()
+                .any(|t| matches!(t.kind, TargetKind::Library));
+        }
+        // Fallback for IRs that pre-date `targets`.
         !self.library_targets().is_empty()
     }
 
@@ -243,12 +274,13 @@ impl fmt::Display for BuildConfigIR {
         }
         write!(
             f,
-            "BuildConfigIR {{ {} vars, {} defines, {} source_selections, {} conditional_targets, {} subdir_selections }}",
+            "BuildConfigIR {{ {} vars, {} defines, {} source_selections, {} conditional_targets, {} subdir_selections, {} targets }}",
             self.variables.len(),
             self.defines.len(),
             self.source_selections.len(),
             self.conditional_targets.len(),
             self.subdir_selections.len(),
+            self.targets.len(),
         )
     }
 }

--- a/tools/build_config/src/scanner.rs
+++ b/tools/build_config/src/scanner.rs
@@ -2630,7 +2630,11 @@ mod tests {
             ("beta/src/lib.c", "// stub\n"),
         ]);
         let ir = scan(&dir);
-        assert!(ir.targets.is_empty(), "top-level targets = {:?}", ir.targets);
+        assert!(
+            ir.targets.is_empty(),
+            "top-level targets = {:?}",
+            ir.targets
+        );
         assert_eq!(ir.subdir_selections.len(), 1);
         let sel = &ir.subdir_selections[0];
         assert_eq!(sel.variants.len(), 2);

--- a/tools/build_config/src/scanner.rs
+++ b/tools/build_config/src/scanner.rs
@@ -15,7 +15,7 @@ use tracing::warn;
 
 use crate::ir::{
     BuildConfigIR, ConditionalTarget, ConfigVarKind, ConfigVariable, DefineKind, DefineMapping,
-    SourceSelection, SourceVariant, SubdirSelection, SubdirVariant,
+    SourceSelection, SourceVariant, SubdirSelection, SubdirVariant, TargetDecl, TargetKind,
 };
 
 /// Top-level entry point. Given the project's `RawDir`, produce a
@@ -62,6 +62,7 @@ pub fn scan(dir: &RawDir) -> BuildConfigIR {
         source_selections: scanned.source_selections,
         conditional_targets: scanned.conditional_targets,
         subdir_selections: scanned.subdir_selections,
+        targets: scanned.targets,
         is_empty: false,
     }
 }
@@ -75,6 +76,7 @@ struct ScannedCmake {
     source_selections: Vec<SourceSelection>,
     conditional_targets: Vec<ConditionalTarget>,
     subdir_selections: Vec<SubdirSelection>,
+    targets: Vec<TargetDecl>,
     /// Variable name -> default value parsed from CMake (`set(... CACHE ...)`
     /// or `option(...)`).
     var_defaults: HashMap<String, Option<String>>,
@@ -299,8 +301,14 @@ fn scan_cmake_file(
                 handle_add_definitions(&stmt.args, known_vars, out, inside_gate);
             }
             "add_library" | "add_executable" => {
+                let kind = if stmt.command == "add_executable" {
+                    TargetKind::Executable
+                } else {
+                    TargetKind::Library
+                };
                 handle_target_definition(
                     &stmt.args,
+                    kind,
                     known_vars,
                     source_lists,
                     rel_dir,
@@ -405,6 +413,7 @@ fn handle_add_subdirectory(
                 source_selections: variant_out.source_selections,
                 conditional_targets: variant_out.conditional_targets,
                 subdir_selections: variant_out.subdir_selections,
+                targets: variant_out.targets,
             });
         }
         if !variants.is_empty() {
@@ -1005,8 +1014,10 @@ fn extract_defines_from_flags(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_target_definition(
     args: &[String],
+    kind: TargetKind,
     known_vars: &HashSet<&str>,
     source_lists: &HashMap<String, Vec<String>>,
     rel_dir: &Path,
@@ -1049,6 +1060,21 @@ fn handle_target_definition(
         // `lib/CMakeLists.txt` like `src/main.c` becomes `lib/src/main.c`.
         file_args.push(prefix_source_path(rel_dir, &text));
     }
+
+    // Record every declaration in `targets`, regardless of how it is later
+    // classified into source_selections / conditional_targets. Literal file
+    // paths only -- `${VAR}` patterns are tracked in their respective
+    // selections, so dropping them here keeps `targets` byte-stable.
+    let literal_files: Vec<PathBuf> = file_args
+        .iter()
+        .filter(|f| !f.contains("${"))
+        .map(PathBuf::from)
+        .collect();
+    out.targets.push(TargetDecl {
+        name: target.clone(),
+        kind,
+        files: literal_files,
+    });
 
     // If a known variable expands within any file path, treat this as a
     // SourceSelection.
@@ -2467,5 +2493,184 @@ mod tests {
         assert_eq!(alpha.files, vec![PathBuf::from("lib/src/backend_alpha.c")]);
         let beta = sel.variants.iter().find(|v| v.value == "beta").unwrap();
         assert_eq!(beta.files, vec![PathBuf::from("lib/src/backend_beta.c")]);
+    }
+
+    // ---------- target inventory (`BuildConfigIR.targets`) ----------
+
+    #[test]
+    fn plain_add_executable_populates_targets() {
+        let dir = build_dir(&[
+            (
+                "configuration.json",
+                r#"{"configurable_variables": {"OP": ["add", "mul"]}}"#,
+            ),
+            (
+                "CMakeLists.txt",
+                "add_executable(driver src/main.c src/util.c)\n",
+            ),
+            ("src/main.c", "// stub\n"),
+            ("src/util.c", "// stub\n"),
+        ]);
+        let ir = scan(&dir);
+        assert_eq!(ir.targets.len(), 1, "ir = {ir}");
+        let t = &ir.targets[0];
+        assert_eq!(t.name, "driver");
+        assert_eq!(t.kind, TargetKind::Executable);
+        assert_eq!(
+            t.files,
+            vec![PathBuf::from("src/main.c"), PathBuf::from("src/util.c")]
+        );
+        assert!(ir.has_executable_target());
+        assert!(!ir.has_library_target());
+    }
+
+    #[test]
+    fn plain_add_library_populates_targets() {
+        let dir = build_dir(&[
+            (
+                "configuration.json",
+                r#"{"configurable_variables": {"OP": ["add"]}}"#,
+            ),
+            ("CMakeLists.txt", "add_library(foo STATIC src/foo.c)\n"),
+            ("src/foo.c", "// stub\n"),
+        ]);
+        let ir = scan(&dir);
+        assert_eq!(ir.targets.len(), 1);
+        let t = &ir.targets[0];
+        assert_eq!(t.name, "foo");
+        assert_eq!(t.kind, TargetKind::Library);
+        assert_eq!(t.files, vec![PathBuf::from("src/foo.c")]);
+        assert!(ir.has_library_target());
+        assert!(!ir.has_executable_target());
+    }
+
+    #[test]
+    fn mixed_executable_and_library_both_recorded() {
+        let dir = build_dir(&[
+            (
+                "configuration.json",
+                r#"{"configurable_variables": {"OP": ["add"]}}"#,
+            ),
+            (
+                "CMakeLists.txt",
+                "add_library(core STATIC src/core.c)\n\
+                 add_executable(driver src/main.c)\n",
+            ),
+            ("src/core.c", "// stub\n"),
+            ("src/main.c", "// stub\n"),
+        ]);
+        let ir = scan(&dir);
+        assert_eq!(ir.targets.len(), 2);
+        assert!(
+            ir.targets
+                .iter()
+                .any(|t| t.name == "core" && t.kind == TargetKind::Library)
+        );
+        assert!(
+            ir.targets
+                .iter()
+                .any(|t| t.name == "driver" && t.kind == TargetKind::Executable)
+        );
+        assert!(ir.has_executable_target());
+        assert!(ir.has_library_target());
+    }
+
+    #[test]
+    fn variant_selected_target_populates_both_targets_and_source_selections() {
+        // `add_library(core ${CORE_SOURCES})` where CORE_SOURCES contains a
+        // `${BACKEND}` pattern: the per-value file list goes into
+        // `source_selections`, while `targets` still records the declaration
+        // (with no literal paths, since the only file path was a `${VAR}`
+        // pattern).
+        let dir = build_dir(&[
+            (
+                "configuration.json",
+                r#"{"configurable_variables": {"BACKEND": ["alpha", "beta"]}}"#,
+            ),
+            (
+                "CMakeLists.txt",
+                "set(BACKEND \"alpha\" CACHE STRING \"doc\")\n\
+                 set(CORE_SOURCES src/backend_${BACKEND}.c)\n\
+                 add_library(core ${CORE_SOURCES})\n",
+            ),
+            ("src/backend_alpha.c", "// stub\n"),
+            ("src/backend_beta.c", "// stub\n"),
+        ]);
+        let ir = scan(&dir);
+        // source_selections still has its variant-per-value entry.
+        assert_eq!(ir.source_selections.len(), 1);
+        assert_eq!(ir.source_selections[0].target, "core");
+        // targets also has the declaration -- with no literal files, because
+        // the only file argument was a `${BACKEND}`-templated path.
+        assert_eq!(ir.targets.len(), 1);
+        assert_eq!(ir.targets[0].name, "core");
+        assert_eq!(ir.targets[0].kind, TargetKind::Library);
+        assert!(ir.targets[0].files.is_empty());
+        assert!(ir.has_library_target());
+    }
+
+    #[test]
+    fn target_inside_variant_subdir_populates_variant_targets_only() {
+        // `add_subdirectory(${BACKEND})` with each variant subdir declaring its
+        // own `add_library`. Variant `targets` get the per-subdir declarations;
+        // the top-level `targets` stays empty.
+        let dir = build_dir(&[
+            (
+                "configuration.json",
+                r#"{"configurable_variables": {"BACKEND": ["alpha", "beta"]}}"#,
+            ),
+            (
+                "CMakeLists.txt",
+                "set(BACKEND \"alpha\" CACHE STRING \"doc\")\n\
+                 add_subdirectory(${BACKEND})\n",
+            ),
+            ("alpha/CMakeLists.txt", "add_library(alpha_lib src/lib.c)\n"),
+            ("alpha/src/lib.c", "// stub\n"),
+            ("beta/CMakeLists.txt", "add_library(beta_lib src/lib.c)\n"),
+            ("beta/src/lib.c", "// stub\n"),
+        ]);
+        let ir = scan(&dir);
+        assert!(ir.targets.is_empty(), "top-level targets = {:?}", ir.targets);
+        assert_eq!(ir.subdir_selections.len(), 1);
+        let sel = &ir.subdir_selections[0];
+        assert_eq!(sel.variants.len(), 2);
+        let alpha = sel.variants.iter().find(|v| v.value == "alpha").unwrap();
+        assert_eq!(alpha.targets.len(), 1);
+        assert_eq!(alpha.targets[0].name, "alpha_lib");
+        assert_eq!(alpha.targets[0].kind, TargetKind::Library);
+        assert_eq!(
+            alpha.targets[0].files,
+            vec![PathBuf::from("alpha/src/lib.c")]
+        );
+        let beta = sel.variants.iter().find(|v| v.value == "beta").unwrap();
+        assert_eq!(beta.targets.len(), 1);
+        assert_eq!(beta.targets[0].name, "beta_lib");
+    }
+
+    #[test]
+    fn b02_macrodepth_shape_has_executable_target_directly() {
+        // Mirrors the shape of Test-Corpus/.../B02_synthetic/macrodepth_add_5:
+        // configuration.json declares vars but the executable target has no
+        // variable in its file list. Before this followup the legacy
+        // line-prefix matcher in `build_project_spec` was needed to identify
+        // it; now `has_executable_target` answers from the IR directly.
+        let dir = build_dir(&[
+            (
+                "configuration.json",
+                r#"{"configurable_variables": {"OP": ["add", "mul"], "REPEAT": ["1", "5"]}}"#,
+            ),
+            (
+                "CMakeLists.txt",
+                "add_executable(driver src/mdcore.c src/mdmain.c)\n",
+            ),
+            ("src/mdcore.c", "// stub\n"),
+            ("src/mdmain.c", "// stub\n"),
+        ]);
+        let ir = scan(&dir);
+        assert!(!ir.is_empty);
+        assert!(
+            ir.has_executable_target(),
+            "should be answerable from `targets`; ir = {ir}"
+        );
     }
 }

--- a/tools/c_ast/tests/parse_to_ast.rs
+++ b/tools/c_ast/tests/parse_to_ast.rs
@@ -67,6 +67,7 @@ fn synthetic_build_config_with_backend() -> BuildConfigIR {
         }],
         conditional_targets: Vec::new(),
         subdir_selections: Vec::new(),
+        targets: Vec::new(),
         is_empty: false,
     }
 }

--- a/tools/emit_build_features/tests/golden.rs
+++ b/tools/emit_build_features/tests/golden.rs
@@ -79,6 +79,7 @@ fn example_p02_ir() -> BuildConfigIR {
         source_selections: vec![],
         conditional_targets: vec![],
         subdir_selections: vec![],
+        targets: vec![],
         is_empty: false,
     }
 }


### PR DESCRIPTION
## Summary

Followup #1 from the BuildConfigIR followups plan. Strictly additive: new fields and types, no breaking changes to existing consumers.

The `BuildConfigIR` previously only recorded targets that participated in variant selection (`source_selections[].target`) or conditional gating (`conditional_targets[].target`). Plain `add_executable(driver src/main.c)` calls outside any variant or `if(VAR)` block were invisible to the IR. `B02_synthetic/macrodepth_add_5` is the canonical example -- the legacy line-prefix matcher in `build_project_spec` caught it as a fallthrough, but the IR could not on its own answer "what targets does this project have?".

This PR adds a generic target inventory to the IR:

- New `TargetDecl { name, kind: TargetKind, files: Vec<PathBuf> }` and `TargetKind { Executable, Library }` types in `tools/build_config/src/ir.rs`.
- New `targets` field on both `BuildConfigIR` and `SubdirVariant`. Both `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so previously-serialized IRs round-trip cleanly.
- Scanner now pushes a `TargetDecl` for every `add_executable` / `add_library` regardless of source-selection / conditional-target classification. Literal file paths only; `${VAR}`-templated paths are dropped because they are already tracked by their matching `SourceSelection` variant per value.
- `has_executable_target` / `has_library_target` consult `targets` first when populated; they fall back to the existing selection-based heuristic for IRs that pre-date this field, and remain `false` under the outermost `is_empty` gate so legacy line-prefix matching in `build_project_spec` still serves projects without a `configuration.json` byte-equally.

The legacy line-prefix matcher fallback in `build_project_spec/src/lib.rs:83-87` remains in place -- it is still load-bearing for `is_empty` IRs (no `configuration.json`). Future cleanup is possible but is not in scope for this strictly-additive change.

This PR is also the foundation for followup #2 (downstream consumption of `SubdirSelection` / `SubdirVariant` by `emit_build_features` / `verify_fix_agentic` / `c_ast`): per-variant target inventory is now queryable via `SubdirVariant.targets`.

## Test plan

- [x] 6 new unit tests in `tools/build_config/src/scanner.rs` (`plain_add_executable_populates_targets`, `plain_add_library_populates_targets`, `mixed_executable_and_library_both_recorded`, `variant_selected_target_populates_both_targets_and_source_selections`, `target_inside_variant_subdir_populates_variant_targets_only`, `b02_macrodepth_shape_has_executable_target_directly`)
- [x] All 263 existing workspace tests still pass
- [x] `cargo clean && make test` from a fresh target dir (the discipline note from BuildConfigIR followup #9) -- the build, test, clippy, and fmt checks all pass cleanly
- [ ] CI passes

## Pre-existing, unrelated test failure

`cargo clean && make test` from a fresh target dir surfaced one pre-existing failure: `c_ast::tests/parse_to_ast::no_config_and_empty_ir_produce_byte_equal_json`. This is **not** introduced by this PR -- the same test fails on `main` at HEAD. The test compares two serialized `RichSourceMap` JSONs that include absolute paths from independently-created tempdirs, so byte-equality is impossible whenever `libclang` is available locally. CI tolerates it (likely libclang misconfiguration causes `parse_to_ast` to return `Err`, and the test silently returns OK under the `let Some(...) = ... else { return };` skip pattern). Worth fixing in a separate PR by either path-normalizing the JSON before comparison or removing the byte-equality assertion in favor of a semantic comparison.