### PR TITLE
agentic: hand the agent a deterministic project scaffold (crate name + toolchain)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,6 +3175,7 @@ version = "0.1.0"
 dependencies = [
  "build_config",
  "build_project_spec",
+ "emit_build_features",
  "full_source",
  "harvest_core",
  "serde",

--- a/core/src/cargo_utils.rs
+++ b/core/src/cargo_utils.rs
@@ -293,6 +293,17 @@ impl CargoToml {
         }
     }
 
+    /// Returns `true` if the manifest already declares a non-empty `[features]`
+    /// table. Used to make feature emission idempotent: a manifest that already
+    /// carries features (e.g. one produced by a pre-translation scaffold) should
+    /// not have them re-applied.
+    pub fn has_features(&self) -> bool {
+        self.doc
+            .get("features")
+            .and_then(|f| f.as_table())
+            .is_some_and(|t| !t.is_empty())
+    }
+
     /// Sets `[package].build = "<script>"`. Idempotent: replaces any existing value.
     pub fn set_build_script(&mut self, script: &str) {
         let pkg = self

--- a/tools/emit_build_features/src/lib.rs
+++ b/tools/emit_build_features/src/lib.rs
@@ -111,34 +111,17 @@ pub fn apply(
         .to_vec();
     let mut cargo = CargoToml::from_bytes(&cargo_bytes)?;
 
-    // 1. Surface every variable as one or more Cargo features.
-    let mut feature_names: Vec<String> = Vec::new();
-    for var in &cfg.variables {
-        match &var.kind {
-            ConfigVarKind::Boolean => feature_names.push(var.name.clone()),
-            ConfigVarKind::Enum { values, .. } => {
-                for v in values {
-                    feature_names.push(format!("{}_{}", var.name, v));
-                }
-            }
-        }
-    }
-    cargo.add_features(feature_names);
-
-    // 2. Compute the default feature set: pick each variable's default value
-    //    (or, for enums lacking one, fall back to the first listed value so
-    //    builds still produce something).
-    let defaults = default_features(&cfg.variables);
-    cargo.set_default_features(&defaults);
-
-    // 3. If anything in the IR needs a build script (any enum variable, or any
-    //    non-trivial define), wire one up.
-    let needs_build_rs = needs_build_script(cfg);
-    if needs_build_rs {
-        cargo.set_build_script("build.rs");
+    // Idempotency: a manifest that already declares features was produced by a
+    // pre-translation scaffold; re-applying would duplicate keys. Leave it as-is.
+    if cargo.has_features() {
+        debug!("emit_build_features: Cargo.toml already declares features; passing through");
+        return Ok(Box::new(cargo_package));
     }
 
-    // 4. Write the updated Cargo.toml back into the in-memory package.
+    // Apply the feature/build-script wiring, capturing the build.rs to render.
+    let build_rs = apply_features_to_cargo(&mut cargo, cfg);
+
+    // Write the updated Cargo.toml back into the in-memory package.
     let new_cargo = cargo.into_bytes();
     let cargo_slot = cargo_package
         .dir
@@ -146,10 +129,9 @@ pub fn apply(
         .map_err(|e| format!("emit_build_features: failed to mutate Cargo.toml: {e}"))?;
     *cargo_slot = new_cargo;
 
-    // 5. Render and write build.rs (if needed). We tolerate a pre-existing
-    //    build.rs by overwriting it in place.
-    if needs_build_rs {
-        let rendered = render_build_rs(cfg);
+    // Render and write build.rs (if needed). We tolerate a pre-existing
+    // build.rs by overwriting it in place.
+    if let Some(rendered) = build_rs {
         let bytes = rendered.into_bytes();
         if cargo_package.dir.get_file("build.rs").is_ok() {
             let slot = cargo_package
@@ -163,6 +145,40 @@ pub fn apply(
     }
 
     Ok(Box::new(cargo_package))
+}
+
+/// Applies the configurable-variables features and build-script wiring to
+/// `cargo` in place, returning the `build.rs` content to write if one is
+/// needed (`None` when no build script is required, e.g. boolean-only configs).
+///
+/// Shared by [`apply`] and the pre-translation project scaffold in
+/// `translate_agentic` so the two paths cannot drift. Safe to call with an
+/// empty IR (it simply makes no changes and returns `None`).
+pub fn apply_features_to_cargo(cargo: &mut CargoToml, cfg: &BuildConfigIR) -> Option<String> {
+    // Surface every variable as one or more Cargo features.
+    let mut feature_names: Vec<String> = Vec::new();
+    for var in &cfg.variables {
+        match &var.kind {
+            ConfigVarKind::Boolean => feature_names.push(var.name.clone()),
+            ConfigVarKind::Enum { values, .. } => {
+                for v in values {
+                    feature_names.push(format!("{}_{}", var.name, v));
+                }
+            }
+        }
+    }
+    cargo.add_features(feature_names);
+
+    // Default feature set from each variable's recorded default.
+    cargo.set_default_features(&default_features(&cfg.variables));
+
+    // Wire a build script when any enum (or non-trivial define) needs cfg emission.
+    if needs_build_script(cfg) {
+        cargo.set_build_script("build.rs");
+        Some(render_build_rs(cfg))
+    } else {
+        None
+    }
 }
 
 /// True iff the IR requires a generated `build.rs`. Booleans alone do not -- the

--- a/tools/translate_agentic/Cargo.toml
+++ b/tools/translate_agentic/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 build_config.workspace = true
 build_project_spec.workspace = true
+emit_build_features.workspace = true
 full_source.workspace = true
 harvest_core.workspace = true
 serde.workspace = true

--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -9,7 +9,7 @@ use build_config::BuildConfigIR;
 use build_config::prompt_ext::build_system_prompt;
 use build_project_spec::{ProjectKind, ProjectSpec};
 use full_source::{CargoPackage, RawSource};
-use harvest_core::cargo_utils::{CargoToml, strip_for_lib};
+use harvest_core::cargo_utils::{CargoToml, sanitize_package_name, strip_for_lib};
 use harvest_core::config::{AgentKind, unknown_field_warning};
 use harvest_core::fs::RawDir;
 use harvest_core::tools::{RunContext, Tool};
@@ -115,6 +115,15 @@ impl Tool for TranslateAgentic {
         info!("Working directory: {}", case_dir.display());
 
         let translated = case_dir.join("translated_rust");
+
+        // Pre-generate a deterministic project scaffold (Cargo.toml with the
+        // canonical crate name, build.rs, rust-toolchain.toml) so the agent
+        // writes its sources against the final crate name from the start. This
+        // avoids the post-hoc `normalize_name` rename in `try_cargo_build`
+        // breaking the agent's `use <crate>::` imports.
+        let canonical_name = canonical_crate_name(&context.config.output);
+        write_project_scaffold(&translated, &canonical_name, &project_spec.kind, build_cfg)?;
+
         invoke_agent(&translated, &translate_prompt, config.timeout_secs, agent)?;
 
         if !translated.join("Cargo.toml").exists() {
@@ -188,6 +197,54 @@ fn invoke_agent(
     if !status.success() {
         warn!("Translation agent exited with {status}");
     }
+    Ok(())
+}
+
+/// Pinned Rust toolchain for the generated project, so it builds reproducibly
+/// rather than against whatever toolchain happens to be the default.
+const RUST_TOOLCHAIN_TOML: &str = "[toolchain]\nchannel = \"1.93.0\"\n";
+
+/// The canonical crate name for the translated project: the sanitized basename
+/// of the output directory. This matches what `try_cargo_build`'s
+/// `normalize_name` would later impose, so handing it to the agent up front
+/// keeps the agent's `use <crate>::` imports consistent with the final name.
+fn canonical_crate_name(output: &Path) -> String {
+    let raw = output.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let name = sanitize_package_name(raw);
+    if name.is_empty() {
+        "translated_crate".to_string()
+    } else {
+        name
+    }
+}
+
+/// Writes a deterministic project scaffold into `dir`: a `Cargo.toml` carrying
+/// the canonical package/lib name, the `[lib]`/`[[bin]]` section for the
+/// [`ProjectKind`], and the configurable-variables `[features]`; a `build.rs`
+/// when the config needs one; and a pinned `rust-toolchain.toml`. The agent is
+/// told to preserve these and write only `src/`.
+fn write_project_scaffold(
+    dir: &Path,
+    canonical_name: &str,
+    kind: &ProjectKind,
+    build_cfg: &BuildConfigIR,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let base = format!(
+        "[package]\nname = \"{canonical_name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"
+    );
+    let mut cargo = CargoToml::from_bytes(base.as_bytes())?;
+    match kind {
+        ProjectKind::Library => cargo.set_lib(canonical_name),
+        ProjectKind::Executable => cargo.set_bin_driver(),
+    }
+    cargo.add_workspace();
+    let build_rs = emit_build_features::apply_features_to_cargo(&mut cargo, build_cfg);
+
+    fs::write(dir.join("Cargo.toml"), cargo.into_bytes())?;
+    if let Some(rendered) = build_rs {
+        fs::write(dir.join("build.rs"), rendered)?;
+    }
+    fs::write(dir.join("rust-toolchain.toml"), RUST_TOOLCHAIN_TOML)?;
     Ok(())
 }
 
@@ -582,8 +639,9 @@ mod tests {
         assert_eq!(prompt, PROMPT_EXECUTABLE);
     }
 
-    /// The Claude prompt asserts the corrected case-preserving rule -- not
-    /// the milestone3 "lowercase" wording that contradicts EmitBuildFeatures.
+    /// The Claude prompt asserts the corrected case-preserving rule -- not the
+    /// milestone3 "lowercase" wording -- and defers the `[features]` block to the
+    /// pre-generated scaffold rather than asking the agent to author it.
     #[test]
     fn claude_prompt_documents_case_preserving_features() {
         assert!(
@@ -591,8 +649,8 @@ mod tests {
             "the milestone3 lowercase rule was wrong and must not survive in the ported prompt",
         );
         assert!(
-            PROMPT_CLAUDE_TRANSLATE.contains("EmitBuildFeatures"),
-            "the ported Claude prompt should defer the [features] block to EmitBuildFeatures",
+            PROMPT_CLAUDE_TRANSLATE.contains("already contains the `[features]` block"),
+            "the Claude prompt should state the [features] block is provided by the scaffold",
         );
     }
 }

--- a/tools/translate_agentic/src/prompt_claude_translate.md
+++ b/tools/translate_agentic/src/prompt_claude_translate.md
@@ -1,6 +1,14 @@
 <!-- markdownlint-disable MD041 -->
 Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
-Write Cargo.toml and src/ files in the current directory (NOT in c_src/).
+
+A project scaffold is **already provided** in the current directory: a `Cargo.toml`
+(with the crate name, the `[lib]`/`[[bin]]` target, and any `[features]` block),
+a `build.rs` (if the project is configurable), and a `rust-toolchain.toml`. Do
+**NOT** modify, recreate, or delete these files. Write only the Rust source files
+under `src/`. Read the provided `Cargo.toml` first to learn the exact crate name
+and targets — reference items within the crate via `crate::`/`mod`, and if you
+must name the crate (e.g. from a `[[bin]]` target) use the exact name from that
+`Cargo.toml`. Do not invent a different crate name.
 
 ## Step 1: Analyze BEFORE writing any code
 
@@ -9,20 +17,19 @@ Before writing a single line of Rust, you MUST:
    and any build-time configurability (cache variables, options, conditional compilation)
 2. Read all header files to understand the public API, preprocessor macros, and
    namespace/symbol renaming patterns
-3. Determine the project type:
-   - Has `main()` -> needs `[[bin]]` with `name = "driver"`
-   - Exports library functions -> needs `[lib]` with `crate-type = ["cdylib"]`
-   - Both -> include both `[lib]` and `[[bin]]` sections
+3. Read the provided `Cargo.toml` to learn the crate name and whether the target
+   is a `[[bin]]` (`name = "driver"`), a `[lib]`, or both — this is already set
+   for you; match your `src/` layout to it (`src/main.rs` for a bin, `src/lib.rs`
+   for a lib).
 4. Identify ALL backends/variants if the project has build-time configurability
 
 ## Step 2: Plan the translation
 
 If the project has build-time configurability (CMake cache variables selecting different
 source files or parameters):
-- You MUST preserve this using **Cargo features**. If the project ships a
-  `configuration.json`, the `EmitBuildFeatures` tool will write the
-  `[features]` block and `build.rs` for you; do NOT write them yourself. Use
-  the feature names exactly as the tool emits them. For enum-kind variables
+- You MUST preserve this using **Cargo features**. The provided `Cargo.toml`
+  already contains the `[features]` block and a `build.rs` — do NOT modify them.
+  Use the feature names exactly as written there. For enum-kind variables
   (`VAR` with values `a`, `b`), gate code with bare cfg attributes such as
   `#[cfg(VAR_a)]` (NOT `feature = "VAR_a"`). For boolean variables `VAR`,
   gate with `#[cfg(feature = "VAR")]` using the variable's exact case.


### PR DESCRIPTION
## Problem

On a real configurable codebase (SPHINCS+), agentic Claude produced a complete, correct translation that **failed to build over a single crate-naming mismatch**: it wrote an internally-consistent crate named `sphincs_plus` (`use sphincs_plus::...`), but `try_cargo_build`'s `normalize_name` then renamed `[package]`/`[lib]` to the sanitized output-dir basename (`_005_...`) *after* translation — without rewriting the `use` statements. 13 cascading errors, all from that one rename.

## Fix

Hand the agent the canonical name up front. Before invoking the agent, `translate_agentic` writes a **deterministic project scaffold** into the working directory and the prompt instructs the agent to preserve it and write only `src/`:

- `Cargo.toml` — canonical `[package]`/`[lib]` name (exactly what `normalize_name` would impose, so that later call becomes a no-op), the `[lib]`/`[[bin]]` target for the `ProjectKind`, and the configurable-variables `[features]`;
- `build.rs` — when the config needs one;
- `rust-toolchain.toml` — pins the toolchain so generated crates build reproducibly (**closes #160** for the agentic path).

The `[features]`/`build.rs` derivation is factored out of `emit_build_features` into a shared `apply_features_to_cargo`, and `emit_build_features` now **skips a manifest that already declares features** (`CargoToml::has_features`) — so the unconditional `EmitBuildFeatures` pass after translation is a no-op on scaffolded projects, and `normalize_name` is a no-op because the name already matches.

## Scope / safety

- **Agentic (Claude) only.** Non-agentic pipelines are unchanged: no scaffold, they still generate `Cargo.toml`, and `EmitBuildFeatures` applies features as before (their LLM-generated manifest has no `[features]`, so the idempotency guard doesn't trip). Unifying the LLM pipelines onto the same scaffold is a planned follow-up.
- The prompt now tells the agent the scaffold files are provided, to read the crate name from `Cargo.toml`, and to use `crate::`/`mod` (or the exact crate name) — never invent a name.

## Tests

`cargo fmt --check` clean; unit tests pass for `harvest_core`, `emit_build_features`, `translate_agentic` (incl. updated prompt-content test and the shared-helper refactor). End-to-end validation is a fresh agentic SPHINCS+ run (pending) — the prior run built correctly in all 48 configs after exactly the one-line rename this scaffold makes unnecessary.