### PR TITLE
Agentic Kiro/Claude switching via core::config::AgentKind

### DIFF
--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -98,6 +98,7 @@ pub fn translate_c_directory_to_rust_project(
         modular,
         agentic,
         agentic_verify,
+        agentic_agent: None,
         repair_passes,
     }
     .into();

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,7 +1,30 @@
+use std::fmt;
 use std::{collections::HashMap, path::PathBuf};
 
 use serde::Deserialize;
 use serde_json::Value;
+
+/// Which external agent to invoke for agentic translation and verification.
+///
+/// `Kiro` is the historical default (`kiro-cli chat ...`). `Claude` invokes
+/// `claude -p ...` instead and uses a different prompt set tuned for that
+/// agent.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentKind {
+    #[default]
+    Kiro,
+    Claude,
+}
+
+impl fmt::Display for AgentKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AgentKind::Kiro => write!(f, "kiro"),
+            AgentKind::Claude => write!(f, "claude"),
+        }
+    }
+}
 
 /// Configuration for this harvest-translate run. The sources of these configuration values (from
 /// highest-precedence to lowest-precedence) are:
@@ -39,6 +62,12 @@ pub struct Config {
     #[serde(default)]
     pub agentic_verify: bool,
 
+    /// Which external agent to use for agentic translation and verification
+    /// (requires `agentic = true`). Defaults to [`AgentKind::Kiro`] for
+    /// backward compatibility.
+    #[serde(default)]
+    pub agentic_agent: AgentKind,
+
     /// Filter describing which log messages should be output to stdout. This is in the
     /// `tracing_subscriber::filter::EnvFilter` format.
     pub log_filter: String,
@@ -73,6 +102,7 @@ impl Config {
             modular: false,
             agentic: false,
             agentic_verify: false,
+            agentic_agent: AgentKind::Kiro,
             log_filter: "off".to_owned(),
             max_repair_passes: 0,
             tools: Default::default(),
@@ -111,6 +141,35 @@ impl Config {
                 backend, model, max_tokens
             )
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_kind_default_is_kiro() {
+        assert_eq!(AgentKind::default(), AgentKind::Kiro);
+    }
+
+    #[test]
+    fn agent_kind_display_matches_serde_lowercase() {
+        assert_eq!(AgentKind::Kiro.to_string(), "kiro");
+        assert_eq!(AgentKind::Claude.to_string(), "claude");
+    }
+
+    #[test]
+    fn agent_kind_deserializes_lowercase() {
+        let kiro: AgentKind = serde_json::from_str("\"kiro\"").unwrap();
+        assert_eq!(kiro, AgentKind::Kiro);
+        let claude: AgentKind = serde_json::from_str("\"claude\"").unwrap();
+        assert_eq!(claude, AgentKind::Claude);
+    }
+
+    #[test]
+    fn mock_config_defaults_agentic_agent_to_kiro() {
+        assert_eq!(Config::mock().agentic_agent, AgentKind::Kiro);
     }
 }
 

--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -10,7 +10,7 @@ use build_config::prompt_ext::build_system_prompt;
 use build_project_spec::{ProjectKind, ProjectSpec};
 use full_source::{CargoPackage, RawSource};
 use harvest_core::cargo_utils::{CargoToml, strip_for_lib};
-use harvest_core::config::unknown_field_warning;
+use harvest_core::config::{AgentKind, unknown_field_warning};
 use harvest_core::fs::RawDir;
 use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
@@ -23,6 +23,7 @@ use tracing::{info, warn};
 
 const PROMPT_EXECUTABLE: &str = include_str!("prompt_executable.md");
 const PROMPT_LIBRARY: &str = include_str!("prompt_library.md");
+const PROMPT_CLAUDE_TRANSLATE: &str = include_str!("prompt_claude_translate.md");
 
 /// Agent-only structural notes appended after the variable-listing section
 /// when `BuildConfigIR.is_empty == false`. Says only the things that are
@@ -93,11 +94,14 @@ impl Tool for TranslateAgentic {
             .get::<BuildConfigIR>(inputs[2])
             .ok_or("No BuildConfigIR representation found in IR")?;
 
+        let agent = context.config.agentic_agent;
         let translate_prompt = load_prompt(
             &config.prompt_executable,
             &config.prompt_library,
+            &config.prompt_claude_translate,
             &project_spec.kind,
             build_cfg,
+            agent,
         )?;
 
         // Set up a working directory that mirrors the layout the agent expects:
@@ -111,7 +115,7 @@ impl Tool for TranslateAgentic {
         info!("Working directory: {}", case_dir.display());
 
         let translated = case_dir.join("translated_rust");
-        invoke_agent(&translated, &translate_prompt, config.timeout_secs)?;
+        invoke_agent(&translated, &translate_prompt, config.timeout_secs, agent)?;
 
         if !translated.join("Cargo.toml").exists() {
             return Err("Agent did not produce a Cargo.toml".into());
@@ -137,32 +141,49 @@ impl Tool for TranslateAgentic {
     }
 }
 
-/// Invokes the translation agent in `work_dir` with the given prompt and timeout.
+/// Invokes the translation agent in `work_dir` with the given prompt and
+/// timeout. The shell command differs per [`AgentKind`]: Kiro invokes
+/// `kiro-cli chat`; Claude invokes `claude -p`.
 fn invoke_agent(
     work_dir: &Path,
     prompt: &str,
     timeout_secs: u64,
+    agent: AgentKind,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Invoking translation agent (timeout={}s)", timeout_secs);
+    info!("Invoking translation agent ({agent}, timeout={timeout_secs}s)");
 
     let logs_dir = work_dir.parent().unwrap_or(work_dir).join("logs");
     fs::create_dir_all(&logs_dir)?;
     let log_path = logs_dir.join("translation.log");
+    let openssl_dir = std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into());
 
-    let status = Command::new("bash")
-        .arg("-c")
-        .arg(format!(
-            "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
-             --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
-        ))
-        .env("PROMPT", prompt)
-        .env("LOG", &log_path)
-        .env(
-            "OPENSSL_DIR",
-            std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into()),
-        )
-        .current_dir(work_dir)
-        .status()?;
+    let status = match agent {
+        AgentKind::Kiro => Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
+                 --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
+            ))
+            .env("PROMPT", prompt)
+            .env("LOG", &log_path)
+            .env("OPENSSL_DIR", &openssl_dir)
+            .current_dir(work_dir)
+            .status()?,
+        AgentKind::Claude => Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                 --allowedTools 'Bash(*)' 'Write' 'Edit' \
+                 --max-turns 50 \
+                 --output-format stream-json --verbose \
+                 < /dev/null 2>&1 | tee \"$LOG\"",
+            ))
+            .env("PROMPT", prompt)
+            .env("LOG", &log_path)
+            .env("OPENSSL_DIR", &openssl_dir)
+            .current_dir(work_dir)
+            .status()?,
+    };
 
     if !status.success() {
         warn!("Translation agent exited with {status}");
@@ -195,42 +216,60 @@ fn post_process(
     Ok(())
 }
 
-/// Loads the translate prompt for the given project kind.
+/// Loads the translate prompt.
 ///
-/// When a config-path override is provided it is used verbatim. Otherwise the
-/// built-in legacy prompt (`prompt_executable.md` / `prompt_library.md`) is
-/// the base, and when `BuildConfigIR.is_empty == false` two extensions are
-/// appended:
+/// Selection depends on [`AgentKind`]:
 ///
-/// 1. The shared configurable-variables section materialized from the IR by
-///    [`build_system_prompt`]. The variable inventory, default values, and
-///    cfg/env attribution rules are listed concretely so the agent does not
-///    have to discover them from `c_src/configuration.json`.
-/// 2. A small set of agent-specific structural notes
-///    ([`AGENTIC_CONSTRAINTS`]) about not writing `build.rs` and emitting
-///    per-variant modules.
+/// - [`AgentKind::Kiro`] (default): the per-kind built-in prompt
+///   (`prompt_executable.md` / `prompt_library.md`) is the base; on a
+///   non-empty `BuildConfigIR` it is extended with the shared
+///   configurable-variables section from [`build_system_prompt`] and the
+///   Kiro-specific [`AGENTIC_CONSTRAINTS`].
+/// - [`AgentKind::Claude`]: the unified `prompt_claude_translate.md` is the
+///   base. It already documents the configurability rules inline, so it is
+///   returned as-is on the empty-IR path. On a non-empty IR the shared
+///   variable-listing section from [`build_system_prompt`] is appended so
+///   the agent sees the concrete variable inventory; the Kiro-only
+///   sub-task-decomposition constraints are not appended (they reference
+///   `kiro-cli` invocations).
 ///
-/// When `is_empty == true` the legacy prompt is returned byte-for-byte.
+/// Tool-config path overrides take precedence within each agent's branch:
+/// `prompt_executable` / `prompt_library` for Kiro, `prompt_claude_translate`
+/// for Claude. When supplied, the override file is returned verbatim and
+/// the caller is responsible for any configurable-variables wording.
 fn load_prompt(
     prompt_executable: &Option<PathBuf>,
     prompt_library: &Option<PathBuf>,
+    prompt_claude_translate: &Option<PathBuf>,
     kind: &ProjectKind,
     build_cfg: &BuildConfigIR,
+    agent: AgentKind,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let (config_path, legacy) = match kind {
-        ProjectKind::Executable => (prompt_executable, PROMPT_EXECUTABLE),
-        ProjectKind::Library => (prompt_library, PROMPT_LIBRARY),
-    };
-    if let Some(p) = config_path {
-        // Config-path overrides are used verbatim -- the caller supplies the
-        // full prompt and is responsible for any configurable-variables wording.
-        return Ok(fs::read_to_string(p)?);
+    match agent {
+        AgentKind::Kiro => {
+            let (config_path, legacy) = match kind {
+                ProjectKind::Executable => (prompt_executable, PROMPT_EXECUTABLE),
+                ProjectKind::Library => (prompt_library, PROMPT_LIBRARY),
+            };
+            if let Some(p) = config_path {
+                return Ok(fs::read_to_string(p)?);
+            }
+            if build_cfg.is_empty {
+                return Ok(legacy.to_owned());
+            }
+            let with_vars = build_system_prompt(legacy, build_cfg);
+            Ok(format!("{with_vars}{AGENTIC_CONSTRAINTS}"))
+        }
+        AgentKind::Claude => {
+            if let Some(p) = prompt_claude_translate {
+                return Ok(fs::read_to_string(p)?);
+            }
+            if build_cfg.is_empty {
+                return Ok(PROMPT_CLAUDE_TRANSLATE.to_owned());
+            }
+            Ok(build_system_prompt(PROMPT_CLAUDE_TRANSLATE, build_cfg))
+        }
     }
-    if build_cfg.is_empty {
-        return Ok(legacy.to_owned());
-    }
-    let with_vars = build_system_prompt(legacy, build_cfg);
-    Ok(format!("{with_vars}{AGENTIC_CONSTRAINTS}"))
 }
 
 #[cfg(test)]
@@ -263,7 +302,15 @@ mod tests {
     /// With an empty IR, the executable path returns the legacy prompt verbatim.
     #[test]
     fn load_prompt_empty_ir_executable_returns_legacy() {
-        let prompt = load_prompt(&None, &None, &ProjectKind::Executable, &empty_ir()).unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &None,
+            &ProjectKind::Executable,
+            &empty_ir(),
+            AgentKind::Kiro,
+        )
+        .unwrap();
         assert_eq!(
             prompt, PROMPT_EXECUTABLE,
             "empty IR must return legacy executable prompt byte-for-byte"
@@ -273,7 +320,15 @@ mod tests {
     /// With an empty IR, the library path returns the legacy prompt verbatim.
     #[test]
     fn load_prompt_empty_ir_library_returns_legacy() {
-        let prompt = load_prompt(&None, &None, &ProjectKind::Library, &empty_ir()).unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &None,
+            &ProjectKind::Library,
+            &empty_ir(),
+            AgentKind::Kiro,
+        )
+        .unwrap();
         assert_eq!(
             prompt, PROMPT_LIBRARY,
             "empty IR must return legacy library prompt byte-for-byte"
@@ -287,7 +342,15 @@ mod tests {
     /// names with the same casing as `BuildConfigIR.variables[].name`.
     #[test]
     fn load_prompt_non_empty_ir_executable_extends_legacy() {
-        let prompt = load_prompt(&None, &None, &ProjectKind::Executable, &non_empty_ir()).unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &None,
+            &ProjectKind::Executable,
+            &non_empty_ir(),
+            AgentKind::Kiro,
+        )
+        .unwrap();
         assert!(
             prompt.starts_with(PROMPT_EXECUTABLE),
             "extended prompt must start with the legacy executable prompt"
@@ -303,7 +366,15 @@ mod tests {
     /// agentic constraints suffix.
     #[test]
     fn load_prompt_non_empty_ir_library_extends_legacy() {
-        let prompt = load_prompt(&None, &None, &ProjectKind::Library, &non_empty_ir()).unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &None,
+            &ProjectKind::Library,
+            &non_empty_ir(),
+            AgentKind::Kiro,
+        )
+        .unwrap();
         assert!(
             prompt.starts_with(PROMPT_LIBRARY),
             "extended prompt must start with the legacy library prompt"
@@ -328,7 +399,15 @@ mod tests {
             }],
             ..Default::default()
         };
-        let prompt = load_prompt(&None, &None, &ProjectKind::Executable, &ir).unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &None,
+            &ProjectKind::Executable,
+            &ir,
+            AgentKind::Kiro,
+        )
+        .unwrap();
         assert!(prompt.contains("#[cfg(feature = \"ENABLE_EXTRA\")]"));
         assert!(!prompt.contains("#[cfg(feature = \"enable_extra\")]"));
     }
@@ -336,7 +415,15 @@ mod tests {
     /// Non-empty IR includes sub-task decomposition guidance (kiro-cli invocation).
     #[test]
     fn load_prompt_non_empty_ir_includes_subtask_decomposition() {
-        let prompt = load_prompt(&None, &None, &ProjectKind::Executable, &non_empty_ir()).unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &None,
+            &ProjectKind::Executable,
+            &non_empty_ir(),
+            AgentKind::Kiro,
+        )
+        .unwrap();
         assert!(
             prompt.contains("kiro-cli chat --no-interactive --trust-all-tools"),
             "agentic constraints must include kiro-cli subagent invocation"
@@ -352,7 +439,15 @@ mod tests {
     /// Empty IR must NOT include the sub-task decomposition guidance.
     #[test]
     fn load_prompt_empty_ir_omits_subtask_decomposition() {
-        let prompt = load_prompt(&None, &None, &ProjectKind::Executable, &empty_ir()).unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &None,
+            &ProjectKind::Executable,
+            &empty_ir(),
+            AgentKind::Kiro,
+        )
+        .unwrap();
         assert!(
             !prompt.contains("kiro-cli chat --no-interactive --trust-all-tools"),
             "empty IR must not include kiro-cli guidance"
@@ -371,15 +466,134 @@ mod tests {
         let prompt = load_prompt(
             &Some(p.clone()),
             &None,
+            &None,
             &ProjectKind::Executable,
             &non_empty_ir(),
+            AgentKind::Kiro,
         )
         .unwrap();
         assert_eq!(prompt, "CUSTOM_PROMPT");
 
         // Same override with empty IR -- still verbatim.
-        let prompt2 = load_prompt(&Some(p), &None, &ProjectKind::Executable, &empty_ir()).unwrap();
+        let prompt2 = load_prompt(
+            &Some(p),
+            &None,
+            &None,
+            &ProjectKind::Executable,
+            &empty_ir(),
+            AgentKind::Kiro,
+        )
+        .unwrap();
         assert_eq!(prompt2, "CUSTOM_PROMPT");
+    }
+
+    // ---------- Claude agent path ----------
+
+    /// Claude path with empty IR returns the unified Claude prompt verbatim,
+    /// regardless of the project kind. The Kiro per-kind prompts are not
+    /// touched.
+    #[test]
+    fn load_prompt_claude_empty_ir_returns_claude_prompt() {
+        for kind in [ProjectKind::Executable, ProjectKind::Library] {
+            let prompt =
+                load_prompt(&None, &None, &None, &kind, &empty_ir(), AgentKind::Claude).unwrap();
+            assert_eq!(
+                prompt, PROMPT_CLAUDE_TRANSLATE,
+                "claude empty-IR must return the unified prompt byte-for-byte ({kind})",
+            );
+        }
+    }
+
+    /// Claude path with non-empty IR appends the configurable-variables
+    /// section from `build_system_prompt`. The Kiro-only sub-task
+    /// decomposition (kiro-cli references) is not appended.
+    #[test]
+    fn load_prompt_claude_non_empty_ir_extends_with_vars_only() {
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &None,
+            &ProjectKind::Executable,
+            &non_empty_ir(),
+            AgentKind::Claude,
+        )
+        .unwrap();
+        assert!(
+            prompt.starts_with(PROMPT_CLAUDE_TRANSLATE),
+            "claude non-empty prompt must start with the unified base",
+        );
+        assert!(prompt.contains("## Configurable variables"));
+        assert!(prompt.contains("#[cfg(BACKEND_alpha)]"));
+        assert!(
+            !prompt.contains("kiro-cli chat --no-interactive --trust-all-tools"),
+            "claude path must not include kiro-cli sub-task decomposition",
+        );
+    }
+
+    /// The Claude config-path override is honored verbatim regardless of IR.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn load_prompt_claude_config_override_is_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("custom_claude.md");
+        fs::write(&p, b"CUSTOM_CLAUDE_PROMPT").unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &Some(p.clone()),
+            &ProjectKind::Library,
+            &non_empty_ir(),
+            AgentKind::Claude,
+        )
+        .unwrap();
+        assert_eq!(prompt, "CUSTOM_CLAUDE_PROMPT");
+
+        let prompt2 = load_prompt(
+            &None,
+            &None,
+            &Some(p),
+            &ProjectKind::Library,
+            &empty_ir(),
+            AgentKind::Claude,
+        )
+        .unwrap();
+        assert_eq!(prompt2, "CUSTOM_CLAUDE_PROMPT");
+    }
+
+    /// The Kiro `prompt_claude_translate` config field is ignored on the
+    /// Kiro path, and vice versa.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn load_prompt_kiro_ignores_claude_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("claude.md");
+        fs::write(&p, b"CLAUDE_OVERRIDE").unwrap();
+        let prompt = load_prompt(
+            &None,
+            &None,
+            &Some(p),
+            &ProjectKind::Executable,
+            &empty_ir(),
+            AgentKind::Kiro,
+        )
+        .unwrap();
+        // Kiro path returns the legacy executable prompt; the Claude-only
+        // override is not consulted.
+        assert_eq!(prompt, PROMPT_EXECUTABLE);
+    }
+
+    /// The Claude prompt asserts the corrected case-preserving rule -- not
+    /// the milestone3 "lowercase" wording that contradicts EmitBuildFeatures.
+    #[test]
+    fn claude_prompt_documents_case_preserving_features() {
+        assert!(
+            !PROMPT_CLAUDE_TRANSLATE.contains("exact same name in lowercase"),
+            "the milestone3 lowercase rule was wrong and must not survive in the ported prompt",
+        );
+        assert!(
+            PROMPT_CLAUDE_TRANSLATE.contains("EmitBuildFeatures"),
+            "the ported Claude prompt should defer the [features] block to EmitBuildFeatures",
+        );
     }
 }
 
@@ -391,6 +605,10 @@ pub struct Config {
 
     /// Override path for the library translation prompt.
     pub prompt_library: Option<PathBuf>,
+
+    /// Override path for the Claude unified translation prompt. Only used
+    /// when `core::config::Config::agentic_agent == AgentKind::Claude`.
+    pub prompt_claude_translate: Option<PathBuf>,
 
     /// Agent timeout in seconds. Defaults to 1800 (30 minutes).
     #[serde(default = "default_timeout_secs")]

--- a/tools/translate_agentic/src/prompt_claude_translate.md
+++ b/tools/translate_agentic/src/prompt_claude_translate.md
@@ -1,0 +1,57 @@
+<!-- markdownlint-disable MD041 -->
+Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
+Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+
+## Step 1: Analyze BEFORE writing any code
+
+Before writing a single line of Rust, you MUST:
+1. Read `c_src/CMakeLists.txt` to understand the build system, source file selection,
+   and any build-time configurability (cache variables, options, conditional compilation)
+2. Read all header files to understand the public API, preprocessor macros, and
+   namespace/symbol renaming patterns
+3. Determine the project type:
+   - Has `main()` -> needs `[[bin]]` with `name = "driver"`
+   - Exports library functions -> needs `[lib]` with `crate-type = ["cdylib"]`
+   - Both -> include both `[lib]` and `[[bin]]` sections
+4. Identify ALL backends/variants if the project has build-time configurability
+
+## Step 2: Plan the translation
+
+If the project has build-time configurability (CMake cache variables selecting different
+source files or parameters):
+- You MUST preserve this using **Cargo features**. If the project ships a
+  `configuration.json`, the `EmitBuildFeatures` tool will write the
+  `[features]` block and `build.rs` for you; do NOT write them yourself. Use
+  the feature names exactly as the tool emits them. For enum-kind variables
+  (`VAR` with values `a`, `b`), gate code with bare cfg attributes such as
+  `#[cfg(VAR_a)]` (NOT `feature = "VAR_a"`). For boolean variables `VAR`,
+  gate with `#[cfg(feature = "VAR")]` using the variable's exact case.
+- ALL combinations of features must compile.
+- Plan which source files map to which features before writing code.
+- Do NOT hardcode a single configuration -- every variant must be implemented.
+
+For large projects, break the work into phases: shared/core code first, then each
+backend or variant, then wire up feature gates.
+
+## Step 3: Translate
+
+- All public C functions must use `#[unsafe(no_mangle)]` and `extern "C"` with exact
+  C signatures (use `*const c_char`, `c_int`, etc. from `std::ffi`)
+- Pay attention to C preprocessor macros that RENAME functions (e.g.,
+  `#define foo NAMESPACE(foo)` makes the linker symbol `PREFIX_foo`, not `foo`).
+  The Rust `#[no_mangle]` name must match the FINAL linker symbol, not the
+  source-level name.
+- Do NOT fix bugs in the original C code -- reproduce behavior exactly
+- Preserve the exact order of error checks and validation
+- Match C's stdin reading behavior exactly (scanf reads across newlines, fgets does not)
+- Match C's exact printf format output including spacing and newlines
+- Do NOT use the `openssl` crate or any OpenSSL bindings -- use pure-Rust crates instead
+- Use safe Rust internally where possible
+
+## Step 4: Verify
+
+Run `cargo build --release` and fix any errors until it compiles.
+If the project has Cargo features, verify ALL feature combinations compile:
+run `cargo build --release --features <feature>` for each one.
+
+Do NOT modify anything in c_src/.

--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -8,7 +8,7 @@
 
 use build_config::{BuildConfigIR, ConfigVarKind, ConfigVariable, DefineKind, DefineMapping};
 use full_source::{CargoPackage, RawSource};
-use harvest_core::config::unknown_field_warning;
+use harvest_core::config::{AgentKind, unknown_field_warning};
 use harvest_core::fs::RawDir;
 use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
@@ -20,6 +20,7 @@ use std::process::Command;
 use tracing::{info, warn};
 
 const PROMPT_VERIFY: &str = include_str!("prompt_verify.md");
+const PROMPT_CLAUDE_VERIFY: &str = include_str!("prompt_claude_verify.md");
 
 pub struct VerifyFixAgentic;
 
@@ -56,12 +57,21 @@ impl Tool for VerifyFixAgentic {
             .get::<BuildConfigIR>(inputs[2])
             .ok_or("No BuildConfigIR representation found in IR")?;
 
-        let verify_prompt = config
-            .prompt_verify
-            .as_ref()
-            .map(fs::read_to_string)
-            .transpose()?
-            .unwrap_or_else(|| PROMPT_VERIFY.to_owned());
+        let agent = context.config.agentic_agent;
+        let verify_prompt = match agent {
+            AgentKind::Kiro => config
+                .prompt_verify
+                .as_ref()
+                .map(fs::read_to_string)
+                .transpose()?
+                .unwrap_or_else(|| PROMPT_VERIFY.to_owned()),
+            AgentKind::Claude => config
+                .prompt_claude_verify
+                .as_ref()
+                .map(fs::read_to_string)
+                .transpose()?
+                .unwrap_or_else(|| PROMPT_CLAUDE_VERIFY.to_owned()),
+        };
 
         // case_dir/
         //   translated_rust/          <- materialized CargoPackage
@@ -82,7 +92,7 @@ impl Tool for VerifyFixAgentic {
             .replace("{CASE_DIR}", &case_dir.to_string_lossy())
             .replace("{CMAKE_BUILD_FLAGS}", &cmake_flags);
 
-        invoke_agent(case_dir, &prompt, config.timeout_secs)?;
+        invoke_agent(case_dir, &prompt, config.timeout_secs, agent)?;
         info!("Verification complete");
 
         // Remove artifacts that should not be carried into the IR.
@@ -102,32 +112,48 @@ impl Tool for VerifyFixAgentic {
     }
 }
 
-/// Invokes the verification agent in `work_dir` with the given prompt and timeout.
+/// Invokes the verification agent in `work_dir` with the given prompt and
+/// timeout. The shell command differs per [`AgentKind`]: Kiro invokes
+/// `kiro-cli chat`; Claude invokes `claude -p`.
 fn invoke_agent(
     work_dir: &Path,
     prompt: &str,
     timeout_secs: u64,
+    agent: AgentKind,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Invoking verification agent (timeout={}s)", timeout_secs);
+    info!("Invoking verification agent ({agent}, timeout={timeout_secs}s)");
 
     let logs_dir = work_dir.join("logs");
     fs::create_dir_all(&logs_dir)?;
     let log_path = logs_dir.join("verify.log");
+    let openssl_dir = std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into());
 
-    let status = Command::new("bash")
-        .arg("-c")
-        .arg(format!(
-            "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
-             --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
-        ))
-        .env("PROMPT", prompt)
-        .env("LOG", &log_path)
-        .env(
-            "OPENSSL_DIR",
-            std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into()),
-        )
-        .current_dir(work_dir)
-        .status()?;
+    let status = match agent {
+        AgentKind::Kiro => Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
+                 --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
+            ))
+            .env("PROMPT", prompt)
+            .env("LOG", &log_path)
+            .env("OPENSSL_DIR", &openssl_dir)
+            .current_dir(work_dir)
+            .status()?,
+        AgentKind::Claude => Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                 --allowedTools 'Bash(*)' 'Write' 'Edit' \
+                 --output-format stream-json --verbose \
+                 < /dev/null 2>&1 | tee \"$LOG\"",
+            ))
+            .env("PROMPT", prompt)
+            .env("LOG", &log_path)
+            .env("OPENSSL_DIR", &openssl_dir)
+            .current_dir(work_dir)
+            .status()?,
+    };
 
     if !status.success() {
         warn!("Verification agent exited with {status}");
@@ -668,13 +694,30 @@ mod tests {
             "flags={flags}"
         );
     }
+
+    /// The Kiro and Claude verify prompts are non-empty and distinct; the
+    /// Claude prompt is the libloading-based oracle comparison while the
+    /// Kiro prompt is the legacy form.
+    #[test]
+    fn claude_and_kiro_verify_prompts_are_distinct_and_nonempty() {
+        assert!(!PROMPT_VERIFY.is_empty());
+        assert!(!PROMPT_CLAUDE_VERIFY.is_empty());
+        assert_ne!(PROMPT_VERIFY, PROMPT_CLAUDE_VERIFY);
+        // The Claude prompt is the libloading/nm-based oracle form.
+        assert!(PROMPT_CLAUDE_VERIFY.contains("libloading"));
+        assert!(PROMPT_CLAUDE_VERIFY.contains("nm -D"));
+    }
 }
 
 /// Tool-specific configuration, read from `[tools.verify_fix_agentic]` in the HARVEST config.
 #[derive(Debug, Deserialize)]
 pub struct Config {
-    /// Override path for the verification prompt.
+    /// Override path for the Kiro verification prompt.
     pub prompt_verify: Option<PathBuf>,
+
+    /// Override path for the Claude verification prompt. Only used when
+    /// `core::config::Config::agentic_agent == AgentKind::Claude`.
+    pub prompt_claude_verify: Option<PathBuf>,
 
     /// Agent timeout in seconds. Defaults to 2700 (45 minutes).
     #[serde(default = "default_timeout_secs")]

--- a/tools/verify_fix_agentic/src/prompt_claude_verify.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify.md
@@ -1,0 +1,41 @@
+<!-- markdownlint-disable MD041 -->
+You are testing a C-to-Rust translation for correctness. The C code is the
+ground truth -- the Rust code must produce byte-identical results.
+
+- `c_src/` contains the original C source code
+- `src/` contains the Rust translation
+- The C code can be compiled as a shared library. Look at c_src/CMakeLists.txt
+  to understand the build system. Build it with:
+  ```
+  cd c_src && mkdir -p build && cd build && \
+  cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON {CMAKE_BUILD_FLAGS} && \
+  cmake --build .
+  ```
+- Find the resulting .so files in the build output
+
+Your task:
+1. Build the C code as a shared library
+2. Write Rust integration tests (in tests/) that use `libloading`
+   to load the C .so and compare C vs Rust function outputs
+3. Start with the lowest-level functions and work upward to higher-level ones.
+   Look at the C headers to identify the public API and function call hierarchy.
+4. For each function: create fixed test inputs, call both C and Rust versions,
+   assert outputs match byte-for-byte
+5. Run `cargo test` and investigate any mismatches
+6. When you find a Rust function that produces different output than C,
+   fix the Rust code in src/ and re-run until the test passes
+7. Keep going until all public functions match
+8. If the project has a main binary, run both the C binary and the Rust binary
+   with the same inputs and compare their stdout byte-for-byte. Fix any differences.
+9. Compare `nm -D` on the C .so and the Rust .so. Every symbol the C .so
+   exports, the Rust .so must also export with the exact same name. This
+   includes symbols created by preprocessor macros. If the C .so exports it,
+   the Rust .so must export it -- no exceptions. Add missing exports.
+
+Add `libloading = "0.8"` to [dev-dependencies] in Cargo.toml.
+Do NOT modify anything in c_src/.
+
+IMPORTANT: Use timeouts for all commands. No single build or test command should
+run longer than 600 seconds. If a test takes too long, skip it and move on to
+the next function. Use `timeout 600 cargo test ...` or similar. Do not get stuck
+on any single step.

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -5,6 +5,7 @@ log_filter = "info"
 modular = false
 agentic = false
 agentic_verify = false
+agentic_agent = "kiro"
 max_repair_passes = 2
 
 [tools.raw_source_to_cargo_llm]

--- a/translate/src/cli.rs
+++ b/translate/src/cli.rs
@@ -4,7 +4,7 @@
 use clap::Parser;
 use config::FileFormat::Toml;
 use directories::ProjectDirs;
-use harvest_core::config::Config;
+use harvest_core::config::{AgentKind, Config};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -32,6 +32,11 @@ pub struct Args {
     /// Run the agentic verify-and-fix stage after translation (requires --agentic).
     #[arg(long, requires = "agentic")]
     pub agentic_verify: bool,
+
+    /// Which external agent to use for agentic translation and verification
+    /// (kiro | claude). Defaults to kiro for backward compatibility.
+    #[arg(long, requires = "agentic", value_parser = parse_agent_kind)]
+    pub agentic_agent: Option<AgentKind>,
 
     /// Path to the directory containing the C code to translate.
     // Should always be present unless using a subcommand like --print-config-path
@@ -120,6 +125,12 @@ fn load_config(args: &Args, config_dir: &Path) -> Config {
             .expect("settings override failed");
     }
 
+    if let Some(agent) = args.agentic_agent {
+        settings = settings
+            .set_override("agentic_agent", agent.to_string())
+            .expect("settings override failed");
+    }
+
     settings = settings
         .set_override("max_repair_passes", args.repair_passes as i64)
         .expect("settings override failed");
@@ -152,6 +163,17 @@ fn load_config(args: &Args, config_dir: &Path) -> Config {
         config.output = output.clone();
     }
     config
+}
+
+/// Parser for the `--agentic-agent` flag's value (`kiro` or `claude`).
+fn parse_agent_kind(s: &str) -> Result<AgentKind, String> {
+    match s.to_lowercase().as_str() {
+        "kiro" => Ok(AgentKind::Kiro),
+        "claude" => Ok(AgentKind::Claude),
+        other => Err(format!(
+            "unknown agent kind: {other} (expected: kiro, claude)"
+        )),
+    }
 }
 
 /// Returns the config file path, given the config directory.


### PR DESCRIPTION
## Summary

Followup #6 from the BuildConfigIR followups plan. Strictly additive: the default is Kiro, every existing prompt and shell invocation is preserved byte-for-byte on that path, and every existing test still asserts the Kiro behavior. Claude is an opt-in via `agentic_agent = "claude"` in the config or `--agentic-agent claude` on the CLI.

### Surface area

- **`core/src/config.rs`**: new `AgentKind { Kiro (default), Claude }` enum derived `Default, Clone, Copy, PartialEq, Eq, Deserialize`, with `#[serde(rename_all = "lowercase")]` and a matching `Display` impl. `Config` gains `agentic_agent: AgentKind` (`#[serde(default)]`). `Config::mock` and the toml default include `kiro`.
- **`translate/src/cli.rs`**: `--agentic-agent <kiro|claude>` flag with a custom parser, `requires = "agentic"`. The CLI value overrides into the settings layer alongside the other agentic flags.
- **`translate/default_config.toml`**: `agentic_agent = "kiro"`.
- **`tools/translate_agentic/src/lib.rs`**: ports `prompt_claude_translate.md` from `origin/milestone3`, with ASCII cleanup (milestone3 file used Unicode arrows and em-dashes) and with the "exact same name in lowercase" rule rewritten to match the current case-preserving / `EmitBuildFeatures`-driven convention. `load_prompt` now dispatches on `AgentKind`:
  - Kiro: per-kind prompt + `build_system_prompt` extension + Kiro-specific `AGENTIC_CONSTRAINTS` (unchanged from current main).
  - Claude: unified prompt + `build_system_prompt` on non-empty IRs. The kiro-cli sub-task-decomposition block is not appended (it references kiro-cli literally).
  `invoke_agent` dispatches the bash invocation per agent (`kiro-cli chat ...` vs `claude -p ... --allowedTools 'Bash(*)' 'Write' 'Edit' --max-turns 50 --output-format stream-json --verbose`). Tool config gains `prompt_claude_translate: Option<PathBuf>`.
- **`tools/verify_fix_agentic/src/lib.rs`**: ports `prompt_claude_verify.md` from `origin/milestone3` (ASCII cleanup). Prompt loading and `invoke_agent` dispatch on `AgentKind`. Tool config gains `prompt_claude_verify: Option<PathBuf>`.
- **`benchmark/src/main.rs`**: `agentic_agent: None` added to the `translate::cli::Args` struct literal (benchmark wraps the same argument struct; `None` defers to the configured default).

### Test plan

- [x] 4 new `core::config` tests covering `AgentKind` default, Display matches the serde lowercase rename, deserialization from `"kiro"` / `"claude"`, and the mock default.
- [x] 5 new `translate_agentic` Claude-path tests:
  - `load_prompt_claude_empty_ir_returns_claude_prompt` (across Executable + Library)
  - `load_prompt_claude_non_empty_ir_extends_with_vars_only` (no kiro-cli sub-task block)
  - `load_prompt_claude_config_override_is_verbatim`
  - `load_prompt_kiro_ignores_claude_override`
  - `claude_prompt_documents_case_preserving_features` (regression-guard against the milestone3 lowercase rule)
- [x] 1 new `verify_fix_agentic` test asserting Kiro vs Claude prompts are distinct and non-empty.
- [x] All 8 existing `translate_agentic` tests + all 9 existing `verify_fix_agentic` tests still pass (anti-regression for the Kiro path).
- [x] `cargo clean && make test` from a fresh target dir is clean (no fmt diff, no clippy warnings, no test failures). The pre-existing `c_ast::tests/parse_to_ast::no_config_and_empty_ir_produce_byte_equal_json` flake noted in #154 is unrelated and only fires with libclang present locally.
- [ ] CI passes

### What was deliberately not ported from milestone3

- The third project kind (`ProjectKind::Configurable`) and its `prompt_configurable.md`. Main absorbs configurability via the existing `Executable` / `Library` kinds plus `BuildConfigIR`-driven prompt extension (see PR #147). The Claude prompt has its configurability guidance inline.
- All other milestone3 divergence (workflow tooling, removed crates, etc.) -- the scope here is exactly the AgentKind enum, the two prompt files, and the dispatch wiring.

### Followups plan status

- **#1 (PR #154), #2a (PR #155), #2b (PR #156), #2c (PR #157), #3 (PR #158)**: merged.
- **#4 CMakePresets unification**: deferred -- sphincs is on track to get its own `configuration.json` and the existing fallback is small.
- **#5 (PR #153), #7 + #8 (PR #151)**: merged.
- **#6 (this PR)**: open.
- **#9**: kept as a local discipline note, no repo change.