### PR TITLE
agentic: port large-codebase PLAN.md methodology (phase 1: translate prompt)

### DIFF
--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -184,11 +184,19 @@ fn invoke_agent(
                 "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
                  --permission-mode bypassPermissions \
                  --allowedTools 'Bash(*)' 'Write' 'Edit' \
+                 --append-system-prompt \"$APPEND_SYS\" \
                  --output-format stream-json --verbose \
                  < /dev/null 2>&1 | tee \"$LOG\"",
             ))
             .env("PROMPT", prompt)
             .env("LOG", &log_path)
+            // Survives context compaction: the lossy summary retains this line,
+            // so the agent re-reads PLAN.md (its durable plan) before resuming.
+            .env(
+                "APPEND_SYS",
+                "After any context compaction, you MUST re-read PLAN.md (if it exists) \
+                 before doing anything else, and resume from the first unchecked subtask.",
+            )
             .env("OPENSSL_DIR", &openssl_dir)
             .current_dir(work_dir)
             .status()?,
@@ -649,8 +657,13 @@ mod tests {
             "the milestone3 lowercase rule was wrong and must not survive in the ported prompt",
         );
         assert!(
-            PROMPT_CLAUDE_TRANSLATE.contains("already contains the `[features]` block"),
+            PROMPT_CLAUDE_TRANSLATE.contains("are already written for you"),
             "the Claude prompt should state the [features] block is provided by the scaffold",
+        );
+        // Anti-compaction methodology must be present.
+        assert!(
+            PROMPT_CLAUDE_TRANSLATE.contains("PLAN.md"),
+            "the Claude prompt should describe the PLAN.md anti-compaction mechanism",
         );
     }
 }

--- a/tools/translate_agentic/src/prompt_claude_translate.md
+++ b/tools/translate_agentic/src/prompt_claude_translate.md
@@ -1,72 +1,384 @@
 <!-- markdownlint-disable MD041 -->
 Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
+A project scaffold is **already provided** in the current directory (the Rust
+project root, NOT inside `c_src/`): a `Cargo.toml` (with the crate name, the
+`[lib]`/`[[bin]]` target, and any `[features]` block), a `build.rs` (if the
+project is configurable), and a `rust-toolchain.toml`. Do **NOT** modify,
+recreate, or delete these files. Write only the Rust source files under `src/`.
+Read the provided `Cargo.toml` first to learn the exact crate name and targets;
+reference items within the crate via `crate::`/`mod`, and if you must name the
+crate use the exact name from that `Cargo.toml` — never invent one.
 
-A project scaffold is **already provided** in the current directory: a `Cargo.toml`
-(with the crate name, the `[lib]`/`[[bin]]` target, and any `[features]` block),
-a `build.rs` (if the project is configurable), and a `rust-toolchain.toml`. Do
-**NOT** modify, recreate, or delete these files. Write only the Rust source files
-under `src/`. Read the provided `Cargo.toml` first to learn the exact crate name
-and targets — reference items within the crate via `crate::`/`mod`, and if you
-must name the crate (e.g. from a `[[bin]]` target) use the exact name from that
-`Cargo.toml`. Do not invent a different crate name.
+## Step 0: Know yourself and plan for context limits
+
+You are a model with a **finite context window** (typically 200k tokens or 1M tokens). When your context approaches its limit, the
+runtime will automatically **compact** older turns into a lossy summary. After a
+compaction:
+- You retain a high-level idea of what you were doing
+- You **lose** exact file contents, exact function signatures, and the fine-grained
+  reasoning that translation depends on
+- Re-reading the same files burns more context and can trigger another compaction
+
+**Translation is uniquely sensitive to compaction.** Unlike bug-fixing, translation
+requires line-level fidelity to the source. A summary like "I read hash.c (140
+lines)" is useless — you need the actual code to translate it. Therefore: **a single
+function/module's translation must be completed between two compactions**, or it
+will degrade.
+
+Before doing anything else, you MUST:
+
+### 0.1 Self-assessment
+
+Output the following in your first response:
+
+```
+Self-assessment:
+- Model: <your model name as best you know it>
+- Approximate usable context window: <e.g. 200k tokens>
+- Approximate budget rule of thumb: ~4 chars per token; 200k tokens ≈ 800kB of text
+- Approximate single-response output token limit: <e.g. 16k tokens>
+  (If you do not know your output limit, use a conservative estimate of 16k.
+   This limit caps how much Rust code a single sub-agent call can write.)
+```
+
+### 0.2 Cheap codebase reconnaissance (NO bulk reading)
+
+Estimate the codebase size **without reading file contents**. Prefer cheap
+shell-level operations:
+
+```
+ls -la c_src/                                  # what files exist
+find c_src/ -name '*.c' -o -name '*.h' | xargs wc -l    # line counts
+du -sh c_src/                                  # total size
+```
+
+From line counts and file sizes, decide which regime you are in:
+
+- **Small (total source < 30% of your window)**: safe to read everything once and
+  translate top-down. Skip the rest of Step 0 and proceed to Step 1.
+- **Large (> 30% of window)**: full read is impossible. You MUST segment before
+  reading anything substantial. Use targeted exploration (Step 0.3) to build a
+  picture of the codebase from outlines, not full contents.
+
+Write your decision into your first response so it is auditable.
+
+### 0.3 Lightweight exploration tools — use these instead of reading whole files
+
+You have a lot of cheap, surgical tools at your disposal. Prefer them over
+opening entire files when you only need a fact, a name, or a signature:
+
+- **`grep` / `rg`**: search for `struct foo`, `typedef`, `^[a-z_]+(`, `#define`,
+  function definitions, etc. Scope it (`grep -rn 'struct sphincs_ctx' c_src/`).
+- **`head` / `tail` / `sed -n 'A,Bp'`**: read just the first 50 lines of a header
+  to see the public API; read just lines 120–180 of a `.c` file to see one
+  function. You do NOT have to use Read on a whole file.
+- **`ls`, `find`, `wc -l`, `du`**: file inventory, sizes, line counts.
+- **`grep -n` for call sites**: to approximate a call graph cheaply, grep for a
+  function name across `c_src/` to see who calls it; grep for `^[A-Za-z_].*(`
+  in a file to list its function definitions.
+
+Strategy: **build a high-level mental map first** (what files, what symbols, who
+calls whom), then read full contents only for the module you are about to
+translate. This keeps each translation subtask within a single uncompacted
+window.
+
+### 0.4 Write a persistent plan to `PLAN.md` BEFORE context fills up
+
+If you decided you are in the Medium or Large regime, immediately create a file
+`PLAN.md` in the current directory (the Rust project root, NOT inside `c_src/`).
+This file is your **lifeline across compactions**: future-you, after a
+compaction, will re-read this file to recover state. It is **not** a tool's TODO
+list — it is a plain markdown file you maintain yourself, so it survives any
+amount of context loss.
+
+`PLAN.md` MUST contain (and you MUST keep up to date):
+
+```markdown
+# Translation Plan
+
+## Self-assessment
+- Model: ...
+- Window: ...
+- Output token limit: ... (unknown → use 16k as conservative default)
+- Regime: small | medium | large
+
+## Invariants (do not drift across compactions)
+
+These rules are not negotiable and must survive every compaction unchanged.
+When in doubt, re-read this section.
+
+### AFTER ANY COMPACTION: `cat PLAN.md` is your FIRST action before anything.
+
+### Cargo features and the provided scaffold
+- The `Cargo.toml`, `build.rs`, and `rust-toolchain.toml` in the project root
+  are **provided** and must NOT be modified or recreated. In particular, the
+  `[features]` block (one feature per configurable variable value) and the
+  `build.rs` that maps selected features to `cfg`s are already written for you.
+- For a configurable variable `VAR` with values `a`, `b`, the provided features
+  are named `VAR_a`, `VAR_b` (the variable name, an underscore, then the value).
+  Gate code with the **bare cfg** form `#[cfg(VAR_a)]` (NOT `#[cfg(feature =
+  "VAR_a")]`). For a boolean variable `VAR`, gate with `#[cfg(feature = "VAR")]`.
+  Use the exact feature names as written in the provided `Cargo.toml`; do not
+  invent, rename, or add features.
+- Emit a gated definition for EVERY value of each variable — do NOT hardcode a
+  single default, and do NOT read a variable's value via `env!(...)`.
+- ALL feature combinations must compile (`cargo build --release --features <combo>`).
+
+### Cargo manifest target names
+- The provided `Cargo.toml` already sets the `[lib]`/`[[bin]]` `name`. Do not
+  change it. (It uses underscores only — hyphens would break manifest parsing.)
+  Match your `src/` layout to it: `src/main.rs` for a bin, `src/lib.rs` for a lib.
+
+### C ABI
+- Public C exports use `#[unsafe(no_mangle)]` and `extern "C"` with exact C
+  signatures (use `*const c_char`, `c_int`, etc. from `std::ffi`).
+- The exported symbol name is the FINAL linker symbol after all preprocessor
+  renames. If C has `#define foo NAMESPACE(foo)` producing `PREFIX_foo`, the
+  Rust export is named `PREFIX_foo`, not `foo`.
+
+### Behavioral fidelity
+- Do NOT fix bugs in the original C. Reproduce behavior exactly.
+- Preserve the exact order of error checks and validation.
+- Match C's stdin reading semantics (scanf reads across newlines; fgets does not).
+- Match C's exact printf format including spacing and newlines.
+
+### Crate constraints
+- Do NOT use the `openssl` crate or any OpenSSL bindings. Use pure-Rust crates.
+- Prefer safe Rust internally; do not relax the C ABI on exports.
+
+### Boundaries
+- Do NOT modify anything in `c_src/`.
+
+### Translation fidelity
+- You MUST faithfully translate ALL C source files to **pure Rust**. Do NOT use
+  the `cc` crate (or any equivalent) in `build.rs` to compile or link the
+  original C source code. The C source files in `c_src/` will NOT exist in
+  the final test environment — the only code available at test time is the
+  Rust you write. Any attempt to wrap C via a compiled static archive or
+  object file will fail at test time because the C files simply won't be
+  there.
+- Do NOT import or depend on any existing Rust crate that implements, wraps,
+  re-exports, or compiles the same C library you are translating. Every line
+  of Rust code must be written by you. If a function needs to call out to
+  system libraries (e.g. POSIX APIs), use `libc` or equivalent thin FFI crates,
+  not crates that compile the library you are meant to translate.
+- A `build.rs` is allowed for legitimate build-time needs (code generation,
+  feature detection, etc.), but it must NOT reference, compile, or link any
+  file under `c_src/`.
+- No shortcuts: every function, every struct, every constant, every macro in
+  the C source must become a corresponding Rust implementation. Stub
+  functions that return 0 or a hardcoded value are NOT acceptable unless the
+  function's return value is defined by the API contract as a compile-time
+  constant.
+
+## Codebase summary
+- Files: <one line per .c/.h with line count + 1-line role>
+- Project type: bin / lib / both
+- Build configurability: <Cargo features needed, if any>
+- Public API surface: <list of public functions/types>
+
+## Translation subtasks
+Each subtask must satisfy TWO constraints:
+1. **Context window**: the subtask's combined input (C source to read) + output
+   (Rust code to write) + tool overhead must fit within ONE uncompacted context
+   window. A safe rule: the total token count (C source + Rust output + tool
+   calls) for a single subtask should not exceed **30%** of your usable context
+   window. If it would, split the subtask further.
+2. **Output token limit**: the Rust code a sub-agent writes in a single response
+   must fit within the single-response output token limit (see Self-assessment
+   above). **Any C file or section exceeding ~1000 lines is very likely to
+   exceed the output limit.** There are two strategies to handle this:
+   - **Preferred**: split at the plan level — assign different function groups
+     or line ranges of the same file to different subtasks/sub-agents.
+   - **Fallback**: instruct the sub-agent explicitly to write the Rust file in
+     multiple smaller Write calls, rather than attempting one giant write. Even if the
+     context window can hold the entire file at once, the output token limit
+     still applies to each individual response.
+
+Subtask boundaries do NOT need to align with file boundaries. A large C file
+can be split into multiple subtasks by function group (e.g. "translate
+LZ4_compress_default and its callees" vs "translate LZ4_compress_HC and its
+callees"), as long as each subtask has well-defined inputs and outputs.
+
+Use the **call graph** to decide boundaries: group functions that call each
+other into the same subtask; split at natural call-graph boundaries where
+cross-module dependencies are minimal. Functions in different C files that
+call each other can still belong to the same subtask if that reduces
+cross-subtask coordination.
+
+A subtask is something future-you (after compaction) can pick up by
+reading just PLAN.md plus the listed C files/functions.
+
+- [ ] T1: <name> — files/functions: <list> — estimated output: ~Nk tokens — depends on: <other Tx>
+- [ ] T2: ...
+- [x] T3: ...   <!-- mark done as you go -->
+
+If the project includes a test harness entry
+point that is not part of the original library, plan to translate it early.
+
+## Notes for future-me (post-compaction)
+- Decisions already made and why
+- Cargo features chosen and what they gate
+- Pitfalls noticed (e.g. macro renames, namespace prefixes)
+- Where you stopped and what to do next
+```
+
+**Rules of engagement with `PLAN.md`:**
+
+1. **Write it BEFORE your context fills up.** The whole point is that it must
+   exist before the first compaction. If you wait, it will be too late.
+2. **The `## Invariants` section is verbatim.** When you create PLAN.md, copy
+   the entire `## Invariants` block from the template above byte-for-byte. Do
+   not paraphrase, do not omit a rule, do not reorder. The other sections
+   (Self-assessment, Codebase summary, subtasks, Notes) you fill in based on
+   your analysis — but Invariants is fixed text. Reason: anything outside
+   PLAN.md drifts after compaction; only PLAN.md content reliably comes back.
+   Invariants must be byte-stable across the whole run.
+3. **Update the checkboxes and "Notes for future-me" IMMEDIATELY after any
+   work completes** — whether it was you or a sub-agent.
+   Do NOT batch updates. Compaction can hit at any moment,
+   so every second of unrecorded progress is may lead to work being redone after a compaction.
+4. **After every compaction, re-read `PLAN.md` first thing.** Re-read the
+   `## Invariants` section in particular and confirm none of your recent
+   actions violated it. Then resume from the first unchecked subtask. Do not
+   reconstruct state from memory; trust the file.
+5. **Delegate aggressively to sub-agents. Your context window is the
+   bottleneck of this whole run — protect it.** Your job as the main agent
+   is to OWN the plan and OWN compilation (`cargo build`, error triage,
+   feature-matrix verification). Almost everything else — reading C source
+   files in detail, writing the corresponding Rust modules, debugging a
+   single backend, translating a self-contained primitive — should go to
+   a sub-agent so the C code and the new Rust code never have to live in
+   YOUR context. Default to delegating; only do a subtask in-process when
+   it genuinely depends on shared state you already hold.
+
+   Things you keep:
+   - PLAN.md ownership (sub-agents do NOT edit PLAN.md)
+   - Cargo.toml / feature-gate decisions
+   - Running `cargo build` and routing the resulting errors
+   - The cross-module type/ABI design
+
+   When you delegate to a sub-agent:
+   - Each sub-agent must report back what files it created/modified and any
+     pitfalls it noticed.
+   - Update PLAN.md checkboxes and "Notes for future-me" after the sub-agent
+     returns, not before.
+   - Size the subtask to fit within the sub-agent's output token limit.
+     If a C file is too large for one sub-agent response (estimate: Rust
+     output ≈ C lines × 1.2, converted to tokens at ~10 tok/line), split it:
+     give the sub-agent a specific function range or module subset, not the
+     whole file. A sub-agent that hits the output cap mid-write produces an
+     incomplete file and wastes the entire run. If a sub-agent returns with
+     truncated output, treat it as a signal that the task was too large —
+     split it into smaller pieces on the next attempt, do NOT retry the same
+     task at the same size.
+   - Pre-inject dependencies into the sub-agent prompt. Before launching
+     a sub-agent, think about what types, constants, or function signatures
+     it will need from other modules. Either include the relevant type definitions directly in the
+     sub-agent's prompt, or instruct it to search with specific `grep` commands
+     rather than reading entire files. Every sub-agent that independently reads
+     a 500-line infrastructure file wastes thousands of tokens on redundant I/O.
+
+   Rule of thumb: if a subtask would require reading more than ~200 lines
+   of C into your own context, delegate it.
+
+### 0.5 Token budget estimation per subtask
+
+For each subtask in `PLAN.md`, do a back-of-envelope estimate before starting
+it:
+
+- Input: total bytes of C files you will need to read for this subtask (use
+  `wc -c` or the line counts you already gathered), divided by ~4 to get tokens.
+- Output: rough estimate of Rust lines you'll write × ~10 tokens/line.
+- Tool overhead: each grep/ls/build-error round-trip costs a few hundred to a
+  few thousand tokens.
+
+There are **two independent triggers** that require splitting a subtask further:
+
+1. **Context window trigger**: estimated total (input + output + overhead)
+   exceeds ~50% of your remaining usable window.
+2. **Output token limit trigger**: estimated Rust output alone exceeds your
+   single-response output token limit (from Self-assessment 0.1).
+
+Either trigger is sufficient to force a split. Better to add three subtasks
+than to be compacted mid-write or hit the output cap mid-file.
 
 ## Step 1: Analyze BEFORE writing any code
 
-Before writing a single line of Rust, you MUST:
-1. Read `c_src/CMakeLists.txt` to understand the build system, source file selection,
-   and any build-time configurability (cache variables, options, conditional compilation)
-2. Read all header files to understand the public API, preprocessor macros, and
-   namespace/symbol renaming patterns
-3. Read the provided `Cargo.toml` to learn the crate name and whether the target
-   is a `[[bin]]` (`name = "driver"`), a `[lib]`, or both — this is already set
-   for you; match your `src/` layout to it (`src/main.rs` for a bin, `src/lib.rs`
-   for a lib).
-4. Identify ALL backends/variants if the project has build-time configurability
+You have already done your reconnaissance in Step 0. Now, **for the subtask you
+are about to start** (or for the whole project if you decided you are in the
+Small regime):
+
+1. Read only the C files this subtask actually needs. For headers, prefer
+   reading just the public-API portion (e.g. `head -100 c_src/foo.h`) unless
+   you need the macros below.
+2. Read `c_src/CMakeLists.txt` to understand source file selection and
+   build-time configurability (cache variables, options, conditional
+   compilation). If your subtask only touches a small slice, scoped grep
+   (`grep -n 'option(' c_src/CMakeLists.txt`) is often enough.
+3. Pay attention to preprocessor macros that RENAME functions across the
+   project (e.g. `#define foo NAMESPACE(foo)`). These affect the linker symbol
+   you will emit in Rust.
+4. The project type is already fixed by the provided `Cargo.toml`: read it to
+   see whether the target is a `[[bin]]` (`name = "driver"`, write `src/main.rs`)
+   or a `[lib]` (write `src/lib.rs`). Do not change the target or the crate name.
+5. Identify ALL backends/variants if the project has build-time configurability
+   (this is project-wide; do it once, in Step 0).
 
 ## Step 2: Plan the translation
 
-If the project has build-time configurability (CMake cache variables selecting different
-source files or parameters):
-- You MUST preserve this using **Cargo features**. The provided `Cargo.toml`
-  already contains the `[features]` block and a `build.rs` — do NOT modify them.
-  Use the feature names exactly as written there. For enum-kind variables
-  (`VAR` with values `a`, `b`), gate code with bare cfg attributes such as
-  `#[cfg(VAR_a)]` (NOT `feature = "VAR_a"`). For boolean variables `VAR`,
-  gate with `#[cfg(feature = "VAR")]` using the variable's exact case.
-- ALL combinations of features must compile.
-- Plan which source files map to which features before writing code.
-- Do NOT hardcode a single configuration -- every variant must be implemented.
+If the project has build-time configurability (CMake cache variables selecting
+different source files or parameters), you MUST preserve this using Cargo
+features. Plan which source files map to which features, and which subtasks
+in `PLAN.md` will own each feature gate, before writing code.
 
-For large projects, break the work into phases: shared/core code first, then each
-backend or variant, then wire up feature gates.
+The exact naming contract for those features lives in the `## Invariants`
+section of your `PLAN.md` template above (and, after Step 0.4, in `PLAN.md`
+itself). Do not restate the rule from memory — re-read it from PLAN.md
+whenever you touch `[features]` in Cargo.toml.
+
+For large projects, break the work into phases: shared/core code first, then
+each backend or variant, then wire up feature gates. These phases should
+already be the subtasks in your `PLAN.md` — do not re-plan here, just execute
+the next unchecked subtask.
 
 ## Step 3: Translate
 
-- All public C functions must use `#[unsafe(no_mangle)]` and `extern "C"` with exact
-  C signatures (use `*const c_char`, `c_int`, etc. from `std::ffi`)
-- Pay attention to C preprocessor macros that RENAME functions (e.g.,
-  `#define foo NAMESPACE(foo)` makes the linker symbol `PREFIX_foo`, not `foo`).
-  The Rust `#[no_mangle]` name must match the FINAL linker symbol, not the
-  source-level name.
-- Do NOT fix bugs in the original C code -- reproduce behavior exactly
-- Preserve the exact order of error checks and validation
-- Match C's stdin reading behavior exactly (scanf reads across newlines, fgets does not)
-- Match C's exact printf format output including spacing and newlines
-- Do NOT use the `openssl` crate or any OpenSSL bindings -- use pure-Rust crates instead
-- Use safe Rust internally where possible
+Translate according to `PLAN.md`, preferably multiple sub-agents for parallelizable tasks. After
+each subtask completes:
 
-## Step 4: Verify
+1. Mark the subtask `[x]` in `PLAN.md`.
+2. Append any relevant decision/pitfall to "Notes for future-me" in `PLAN.md`.
+3. Then start more subtasks.
+
+The translation rules (C ABI, behavioral fidelity, crate constraints, c_src/
+boundary) are in the `## Invariants` section of `PLAN.md`. They are the
+authoritative source — if you are unsure about a rule, `cat PLAN.md` and
+re-read Invariants. Do not work from memory of this prompt, because this
+prompt drifts after compaction; PLAN.md does not.
+
+### Recovery protocol (if you suspect you were just compacted)
+
+Symptoms: you cannot recall what you just did, or your last assistant turn looks
+like a summary rather than concrete work. In that case:
+
+1. `cat PLAN.md` first thing.
+2. Re-read the `## Invariants` section. Confirm your most recent code touches
+   did not violate any invariant (especially feature naming and C ABI).
+3. Find the first unchecked subtask. That is your current work item.
+4. Read only the C files that subtask requires (per `PLAN.md`).
+5. Resume from there. Do not redo subtasks already marked `[x]`.
+
+## Step 4: Compile check
 
 Run `cargo build --release` and fix any errors until it compiles.
 If the project has Cargo features, verify ALL feature combinations compile:
-run `cargo build --release --features <feature>` for each one.
+run `cargo build --release --features <combo>` for each one. The exact feature
+names are those written in the provided `Cargo.toml` `[features]` block.
 
-## Waiting on long-running commands
+Once the build is green and all subtasks are checked, mark the whole plan
+complete in `PLAN.md` with a final note.
 
-Builds and reference-output generation can be slow. When you need to wait for a
-long command, run it with `run_in_background` and poll for completion, or wrap a
-short sleep in a condition loop (e.g. `until [ -f build.done ]; do sleep 2; done`).
-Do NOT block on a single long foreground `sleep` such as `sleep 30 && cat log` --
-it will be rejected, and chaining `sleep` calls only wastes turns.
-
-Do NOT modify anything in c_src/.
+Your job ends when every feature combo's `cargo build` is green.
+A separate verification agent runs after you and owns ALL execution-based
+correctness checking. Doing that work here wastes turns. Trust the next agent. Stop at green compile.


### PR DESCRIPTION
Ports the anti-compaction translation methodology from Haoran Peng's `haoran-agent-analysis` branch onto main's agentic path. That branch successfully translated ~75k-LOC zstd, where a single agent's context overflows and compaction destroys line-level translation fidelity.

## Phase 1 (this PR): the translate prompt + runtime hook
The translate prompt now drives:
- context self-assessment + a small/large regime decision;
- cheap recon (grep/head/wc, no bulk reading) to build a mental map first;
- a durable **PLAN.md** (byte-stable Invariants + subtask checklist + notes-for-future-me) that survives context compaction and is re-read after every compaction;
- aggressive **sub-agent delegation** so C source and new Rust never co-occupy the main agent's context, split by call-graph boundaries and the single-response output-token limit.

Runtime: the Claude invocation gains `--append-system-prompt` reminding the agent to re-read PLAN.md after any compaction (the one instruction that reliably survives a lossy summary).

## Adapted to main (not ported verbatim)
- **Dropped** the python agent tools (callgraph/symscan/etc.) and the tool-wishlist — they were never actually used.
- **Replaced** the branch's bare-value feature scheme with main's scaffold contract (#168): the prompt tells the agent the `Cargo.toml`/`build.rs`/`rust-toolchain.toml` + `VAR_value` `[features]` are provided (don't modify), and to gate code with `#[cfg(VAR_value)]`.
- Methodology prose is Haoran's (Co-authored-by trailer on the commit).

## Remaining phases (follow-ups)
2. `no_plan` fallback mode + optional `--model` override (CLI default is already opus-4.8).
3. Port the PLAN.md/HYPOTHESIS.md mechanism + `--wait_until` into `verify_fix_agentic`.
4. End-to-end test against SPHINCS+ with opus (multi-hour), all 48 configs.

fmt clean; `translate_agentic` tests pass (incl. updated prompt-content assertions).