### PR TITLE
agentic: no_plan mode + optional --model override (phase 2)

### DIFF
--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -24,6 +24,7 @@ use tracing::{info, warn};
 const PROMPT_EXECUTABLE: &str = include_str!("prompt_executable.md");
 const PROMPT_LIBRARY: &str = include_str!("prompt_library.md");
 const PROMPT_CLAUDE_TRANSLATE: &str = include_str!("prompt_claude_translate.md");
+const PROMPT_CLAUDE_TRANSLATE_NO_PLAN: &str = include_str!("prompt_claude_translate_no_plan.md");
 
 /// Agent-only structural notes appended after the variable-listing section
 /// when `BuildConfigIR.is_empty == false`. Says only the things that are
@@ -95,14 +96,28 @@ impl Tool for TranslateAgentic {
             .ok_or("No BuildConfigIR representation found in IR")?;
 
         let agent = context.config.agentic_agent;
-        let translate_prompt = load_prompt(
-            &config.prompt_executable,
-            &config.prompt_library,
-            &config.prompt_claude_translate,
-            &project_spec.kind,
-            build_cfg,
-            agent,
-        )?;
+        // `no_plan` selects the leaner prompt that omits the PLAN.md /
+        // sub-agent machinery (only meaningful for Claude, and only when no
+        // explicit prompt override is configured).
+        let translate_prompt = if config.no_plan
+            && matches!(agent, AgentKind::Claude)
+            && config.prompt_claude_translate.is_none()
+        {
+            if build_cfg.is_empty {
+                PROMPT_CLAUDE_TRANSLATE_NO_PLAN.to_owned()
+            } else {
+                build_system_prompt(PROMPT_CLAUDE_TRANSLATE_NO_PLAN, build_cfg)
+            }
+        } else {
+            load_prompt(
+                &config.prompt_executable,
+                &config.prompt_library,
+                &config.prompt_claude_translate,
+                &project_spec.kind,
+                build_cfg,
+                agent,
+            )?
+        };
 
         // Set up a working directory that mirrors the layout the agent expects:
         //   case_dir/translated_rust/c_src/  <- materialized C source
@@ -124,7 +139,14 @@ impl Tool for TranslateAgentic {
         let canonical_name = canonical_crate_name(&context.config.output);
         write_project_scaffold(&translated, &canonical_name, &project_spec.kind, build_cfg)?;
 
-        invoke_agent(&translated, &translate_prompt, config.timeout_secs, agent)?;
+        invoke_agent(
+            &translated,
+            &translate_prompt,
+            config.timeout_secs,
+            agent,
+            config.model.as_deref(),
+            config.no_plan,
+        )?;
 
         if !translated.join("Cargo.toml").exists() {
             return Err("Agent did not produce a Cargo.toml".into());
@@ -158,13 +180,31 @@ fn invoke_agent(
     prompt: &str,
     timeout_secs: u64,
     agent: AgentKind,
+    model: Option<&str>,
+    no_plan: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Invoking translation agent ({agent}, timeout={timeout_secs}s)");
+    info!(
+        "Invoking translation agent ({agent}, model={}, no_plan={no_plan}, timeout={timeout_secs}s)",
+        model.unwrap_or("(cli default)")
+    );
 
     let logs_dir = work_dir.parent().unwrap_or(work_dir).join("logs");
     fs::create_dir_all(&logs_dir)?;
     let log_path = logs_dir.join("translation.log");
     let openssl_dir = std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into());
+
+    // Optional `--model` override (default: the CLI's own default model). The
+    // `--append-system-prompt` PLAN.md reminder is only useful in plan mode.
+    let model_flag = if model.is_some() {
+        "--model \"$MODEL\" "
+    } else {
+        ""
+    };
+    let append_sys_flag = if no_plan {
+        ""
+    } else {
+        "--append-system-prompt \"$APPEND_SYS\" "
+    };
 
     let status = match agent {
         AgentKind::Kiro => Command::new("bash")
@@ -178,28 +218,35 @@ fn invoke_agent(
             .env("OPENSSL_DIR", &openssl_dir)
             .current_dir(work_dir)
             .status()?,
-        AgentKind::Claude => Command::new("bash")
-            .arg("-c")
-            .arg(format!(
-                "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
-                 --permission-mode bypassPermissions \
-                 --allowedTools 'Bash(*)' 'Write' 'Edit' \
-                 --append-system-prompt \"$APPEND_SYS\" \
-                 --output-format stream-json --verbose \
-                 < /dev/null 2>&1 | tee \"$LOG\"",
-            ))
-            .env("PROMPT", prompt)
-            .env("LOG", &log_path)
-            // Survives context compaction: the lossy summary retains this line,
-            // so the agent re-reads PLAN.md (its durable plan) before resuming.
-            .env(
-                "APPEND_SYS",
-                "After any context compaction, you MUST re-read PLAN.md (if it exists) \
-                 before doing anything else, and resume from the first unchecked subtask.",
-            )
-            .env("OPENSSL_DIR", &openssl_dir)
-            .current_dir(work_dir)
-            .status()?,
+        AgentKind::Claude => {
+            let mut cmd = Command::new("bash");
+            cmd.arg("-c")
+                .arg(format!(
+                    "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                     --permission-mode bypassPermissions \
+                     --allowedTools 'Bash(*)' 'Write' 'Edit' \
+                     {model_flag}{append_sys_flag}\
+                     --output-format stream-json --verbose \
+                     < /dev/null 2>&1 | tee \"$LOG\"",
+                ))
+                .env("PROMPT", prompt)
+                .env("LOG", &log_path)
+                .env("OPENSSL_DIR", &openssl_dir)
+                .current_dir(work_dir);
+            if let Some(m) = model {
+                cmd.env("MODEL", m);
+            }
+            if !no_plan {
+                // Survives context compaction: the lossy summary retains this
+                // line, so the agent re-reads PLAN.md before resuming.
+                cmd.env(
+                    "APPEND_SYS",
+                    "After any context compaction, you MUST re-read PLAN.md (if it exists) \
+                     before doing anything else, and resume from the first unchecked subtask.",
+                );
+            }
+            cmd.status()?
+        }
     };
 
     if !status.success() {
@@ -666,6 +713,28 @@ mod tests {
             "the Claude prompt should describe the PLAN.md anti-compaction mechanism",
         );
     }
+
+    /// The no-plan prompt is the lean variant: scaffold-aware, no PLAN.md
+    /// machinery, no leftover bare-value feature rule or agent-tools placeholder.
+    #[test]
+    fn no_plan_prompt_is_scaffold_aware_and_planless() {
+        assert!(
+            !PROMPT_CLAUDE_TRANSLATE_NO_PLAN.contains("PLAN.md"),
+            "the no-plan prompt must not carry the PLAN.md machinery",
+        );
+        assert!(
+            !PROMPT_CLAUDE_TRANSLATE_NO_PLAN.contains("exact same name in lowercase"),
+            "the bare-value lowercase feature rule must not survive",
+        );
+        assert!(
+            !PROMPT_CLAUDE_TRANSLATE_NO_PLAN.contains("{AGENT_TOOLS_SECTION}"),
+            "the dropped agent-tools placeholder must not survive",
+        );
+        assert!(
+            PROMPT_CLAUDE_TRANSLATE_NO_PLAN.contains("already provided"),
+            "the no-plan prompt should state the scaffold is provided",
+        );
+    }
 }
 
 /// Tool-specific configuration, read from `[tools.translate_agentic]` in the HARVEST config.
@@ -686,6 +755,18 @@ pub struct Config {
     /// this is generous; override it in `[tools.translate_agentic]` if needed.
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+
+    /// Optional model override passed to `claude --model`. When absent, the
+    /// Claude CLI's own default model is used (currently Opus). Accepts short
+    /// aliases ("opus", "sonnet", "haiku") or full model IDs.
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// When true, use the leaner no-plan prompt (no PLAN.md / sub-agent
+    /// machinery) and skip the post-compaction "re-read PLAN.md" reminder.
+    /// Defaults to false (the large-codebase plan-mode methodology).
+    #[serde(default)]
+    pub no_plan: bool,
 
     #[serde(flatten)]
     unknown: HashMap<String, serde_json::Value>,

--- a/tools/translate_agentic/src/prompt_claude_translate_no_plan.md
+++ b/tools/translate_agentic/src/prompt_claude_translate_no_plan.md
@@ -1,0 +1,79 @@
+<!-- markdownlint-disable MD041 -->
+Translate the C code in c_src/ to Rust that produces **byte-identical output** for the same inputs.
+A project scaffold is **already provided** in the current directory (the Rust project root, NOT inside
+`c_src/`): a `Cargo.toml` (crate name, `[lib]`/`[[bin]]` target, any `[features]` block), a `build.rs`
+(if configurable), and a `rust-toolchain.toml`. Do **NOT** modify, recreate, or delete these files.
+Write only the Rust source files under `src/`. Read the provided `Cargo.toml` first for the exact crate
+name and target; reference items via `crate::`/`mod` and never invent a crate name.
+
+**CRITICAL CONSTRAINT: Pure Rust Translation Only**
+
+You MUST faithfully translate ALL C source files to **pure Rust**. Do NOT use
+the `cc` crate (or any equivalent) in `build.rs` to compile or link the original
+C source code. The C source files in `c_src/` will NOT exist in the final test
+environment — the only code available at test time is the Rust you write. Any
+`extern "C"` FFI declarations must resolve to Rust implementations you provide,
+not to compiled C object files.
+
+Do NOT import or depend on any existing Rust crate that implements, wraps,
+re-exports, or compiles the same C library you are translating. Every line
+of Rust code must be written by you. If a function needs to call out to
+system libraries (e.g. POSIX APIs), use `libc` or equivalent thin FFI crates,
+not crates that compile the library you are meant to translate.
+
+A `build.rs` is allowed for legitimate build-time needs (code generation,
+feature detection, etc.), but it must NOT reference, compile, or link any
+file under `c_src/`.
+
+If the codebase is large, you must still translate all of it. No stubs, no
+placeholders, no shortcuts. Never refuse or abort a translation because the codebase seems too big.
+
+## Step 1: Analyze BEFORE writing any code
+
+Before writing a single line of Rust, you MUST:
+1. Read `c_src/CMakeLists.txt` to understand the build system, source file selection,
+   and any build-time configurability (cache variables, options, conditional compilation)
+2. Read all header files to understand the public API, preprocessor macros, and
+   namespace/symbol renaming patterns
+3. The project type is fixed by the provided `Cargo.toml`: read it to see whether the target is a
+   `[[bin]]` (`name = "driver"`, write `src/main.rs`) or a `[lib]` (write `src/lib.rs`). Do not change it.
+4. Identify ALL backends/variants if the project has build-time configurability
+
+## Step 2: Plan the translation
+
+If the project has build-time configurability (CMake cache variables selecting different
+source files or parameters):
+- You MUST preserve this using **Cargo features**. The provided `Cargo.toml` already contains the
+  `[features]` block and a `build.rs` — do NOT modify them. For an enum variable `VAR` with values
+  `a`, `b` the features are named `VAR_a`, `VAR_b`; gate code with the **bare cfg** `#[cfg(VAR_a)]`
+  (NOT `#[cfg(feature = "VAR_a")]`). For a boolean variable `VAR`, gate with `#[cfg(feature = "VAR")]`.
+- ALL feature combinations must compile.
+- Do NOT hardcode a single configuration — every variant must be implemented, and do NOT read a
+  variable's value via `env!(...)`.
+
+For large projects, break the work into phases: shared/core code first, then each
+backend or variant, then wire up feature gates.
+
+## Step 3: Translate
+
+- All public C functions must use `#[unsafe(no_mangle)]` and `extern "C"` with exact
+  C signatures (use `*const c_char`, `c_int`, etc. from `std::ffi`)
+- Pay attention to C preprocessor macros that RENAME functions (e.g.,
+  `#define foo NAMESPACE(foo)` makes the linker symbol `PREFIX_foo`, not `foo`).
+  The Rust `#[no_mangle]` name must match the FINAL linker symbol, not the
+  source-level name.
+- Do NOT fix bugs in the original C code — reproduce behavior exactly
+- Preserve the exact order of error checks and validation
+- Match C's stdin reading behavior exactly (scanf reads across newlines, fgets does not)
+- Match C's exact printf format output including spacing and newlines
+- Do NOT use the `openssl` crate or any OpenSSL bindings — use pure-Rust crates instead
+- Use safe Rust internally where possible
+
+## Step 4: Verify
+
+Run `cargo build --release` and fix any errors until it compiles.
+If the project has Cargo features, verify ALL feature combinations compile:
+run `cargo build --release --features <feature>` for each one. The exact feature names are those in
+the provided `Cargo.toml`.
+
+Do NOT modify anything in c_src/.


### PR DESCRIPTION
Phase 2 of porting Haoran Peng's large-codebase agentic methodology (follows #170).

Two `[tools.translate_agentic]` knobs, both defaulting to current behavior:

- **`no_plan`** (default `false`): selects a leaner translation prompt that omits the PLAN.md / sub-agent machinery and skips the post-compaction "re-read PLAN.md" reminder — for small projects where plan-mode overhead isn't worth it. Ports Haoran's no-plan prompt, adapted to main's scaffold contract (provided `Cargo.toml`/`build.rs`, `VAR_value` features, `#[cfg(VAR_value)]` gating), with the dropped agent-tools/wishlist removed.
- **`model`** (default none): optional `claude --model` override. Absent ⇒ the CLI's own default model (currently Opus), so existing runs are unchanged — no need to set it to "use the most powerful model".

Set via the config file or `--config tools.translate_agentic.no_plan=true` / `...model=opus`. The plan-mode default path (used for the SPHINCS+ test) is unaffected.

fmt clean; `translate_agentic` tests pass, incl. a new assertion that the no-plan prompt is scaffold-aware and plan-free. No-plan prompt prose is Haoran's (Co-authored-by trailer).

Remaining phases: (3) PLAN.md/HYPOTHESIS.md + `--wait_until` in `verify_fix_agentic`; (4) the SPHINCS+ opus end-to-end test.