### PR TITLE
prompts: gate value-defining config macros on cfg instead of env!

### DIFF
--- a/tools/build_config/src/prompt_ext.rs
+++ b/tools/build_config/src/prompt_ext.rs
@@ -73,6 +73,18 @@ pub fn build_configurable_vars_section(cfg: &BuildConfigIR) -> String {
         }
     }
 
+    out.push_str(
+        "\nWhen a macro or declaration *defines* one of these variables directly (for example \
+        a `#define REPEAT 5` value macro, or a `#define OP add` identifier macro), do NOT \
+        translate it into a single `const`/`static`, and do NOT read it via `env!`. Instead \
+        either omit it and cfg-gate the items that use it, or emit one cfg-gated definition per \
+        value. For a numeric variable `REPEAT` with values 0..6 that means:\n\n\
+        #[cfg(REPEAT_0)] const REPEAT: i32 = 0;\n\
+        // ... one gated arm per value ...\n\
+        #[cfg(REPEAT_6)] const REPEAT: i32 = 6;\n\n\
+        This applies even when each declaration is translated in isolation.\n",
+    );
+
     if !cfg.defines.is_empty() {
         out.push('\n');
         out.push_str(
@@ -214,5 +226,7 @@ mod tests {
         assert!(result.contains("do NOT hardcode a single"));
         // Enum guidance explicitly rules out env! as the selection mechanism.
         assert!(result.contains("NOT `env!`"));
+        // Value-defining macros must become cfg-gated definitions, not env! consts.
+        assert!(result.contains("*defines* one of these variables directly"));
     }
 }


### PR DESCRIPTION
Stacked on #163 (base is that branch; retarget to `main` once #163 merges).

Follow-up addressing the known gap noted in #163: the modular path still emitted `const OP = env!("OP")` / `const REPEAT = env!("REPEAT")` for the macros that *define* a configurable variable's value (e.g. `#define REPEAT 5`). The modular macros pass translates each declaration in isolation, and its own `#define MAX_LEN 1024 -> const` example pulls toward a single const, which it then made configurable via `env!`.

## Change

Extends the shared configurable-variables prompt section with explicit guidance (and a cfg-ladder example) for the case where a macro/declaration defines a configurable variable directly: omit it and cfg-gate the dependents, or emit one `#[cfg(NAME_value)]` definition per value -- never a single const or an `env!` read, even when each declaration is translated in isolation. Adds a test asserting the guidance is present.

## Validation

On `macrodepth_add_5` (modular): the `env!` consts are gone; `OP` and `REPEAT` are now emitted as cfg-gated ladders:

```
#[cfg(OP_add)] const OP: &str = "add";
#[cfg(OP_sub)] const OP: &str = "sub";
#[cfg(OP_mul)] const OP: &str = "mul";
#[cfg(REPEAT_0)] const REPEAT: i32 = 0;
// ...
#[cfg(REPEAT_6)] const REPEAT: i32 = 6;
```

The remaining test failure on this case is a separate, strategy-independent bug in translating the unrolled `REP0..REP6` / `RUN_LOOP` accumulator macros (the accumulator computes to 0), not a configuration issue.