### PR TITLE
agentic: long-run robustness — sleep guidance + fix claude -p pipe hang

### DIFF
--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -222,12 +222,20 @@ fn invoke_agent(
             let mut cmd = Command::new("bash");
             cmd.arg("-c")
                 .arg(format!(
-                    "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                    // Redirect to the log file (no `| tee`): a `run_in_background`
+                    // bash task the agent spawns inherits claude's stdout fd, and
+                    // with a pipe it would hold the write-end open after claude
+                    // exits, so `tee` never sees EOF and this command hangs until
+                    // the timeout. Writing to a file avoids the pipe; we replay
+                    // the log to stdout afterward so the transcript still reaches
+                    // the benchmark's captured output. `--kill-after` hard-kills
+                    // claude if it ignores SIGTERM at the timeout.
+                    "timeout --kill-after=60s {timeout_secs} claude -p \"$PROMPT\" \
                      --permission-mode bypassPermissions \
                      --allowedTools 'Bash(*)' 'Write' 'Edit' \
                      {model_flag}{append_sys_flag}\
                      --output-format stream-json --verbose \
-                     < /dev/null 2>&1 | tee \"$LOG\"",
+                     < /dev/null > \"$LOG\" 2>&1; status=$?; cat \"$LOG\"; exit $status",
                 ))
                 .env("PROMPT", prompt)
                 .env("LOG", &log_path)

--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -735,6 +735,17 @@ mod tests {
             "the no-plan prompt should state the scaffold is provided",
         );
     }
+
+    /// The translate prompt must keep the run_in_background guidance: a single
+    /// long foreground `sleep` is rejected by the agent's Bash tool and stalls
+    /// the run, so the prompt must steer the agent to background+poll instead.
+    #[test]
+    fn translate_prompt_has_sleep_guidance() {
+        assert!(
+            PROMPT_CLAUDE_TRANSLATE.contains("run_in_background"),
+            "the translate prompt must carry the run_in_background sleep guidance",
+        );
+    }
 }
 
 /// Tool-specific configuration, read from `[tools.translate_agentic]` in the HARVEST config.

--- a/tools/translate_agentic/src/prompt_claude_translate.md
+++ b/tools/translate_agentic/src/prompt_claude_translate.md
@@ -382,3 +382,11 @@ complete in `PLAN.md` with a final note.
 Your job ends when every feature combo's `cargo build` is green.
 A separate verification agent runs after you and owns ALL execution-based
 correctness checking. Doing that work here wastes turns. Trust the next agent. Stop at green compile.
+## Waiting on long-running commands
+
+Building the C reference, building Rust, and running KAT/signing tests can be
+slow (some configurations take minutes). When you need to wait for a long
+command, run it with `run_in_background` and poll for completion, or wrap a
+short sleep in a condition loop (e.g. `until [ -f done.marker ]; do sleep 2; done`).
+Do NOT block on a single long foreground `sleep` such as `sleep 30 && cat log` --
+it will be rejected, and chaining `sleep` calls only wastes turns.

--- a/tools/translate_agentic/src/prompt_claude_translate.md
+++ b/tools/translate_agentic/src/prompt_claude_translate.md
@@ -384,8 +384,7 @@ A separate verification agent runs after you and owns ALL execution-based
 correctness checking. Doing that work here wastes turns. Trust the next agent. Stop at green compile.
 ## Waiting on long-running commands
 
-Building the C reference, building Rust, and running KAT/signing tests can be
-slow (some configurations take minutes). When you need to wait for a long
+Builds and tests can be slow (some commands take minutes). When you need to wait for a long
 command, run it with `run_in_background` and poll for completion, or wrap a
 short sleep in a condition loop (e.g. `until [ -f done.marker ]; do sleep 2; done`).
 Do NOT block on a single long foreground `sleep` such as `sleep 30 && cat log` --

--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -780,6 +780,21 @@ mod tests {
             "the dropped agent-tools placeholder must not survive in either prompt",
         );
     }
+
+    /// Both verify prompts must carry the run_in_background sleep guidance: the
+    /// verify loop runs slow C/Rust builds and KAT tests, and a single long
+    /// foreground `sleep` is rejected by the agent's Bash tool and stalls it.
+    #[test]
+    fn verify_prompts_have_sleep_guidance() {
+        assert!(
+            PROMPT_CLAUDE_VERIFY.contains("run_in_background"),
+            "plan-mode verify prompt must carry the run_in_background sleep guidance",
+        );
+        assert!(
+            PROMPT_CLAUDE_VERIFY_NO_PLAN.contains("run_in_background"),
+            "no-plan verify prompt must carry the run_in_background sleep guidance",
+        );
+    }
 }
 
 /// Tool-specific configuration, read from `[tools.verify_fix_agentic]` in the HARVEST config.

--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -183,12 +183,20 @@ fn invoke_agent(
             let mut cmd = Command::new("bash");
             cmd.arg("-c")
                 .arg(format!(
-                    "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                    // Redirect to the log file (no `| tee`): a `run_in_background`
+                    // bash task the agent spawns inherits claude's stdout fd, and
+                    // with a pipe it would hold the write-end open after claude
+                    // exits, so `tee` never sees EOF and this command hangs until
+                    // the timeout (observed on the SPHINCS+ verify run). Writing
+                    // to a file avoids the pipe; we replay the log to stdout
+                    // afterward so the transcript still reaches captured output.
+                    // `--kill-after` hard-kills claude if it ignores SIGTERM.
+                    "timeout --kill-after=60s {timeout_secs} claude -p \"$PROMPT\" \
                      --permission-mode bypassPermissions \
                      --allowedTools 'Bash(*)' 'Write' 'Edit' \
                      {model_flag}{append_sys_flag}\
                      --output-format stream-json --verbose \
-                     < /dev/null 2>&1 | tee \"$LOG\"",
+                     < /dev/null > \"$LOG\" 2>&1; status=$?; cat \"$LOG\"; exit $status",
                 ))
                 .env("PROMPT", prompt)
                 .env("LOG", &log_path)

--- a/tools/verify_fix_agentic/src/prompt_claude_verify.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify.md
@@ -192,3 +192,11 @@ re-verification, the 600-second timeout cap) live in the `## Invariants`
 section of your `HYPOTHESES.md` template above. Re-read them from
 `HYPOTHESES.md` whenever you are unsure — do not work from memory of this
 prompt.
+## Waiting on long-running commands
+
+Building the C reference, building Rust, and running KAT/signing tests can be
+slow (some configurations take minutes). When you need to wait for a long
+command, run it with `run_in_background` and poll for completion, or wrap a
+short sleep in a condition loop (e.g. `until [ -f done.marker ]; do sleep 2; done`).
+Do NOT block on a single long foreground `sleep` such as `sleep 30 && cat log` --
+it will be rejected, and chaining `sleep` calls only wastes turns.

--- a/tools/verify_fix_agentic/src/prompt_claude_verify.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify.md
@@ -194,8 +194,7 @@ section of your `HYPOTHESES.md` template above. Re-read them from
 prompt.
 ## Waiting on long-running commands
 
-Building the C reference, building Rust, and running KAT/signing tests can be
-slow (some configurations take minutes). When you need to wait for a long
+Builds and tests can be slow (some commands take minutes). When you need to wait for a long
 command, run it with `run_in_background` and poll for completion, or wrap a
 short sleep in a condition loop (e.g. `until [ -f done.marker ]; do sleep 2; done`).
 Do NOT block on a single long foreground `sleep` such as `sleep 30 && cat log` --

--- a/tools/verify_fix_agentic/src/prompt_claude_verify_no_plan.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify_no_plan.md
@@ -46,3 +46,11 @@ IMPORTANT: Use timeouts for all commands. No single build or test command should
 run longer than 600 seconds. If a test takes too long, skip it and move on to
 the next function. Use `timeout 600 cargo test ...` or similar. Do not get stuck
 on any single step.
+## Waiting on long-running commands
+
+Building the C reference, building Rust, and running KAT/signing tests can be
+slow (some configurations take minutes). When you need to wait for a long
+command, run it with `run_in_background` and poll for completion, or wrap a
+short sleep in a condition loop (e.g. `until [ -f done.marker ]; do sleep 2; done`).
+Do NOT block on a single long foreground `sleep` such as `sleep 30 && cat log` --
+it will be rejected, and chaining `sleep` calls only wastes turns.

--- a/tools/verify_fix_agentic/src/prompt_claude_verify_no_plan.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify_no_plan.md
@@ -48,8 +48,7 @@ the next function. Use `timeout 600 cargo test ...` or similar. Do not get stuck
 on any single step.
 ## Waiting on long-running commands
 
-Building the C reference, building Rust, and running KAT/signing tests can be
-slow (some configurations take minutes). When you need to wait for a long
+Builds and tests can be slow (some commands take minutes). When you need to wait for a long
 command, run it with `run_in_background` and poll for completion, or wrap a
 short sleep in a condition loop (e.g. `until [ -f done.marker ]; do sleep 2; done`).
 Do NOT block on a single long foreground `sleep` such as `sleep 30 && cat log` --


### PR DESCRIPTION
Two related fixes for long, unattended agentic runs (surfaced by the SPHINCS+ end-to-end run), plus a review tweak.

## 1. run_in_background sleep guidance (prompts)
The agent's Bash tool rejects a single long foreground `sleep` as an anti-pattern; the verify loop runs slow builds/tests and kept hitting "Blocked: sleep". Added a "Waiting on long-running commands" section to both verify prompts telling the agent to use `run_in_background` + polling (or a short sleep inside an `until` loop), never a long foreground sleep. **Restored** the same section to the translate prompt (it had it pre-port, but #170 dropped it when it overwrote the translate prompt). Regression tests in both crates so it can't be silently dropped again.

Per review: generalized the wording (dropped SPHINCS-specific "KAT/signing tests" → "Builds and tests can be slow").

## 2. Fix `claude -p` pipe hang (invoke_agent) — folded in from #174
After the agent finished (emitted its `result` event), the benchmark stayed blocked for ~35 min until the timeout. Cause: the invocation piped through `tee`, and a `run_in_background` child inherits claude's stdout fd; `claude -p` doesn't wait for/kill background tasks on exit, so the orphan held the pipe's write-end open → `tee` never got EOF → `.status()` blocked.

Fix: redirect claude's output to the log **file** (no pipe), then `cat` it to stdout afterward so the transcript still reaches captured output; add `timeout --kill-after=60s`. Applied to both translate and verify Claude invocations. Shell-validated: redirect returns in ~0.015s with a lingering 20s background child vs ~20s for the `| tee` pattern.

fmt clean; `translate_agentic` (15) + `verify_fix_agentic` (12) tests pass.

Context: part of preparing the agentic pipeline for T&E (large ~100kloc codebases, long unattended runs). The ported methodology was validated on SPHINCS+ (48/48 configs byte-identical).