### PR TITLE
agentic: PLAN.md/HYPOTHESES.md verify methodology + knobs (phase 3)

### DIFF
--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -21,6 +21,7 @@ use tracing::{info, warn};
 
 const PROMPT_VERIFY: &str = include_str!("prompt_verify.md");
 const PROMPT_CLAUDE_VERIFY: &str = include_str!("prompt_claude_verify.md");
+const PROMPT_CLAUDE_VERIFY_NO_PLAN: &str = include_str!("prompt_claude_verify_no_plan.md");
 
 pub struct VerifyFixAgentic;
 
@@ -57,6 +58,20 @@ impl Tool for VerifyFixAgentic {
             .get::<BuildConfigIR>(inputs[2])
             .ok_or("No BuildConfigIR representation found in IR")?;
 
+        // Optional scheduled start: sleep until the given Unix timestamp (e.g.
+        // to stagger long unattended runs).
+        if let Some(target_ts) = config.wait_until {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            if target_ts > now {
+                let wait_secs = target_ts - now;
+                info!("Waiting {wait_secs}s until Unix timestamp {target_ts} before verifying");
+                std::thread::sleep(std::time::Duration::from_secs(wait_secs));
+            }
+        }
+
         let agent = context.config.agentic_agent;
         let verify_prompt = match agent {
             AgentKind::Kiro => config
@@ -65,12 +80,11 @@ impl Tool for VerifyFixAgentic {
                 .map(fs::read_to_string)
                 .transpose()?
                 .unwrap_or_else(|| PROMPT_VERIFY.to_owned()),
-            AgentKind::Claude => config
-                .prompt_claude_verify
-                .as_ref()
-                .map(fs::read_to_string)
-                .transpose()?
-                .unwrap_or_else(|| PROMPT_CLAUDE_VERIFY.to_owned()),
+            AgentKind::Claude => match &config.prompt_claude_verify {
+                Some(p) => fs::read_to_string(p)?,
+                None if config.no_plan => PROMPT_CLAUDE_VERIFY_NO_PLAN.to_owned(),
+                None => PROMPT_CLAUDE_VERIFY.to_owned(),
+            },
         };
 
         // case_dir/
@@ -92,7 +106,14 @@ impl Tool for VerifyFixAgentic {
             .replace("{CASE_DIR}", &case_dir.to_string_lossy())
             .replace("{CMAKE_BUILD_FLAGS}", &cmake_flags);
 
-        invoke_agent(case_dir, &prompt, config.timeout_secs, agent)?;
+        invoke_agent(
+            case_dir,
+            &prompt,
+            config.timeout_secs,
+            agent,
+            config.model.as_deref(),
+            config.no_plan,
+        )?;
         info!("Verification complete");
 
         // Remove artifacts that should not be carried into the IR.
@@ -120,13 +141,31 @@ fn invoke_agent(
     prompt: &str,
     timeout_secs: u64,
     agent: AgentKind,
+    model: Option<&str>,
+    no_plan: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Invoking verification agent ({agent}, timeout={timeout_secs}s)");
+    info!(
+        "Invoking verification agent ({agent}, model={}, no_plan={no_plan}, timeout={timeout_secs}s)",
+        model.unwrap_or("(cli default)")
+    );
 
     let logs_dir = work_dir.join("logs");
     fs::create_dir_all(&logs_dir)?;
     let log_path = logs_dir.join("verify.log");
     let openssl_dir = std::env::var("OPENSSL_DIR").unwrap_or_else(|_| "/usr".into());
+
+    // Optional `--model` override (default: the CLI's own default model). The
+    // `--append-system-prompt` reminder is only useful in plan mode.
+    let model_flag = if model.is_some() {
+        "--model \"$MODEL\" "
+    } else {
+        ""
+    };
+    let append_sys_flag = if no_plan {
+        ""
+    } else {
+        "--append-system-prompt \"$APPEND_SYS\" "
+    };
 
     let status = match agent {
         AgentKind::Kiro => Command::new("bash")
@@ -140,20 +179,33 @@ fn invoke_agent(
             .env("OPENSSL_DIR", &openssl_dir)
             .current_dir(work_dir)
             .status()?,
-        AgentKind::Claude => Command::new("bash")
-            .arg("-c")
-            .arg(format!(
-                "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
-                 --permission-mode bypassPermissions \
-                 --allowedTools 'Bash(*)' 'Write' 'Edit' \
-                 --output-format stream-json --verbose \
-                 < /dev/null 2>&1 | tee \"$LOG\"",
-            ))
-            .env("PROMPT", prompt)
-            .env("LOG", &log_path)
-            .env("OPENSSL_DIR", &openssl_dir)
-            .current_dir(work_dir)
-            .status()?,
+        AgentKind::Claude => {
+            let mut cmd = Command::new("bash");
+            cmd.arg("-c")
+                .arg(format!(
+                    "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                     --permission-mode bypassPermissions \
+                     --allowedTools 'Bash(*)' 'Write' 'Edit' \
+                     {model_flag}{append_sys_flag}\
+                     --output-format stream-json --verbose \
+                     < /dev/null 2>&1 | tee \"$LOG\"",
+                ))
+                .env("PROMPT", prompt)
+                .env("LOG", &log_path)
+                .env("OPENSSL_DIR", &openssl_dir)
+                .current_dir(work_dir);
+            if let Some(m) = model {
+                cmd.env("MODEL", m);
+            }
+            if !no_plan {
+                cmd.env(
+                    "APPEND_SYS",
+                    "After any context compaction, you MUST first re-read PLAN.md and \
+                     HYPOTHESES.md (if they exist) before doing anything else.",
+                );
+            }
+            cmd.status()?
+        }
     };
 
     if !status.success() {
@@ -708,6 +760,26 @@ mod tests {
         assert!(PROMPT_CLAUDE_VERIFY.contains("libloading"));
         assert!(PROMPT_CLAUDE_VERIFY.contains("nm -D"));
     }
+
+    /// The plan-mode verify prompt carries the HYPOTHESES.md anti-compaction
+    /// mechanism; the no-plan variant is lean (no PLAN/HYPOTHESES machinery) and
+    /// neither carries the dropped agent-tools placeholder.
+    #[test]
+    fn verify_prompts_methodology_and_scaffold() {
+        assert!(
+            PROMPT_CLAUDE_VERIFY.contains("HYPOTHESES.md"),
+            "plan-mode verify prompt should describe the HYPOTHESES.md mechanism",
+        );
+        assert!(
+            !PROMPT_CLAUDE_VERIFY_NO_PLAN.contains("HYPOTHESES.md"),
+            "no-plan verify prompt must not carry the HYPOTHESES.md machinery",
+        );
+        assert!(
+            !PROMPT_CLAUDE_VERIFY.contains("{AGENT_TOOLS_SECTION}")
+                && !PROMPT_CLAUDE_VERIFY_NO_PLAN.contains("{AGENT_TOOLS_SECTION}"),
+            "the dropped agent-tools placeholder must not survive in either prompt",
+        );
+    }
 }
 
 /// Tool-specific configuration, read from `[tools.verify_fix_agentic]` in the HARVEST config.
@@ -724,6 +796,21 @@ pub struct Config {
     /// `[tools.verify_fix_agentic]` if needed.
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+
+    /// Optional model override passed to `claude --model`. When absent, the
+    /// Claude CLI's own default model (currently Opus) is used.
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// When true, use the leaner no-plan verify prompt (no PLAN.md/HYPOTHESES.md
+    /// machinery) and skip the post-compaction reminder. Defaults to false.
+    #[serde(default)]
+    pub no_plan: bool,
+
+    /// Optional Unix timestamp; when set, the verifier sleeps until that time
+    /// before starting (to stagger long unattended runs). Defaults to none.
+    #[serde(default)]
+    pub wait_until: Option<u64>,
 
     #[serde(flatten)]
     unknown: HashMap<String, serde_json::Value>,

--- a/tools/verify_fix_agentic/src/prompt_claude_verify.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD041 -->
 You are testing a C-to-Rust translation for correctness. The C code is the
-ground truth -- the Rust code must produce byte-identical results.
+ground truth — the Rust code must produce byte-identical results.
 
 - `c_src/` contains the original C source code
 - `src/` contains the Rust translation
@@ -13,7 +13,160 @@ ground truth -- the Rust code must produce byte-identical results.
   ```
 - Find the resulting .so files in the build output
 
-Your task:
+## Step 0: Read PLAN.md FIRST
+
+A previous translation agent left a file `PLAN.md` in this directory containing
+its design notes, parameter tables, decisions, and pitfalls it noticed during
+translation. **Before doing anything else**, run:
+
+```
+cat PLAN.md
+```
+
+If `PLAN.md` exists, treat it as authoritative background. Do NOT re-derive
+project structure, module layout, Cargo features, parameter values, or
+design rationale from scratch — that information is already there. Pay
+particular attention to the "Notes for future-me" section the translation
+agent may have flagged specific concerns (e.g. "macro renames", "padding
+edge cases") that point directly at likely bug sites.
+
+If `PLAN.md` does not exist, the project was small enough that the translator
+chose not to write one; proceed without it.
+
+## Step 1: Maintain `HYPOTHESES.md`
+
+Verification work involves forming hypotheses about why the C and Rust outputs
+differ, then confirming or refuting them. Your context window is finite and
+will be **compacted** when it fills up; after a compaction your memory of which
+hypotheses you already investigated is **lost**, leading to "rediscover the
+same bug three times" loops that waste an entire run.
+
+To prevent this, you MUST maintain a file `HYPOTHESES.md` in the current
+directory as an append-only log of bug hypotheses. Create it at the very
+start of your work (right after reading `PLAN.md`) with this template:
+
+```markdown
+# Verification Hypotheses Log
+
+This is an append-only log of bug hypotheses I form while verifying the
+Rust translation. After every compaction I will `cat HYPOTHESES.md` first
+thing to recover state.
+
+## Invariants (do not drift across compactions)
+
+These rules govern verification. They must survive every compaction unchanged.
+
+### AFTER ANY COMPACTION: `cat PLAN.md HYPOTHESES.md` is your FIRST action before anything.
+
+### Ground truth
+- The C code is the authoritative reference. Rust outputs must match C
+  byte-for-byte (binary stdout AND every public function output under
+  libloading-based comparison).
+- If C and Rust diverge, fix Rust. NEVER modify C.
+
+### Cargo features (FRAMEWORK CONTRACT)
+- The `Cargo.toml`, `build.rs`, and `rust-toolchain.toml` are a provided
+  scaffold; do NOT modify them. The `[features]` block exposes one feature per
+  configurable-variable value, named `VAR_value` (e.g. `HASH_BACKEND_blake`).
+- The harness rebuilds each configuration with
+  `cargo build --no-default-features --features <VAR_value>,...` using those
+  exact names; Rust code gates on the bare cfg `#[cfg(VAR_value)]`.
+- If a configuration fails to build or diverges, fix the Rust sources under
+  `src/`, NOT the provided `Cargo.toml`/`build.rs`.
+
+### Boundaries
+- Do NOT modify anything in `c_src/`.
+- Add `libloading = "0.8"` to `[dev-dependencies]` in `Cargo.toml` (so your
+  integration tests can dlopen the C shared library).
+
+### Configuration coverage
+- Every configuration listed under "Configurations to verify" in this task
+  must be checked. For each one:
+    1. Clean and rebuild C with the listed cmake flags.
+    2. Rebuild Rust with the matching Cargo features
+       (`cargo build --release --no-default-features --features <list>`).
+    3. Re-run integration tests and fix any mismatches before moving on.
+
+{ALL_CONFIGURATIONS}
+
+### Operational
+- Wrap every `cargo build`, `cargo test`, `cmake`, or other long-running
+  command in `timeout 600` (or shorter). No single command should run > 600s.
+- If a single test takes too long, skip it and move on. Do not get stuck on
+  one step.
+
+## Hypothesis log
+
+Format per entry:
+### H<N>: <one-line hypothesis>
+- Status: open | confirmed | refuted | fixed
+- Evidence: <how I think I know>
+- Files/lines suspected: <file path:line>
+- Action taken: <Edit/test/none yet>
+- Outcome: <what happened after the action>
+```
+
+**Rules of engagement with `HYPOTHESES.md`:**
+
+1. **The `## Invariants` section is verbatim.** When you create
+   `HYPOTHESES.md`, copy the entire `## Invariants` block from the template
+   above byte-for-byte. Do not paraphrase, do not omit, do not reorder. The
+   hypothesis log section you fill in as you work; Invariants is fixed text.
+   Reason: anything outside HYPOTHESES.md drifts after compaction; only this
+   file reliably comes back. Invariants must be byte-stable.
+2. **Every time you form a new hypothesis** (e.g. "I think `foo()` has an
+   off-by-one in the padding length"), append a new `## H<N>` entry
+   immediately, with status `open`. Do NOT wait until you have proof.
+3. **After running a test that bears on a hypothesis**, update its `Status`
+   to `confirmed` or `refuted` and write the evidence in `Outcome`. Do NOT
+   leave entries stale.
+4. **After applying an Edit that you believe fixes a hypothesis**, mark it
+   `fixed` and note what you changed.
+5. **Before forming a new hypothesis, check if it is already in the file.**
+   If so, do not re-investigate it — read its current Status and proceed.
+6. **After every compaction, `cat HYPOTHESES.md` first thing.** Re-read the
+   `## Invariants` section, then the hypothesis log. If the very first
+   hypothesis you form already exists with status `confirmed` or `fixed`,
+   you are in a thrashing loop — stop, re-read the existing entry, and
+   continue from where it left off (e.g. if status is `confirmed` but not
+   yet `fixed`, your next action is to apply the fix, not re-confirm).
+7. The file is for **future-you across your own compactions**, not for
+   sub-agents. Do not delegate; you maintain it yourself.
+8. **Delegate fixing work aggressively. Your context window is the
+   bottleneck — protect it.** Your job as the main agent is to OWN
+   HYPOTHESES.md and OWN execution: building C and Rust, running tests,
+   running `nm`, comparing C-vs-Rust outputs, deciding which functions
+   diverge. Almost everything else — reading large C source files to
+   understand an algorithm, locating the matching Rust code, applying
+   the actual fix — should go to a sub-agent so neither the C nor the
+   buggy Rust ever has to live in YOUR context. Default to delegating;
+   only do a fix in-process when it is a one-line change you can apply
+   from what you already see.
+
+   Things you keep:
+   - HYPOTHESES.md ownership (sub-agents do NOT edit HYPOTHESES.md)
+   - Building C / Rust, running cargo test, running nm, output comparison
+   - Hypothesis status updates after each test run
+   - Per-configuration coverage tracking
+
+   Rule of thumb: if investigating or fixing a hypothesis would require
+   reading more than ~200 lines of C or Rust into your own context,
+   delegate the fix to a sub-agent and let it report back what it changed.
+
+### Recovery protocol (if you suspect you were just compacted)
+
+Symptoms: you cannot recall what hypothesis you were testing, or your last
+turn looks like a summary rather than concrete work. In that case:
+
+1. `cat PLAN.md HYPOTHESES.md` first thing.
+2. Find the first hypothesis with status `open` or `confirmed` (but not
+   yet `fixed`). That is your current work item.
+3. Resume from its `Action taken` field. Do not redo work already logged.
+
+## Step 2: Verification workflow
+
+Now do the actual verification:
+
 1. Build the C code as a shared library
 2. Write Rust integration tests (in tests/) that use `libloading`
    to load the C .so and compare C vs Rust function outputs
@@ -21,21 +174,21 @@ Your task:
    Look at the C headers to identify the public API and function call hierarchy.
 4. For each function: create fixed test inputs, call both C and Rust versions,
    assert outputs match byte-for-byte
-5. Run `cargo test` and investigate any mismatches
+5. Run `cargo test` and investigate any mismatches. Every time a test
+   exposes a divergence, append a hypothesis to `HYPOTHESES.md`.
 6. When you find a Rust function that produces different output than C,
-   fix the Rust code in src/ and re-run until the test passes
+   fix the Rust code in src/ and re-run until the test passes. Update the
+   matching hypothesis to `fixed` after the Edit.
 7. Keep going until all public functions match
 8. If the project has a main binary, run both the C binary and the Rust binary
    with the same inputs and compare their stdout byte-for-byte. Fix any differences.
 9. Compare `nm -D` on the C .so and the Rust .so. Every symbol the C .so
    exports, the Rust .so must also export with the exact same name. This
    includes symbols created by preprocessor macros. If the C .so exports it,
-   the Rust .so must export it -- no exceptions. Add missing exports.
+   the Rust .so must export it — no exceptions. Add missing exports.
 
-Add `libloading = "0.8"` to [dev-dependencies] in Cargo.toml.
-Do NOT modify anything in c_src/.
-
-IMPORTANT: Use timeouts for all commands. No single build or test command should
-run longer than 600 seconds. If a test takes too long, skip it and move on to
-the next function. Use `timeout 600 cargo test ...` or similar. Do not get stuck
-on any single step.
+All operational rules (libloading dev-dep, c_src boundary, per-configuration
+re-verification, the 600-second timeout cap) live in the `## Invariants`
+section of your `HYPOTHESES.md` template above. Re-read them from
+`HYPOTHESES.md` whenever you are unsure — do not work from memory of this
+prompt.

--- a/tools/verify_fix_agentic/src/prompt_claude_verify_no_plan.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify_no_plan.md
@@ -1,0 +1,48 @@
+<!-- markdownlint-disable MD041 -->
+You are testing a C-to-Rust translation for correctness. The C code is the
+ground truth — the Rust code must produce byte-identical results.
+
+- `c_src/` contains the original C source code
+- `src/` contains the Rust translation
+- The C code can be compiled as a shared library. Look at c_src/CMakeLists.txt
+  to understand the build system. Build it with:
+  ```
+  cd c_src && mkdir -p build && cd build && \
+  cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON {CMAKE_BUILD_FLAGS} && \
+  cmake --build .
+  ```
+- Find the resulting .so files in the build output
+
+Your task:
+1. Build the C code as a shared library
+2. Write Rust integration tests (in tests/) that use `libloading`
+   to load the C .so and compare C vs Rust function outputs
+3. Start with the lowest-level functions and work upward to higher-level ones.
+   Look at the C headers to identify the public API and function call hierarchy.
+4. For each function: create fixed test inputs, call both C and Rust versions,
+   assert outputs match byte-for-byte
+5. Run `cargo test` and investigate any mismatches
+6. When you find a Rust function that produces different output than C,
+   fix the Rust code in src/ and re-run until the test passes
+7. Keep going until all public functions match
+8. If the project has a main binary, run both the C binary and the Rust binary
+   with the same inputs and compare their stdout byte-for-byte. Fix any differences.
+9. Compare `nm -D` on the C .so and the Rust .so. Every symbol the C .so
+   exports, the Rust .so must also export with the exact same name. This
+   includes symbols created by preprocessor macros. If the C .so exports it,
+   the Rust .so must export it — no exceptions. Add missing exports.
+
+Add `libloading = "0.8"` to [dev-dependencies] in Cargo.toml.
+Do NOT modify anything in c_src/.
+
+If configurations are listed below, you MUST verify each one:
+- Clean and rebuild C with the listed cmake flags
+- Rebuild Rust with the matching Cargo features (`--no-default-features --features <list>`)
+- Re-run integration tests and fix any mismatches before moving to the next configuration
+
+{ALL_CONFIGURATIONS}
+
+IMPORTANT: Use timeouts for all commands. No single build or test command should
+run longer than 600 seconds. If a test takes too long, skip it and move on to
+the next function. Use `timeout 600 cargo test ...` or similar. Do not get stuck
+on any single step.


### PR DESCRIPTION
Phase 3 of porting Haoran Peng's large-codebase agentic methodology (after #170, alongside #171). Applies the anti-compaction approach to the **verify-and-fix** agent.

## Changes
- **Verify prompt** now: reads the translator's `PLAN.md` first (authoritative background), maintains a durable **`HYPOTHESES.md`** (byte-stable Invariants + hypothesis log, re-read after every compaction) for the C-vs-Rust discrepancy-hunting loop, and delegates fixes to sub-agents. Ported from Haoran's verify prompt, adapted to main's scaffold contract — the branch's bare-value feature rule is replaced by the provided `VAR_value` features + `#[cfg(VAR_value)]` gating; agent-tools/wishlist removed.
- **`--append-system-prompt`** reminds the agent to re-read `PLAN.md` + `HYPOTHESES.md` after any compaction (skipped in no_plan mode).
- New `[tools.verify_fix_agentic]` knobs, all defaulting to current behavior:
  - `model` — optional `claude --model` override (absent ⇒ CLI default, currently Opus);
  - `no_plan` — lean no-plan verify prompt;
  - `wait_until` — Unix timestamp to sleep until before starting (stagger long unattended runs).

## Notes
- Independent of #171 (different tool); either merge order is fine.
- Existing verify-prompt test (libloading/`nm -D` oracle form) still passes; added a test for the HYPOTHESES.md methodology + no-plan/scaffold adaptation.
- Verify prose is Haoran's (Co-authored-by trailer). fmt clean; `verify_fix_agentic` tests pass (11).

Remaining: Phase 4 — the SPHINCS+ opus end-to-end test of the full ported methodology (translate + verify), all 48 configs.