### PR TITLE
prompts: mandate cfg-based feature gating for configurable variables

### DIFF
--- a/tools/build_config/src/prompt_ext.rs
+++ b/tools/build_config/src/prompt_ext.rs
@@ -73,6 +73,18 @@ pub fn build_configurable_vars_section(cfg: &BuildConfigIR) -> String {
         }
     }
 
+    out.push_str(
+        "\nWhen a macro or declaration *defines* one of these variables directly (for example \
+        a `#define REPEAT 5` value macro, or a `#define OP add` identifier macro), do NOT \
+        translate it into a single `const`/`static`, and do NOT read it via `env!`. Instead \
+        either omit it and cfg-gate the items that use it, or emit one cfg-gated definition per \
+        value. For a numeric variable `REPEAT` with values 0..6 that means:\n\n\
+        #[cfg(REPEAT_0)] const REPEAT: i32 = 0;\n\
+        // ... one gated arm per value ...\n\
+        #[cfg(REPEAT_6)] const REPEAT: i32 = 6;\n\n\
+        This applies even when each declaration is translated in isolation.\n",
+    );
+
     if !cfg.defines.is_empty() {
         out.push('\n');
         out.push_str(
@@ -214,5 +226,7 @@ mod tests {
         assert!(result.contains("do NOT hardcode a single"));
         // Enum guidance explicitly rules out env! as the selection mechanism.
         assert!(result.contains("NOT `env!`"));
+        // Value-defining macros must become cfg-gated definitions, not env! consts.
+        assert!(result.contains("*defines* one of these variables directly"));
     }
 }

--- a/tools/build_config/src/prompt_ext.rs
+++ b/tools/build_config/src/prompt_ext.rs
@@ -38,8 +38,13 @@ pub fn build_configurable_vars_section(cfg: &BuildConfigIR) -> String {
     );
 
     out.push_str(
-        "Apply the following rules when translating `#ifdef`/`#if` guards that test \
-        these variables:\n\n",
+        "Select configurable behavior at compile time using `#[cfg(...)]` gating only. \
+        Emit a gated definition for EVERY value of each variable -- do NOT hardcode a single \
+        default value, and do NOT read a variable's value through `env!(...)` or any \
+        environment variable that `build.rs` may emit, even for numeric variables. The \
+        configuration contract is the Cargo feature cfgs; the translated code must change \
+        behavior when a different feature is selected. Apply the following rules when \
+        translating `#ifdef`/`#if` guards that test these variables:\n\n",
     );
 
     for var in &cfg.variables {
@@ -56,8 +61,10 @@ pub fn build_configurable_vars_section(cfg: &BuildConfigIR) -> String {
                     .map(|v| format!("`#[cfg({name}_{v})]`", name = var.name))
                     .collect();
                 out.push_str(&format!(
-                    "- `{name}` (enum, values: {values}): use bare cfg -- {variants} \
-                    (NOT `feature = ...`)\n",
+                    "- `{name}` (enum, values: {values}): select the value with bare cfg -- \
+                    {variants} (NOT `feature = ...`, and NOT `env!`). Provide one \
+                    `#[cfg({name}_<value>)]`-gated item (e.g. a `const`, `fn`, or `use`) per \
+                    value rather than reading the value dynamically.\n",
                     name = var.name,
                     values = values.join(", "),
                     variants = variants.join(" / "),
@@ -197,5 +204,15 @@ mod tests {
     fn no_features_block_instruction() {
         let result = build_system_prompt(BASE_PROMPT, &nonempty_ir());
         assert!(result.contains("do NOT write a `[features]` block"));
+    }
+
+    /// Variables must be gated on cfg, not hardcoded and not read via env!/build-script vars.
+    #[test]
+    fn variables_mandate_cfg_not_env_or_hardcode() {
+        let result = build_system_prompt(BASE_PROMPT, &nonempty_ir());
+        assert!(result.contains("`#[cfg(...)]` gating only"));
+        assert!(result.contains("do NOT hardcode a single"));
+        // Enum guidance explicitly rules out env! as the selection mechanism.
+        assert!(result.contains("NOT `env!`"));
     }
 }

--- a/tools/modular_translation_llm/src/translation_llm.rs
+++ b/tools/modular_translation_llm/src/translation_llm.rs
@@ -141,35 +141,42 @@ impl ModularTranslationLLM {
     /// Initializes separate HarvestLLM instances for each type of translation task with the
     /// appropriate system prompts and structured output schemas.
     ///
-    /// When `build_cfg.is_empty == false`, the cargo_toml system prompt is extended with a
-    /// configurable-variables section that instructs the LLM not to write a `[features]` block
-    /// (since `EmitBuildFeatures` owns that) and teaches it the cfg/env rules for each variable.
+    /// When `build_cfg.is_empty == false`, every per-declaration system prompt is extended
+    /// with a configurable-variables section that teaches the LLM the cfg gating rules for
+    /// each variable (and, for the cargo_toml prompt, not to write a `[features]` block since
+    /// `EmitBuildFeatures` owns that). The macros/types/functions/interface prompts need this
+    /// too: that is where the cfg-gated declarations are actually emitted, so without it those
+    /// translations hardcode the default configuration. When the IR is empty the extension is
+    /// a no-op and each prompt is byte-identical to its static base.
     pub fn build(
         config: &Config,
         build_cfg: &BuildConfigIR,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        let macros_system_prompt = build_system_prompt(SYSTEM_PROMPT_MACROS, build_cfg);
         let macros_llm = HarvestLLM::build(
             &config.llm,
             STRUCTURED_OUTPUT_SCHEMA_MACROS,
-            SYSTEM_PROMPT_MACROS,
+            &macros_system_prompt,
         )?;
+        let types_system_prompt = build_system_prompt(SYSTEM_PROMPT_TYPES, build_cfg);
         let types_llm = HarvestLLM::build(
             &config.llm,
             STRUCTURED_OUTPUT_SCHEMA_TYPES,
-            SYSTEM_PROMPT_TYPES,
+            &types_system_prompt,
         )?;
+        let functions_system_prompt = build_system_prompt(SYSTEM_PROMPT_FUNCTIONS, build_cfg);
         let functions_llm = HarvestLLM::build(
             &config.llm,
             STRUCTURED_OUTPUT_SCHEMA_FUNCTIONS,
-            SYSTEM_PROMPT_FUNCTIONS,
+            &functions_system_prompt,
         )?;
+        let interface_system_prompt = build_system_prompt(SYSTEM_PROMPT_INTERFACE, build_cfg);
         let interface_llm = HarvestLLM::build(
             &config.llm,
             STRUCTURED_OUTPUT_SCHEMA_INTERFACE,
-            SYSTEM_PROMPT_INTERFACE,
+            &interface_system_prompt,
         )?;
-        // Build the cargo_toml system prompt programmatically: start with the static base,
-        // then append the configurable-variables section only when the IR is non-empty.
+        // The cargo_toml prompt additionally gains the "do not write [features]" guidance.
         let cargo_toml_system_prompt = build_system_prompt(SYSTEM_PROMPT_CARGO_TOML, build_cfg);
         let cargo_toml_llm = HarvestLLM::build(
             &config.llm,


### PR DESCRIPTION
Tightens how the LLM translation paths handle configurable variables (declared in a project's `configuration.json`), based on observed behavior on `B02_synthetic/macrodepth_*`. Two commits.

## Problem

On a configurable example (`OP` enum + `REPEAT` numeric enum), the two LLM paths mishandled the configuration:

- **all-at-once** gated the enum operation on `#[cfg(OP_*)]` correctly, but read the numeric `REPEAT` through `env!("REPEAT")` -- a build-script side-channel that `build.rs` happens to emit -- instead of `#[cfg(REPEAT_n)]`.
- **modular** ignored the configurable variables and hardcoded the default, because the configurable-variables prompt section was only appended to the `cargo_toml` sub-prompt -- not the macros/types/functions/interface sub-prompts where cfg-gated declarations are emitted. Even after that was fixed, the macros pass still emitted `const OP = env!("OP")` / `const REPEAT = env!("REPEAT")` for the macros that *define* a variable's value, because it translates each declaration in isolation.

## Changes

1. **Shared prompt section** (`build_config::prompt_ext`): mandates compile-time `#[cfg(...)]` gating, requires a gated definition for every value (no hardcoding a single default), and forbids reading a variable's value via `env!(...)` / build.rs-emitted env vars. The legitimate `env!` path for string-valued `defines` is unchanged.
2. **Modular translation** (`modular_translation_llm`): the configurable-variables section is now appended to the macros/types/functions/interface sub-prompts as well.
3. **Value-defining macros**: explicit guidance + a cfg-ladder example for the case where a macro/declaration defines a configurable variable directly (omit and cfg-gate dependents, or one `#[cfg(NAME_value)]` definition per value -- never a single const or an `env!` read).

## Anti-regression

When a project has no `configuration.json`, the `BuildConfigIR` is empty and the prompt extension is a no-op, so every existing TRACTOR corpus project receives byte-identical prompts. Existing byte-equality tests still pass; new tests assert the cfg-only / no-env! / no-hardcode / value-macro mandates.

## Validation (`macrodepth_add_5`)

- all-at-once: `REPEAT` now gated on `#[cfg(REPEAT_n)]`, zero `env!`.
- modular: `OP`/`REPEAT` emitted as cfg-gated ladders (`#[cfg(OP_add)] const OP = "add"`, `#[cfg(REPEAT_5)] const REPEAT: i32 = 5`, ...), zero `env!`, 65 cfg uses (was 0).

Out of scope: a separate, strategy-independent bug in translating the unrolled `REP0..REP6`/`RUN_LOOP` accumulator macros (accumulator computes to 0) still fails this case's tests; that is not a configuration issue.