### PR TITLE
agentic: fix claude -p hang (redirect to file instead of tee)

### DIFF
--- a/tools/translate_agentic/src/lib.rs
+++ b/tools/translate_agentic/src/lib.rs
@@ -222,12 +222,20 @@ fn invoke_agent(
             let mut cmd = Command::new("bash");
             cmd.arg("-c")
                 .arg(format!(
-                    "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                    // Redirect to the log file (no `| tee`): a `run_in_background`
+                    // bash task the agent spawns inherits claude's stdout fd, and
+                    // with a pipe it would hold the write-end open after claude
+                    // exits, so `tee` never sees EOF and this command hangs until
+                    // the timeout. Writing to a file avoids the pipe; we replay
+                    // the log to stdout afterward so the transcript still reaches
+                    // the benchmark's captured output. `--kill-after` hard-kills
+                    // claude if it ignores SIGTERM at the timeout.
+                    "timeout --kill-after=60s {timeout_secs} claude -p \"$PROMPT\" \
                      --permission-mode bypassPermissions \
                      --allowedTools 'Bash(*)' 'Write' 'Edit' \
                      {model_flag}{append_sys_flag}\
                      --output-format stream-json --verbose \
-                     < /dev/null 2>&1 | tee \"$LOG\"",
+                     < /dev/null > \"$LOG\" 2>&1; status=$?; cat \"$LOG\"; exit $status",
                 ))
                 .env("PROMPT", prompt)
                 .env("LOG", &log_path)

--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -183,12 +183,20 @@ fn invoke_agent(
             let mut cmd = Command::new("bash");
             cmd.arg("-c")
                 .arg(format!(
-                    "set -o pipefail; timeout {timeout_secs} claude -p \"$PROMPT\" \
+                    // Redirect to the log file (no `| tee`): a `run_in_background`
+                    // bash task the agent spawns inherits claude's stdout fd, and
+                    // with a pipe it would hold the write-end open after claude
+                    // exits, so `tee` never sees EOF and this command hangs until
+                    // the timeout (observed on the SPHINCS+ verify run). Writing
+                    // to a file avoids the pipe; we replay the log to stdout
+                    // afterward so the transcript still reaches captured output.
+                    // `--kill-after` hard-kills claude if it ignores SIGTERM.
+                    "timeout --kill-after=60s {timeout_secs} claude -p \"$PROMPT\" \
                      --permission-mode bypassPermissions \
                      --allowedTools 'Bash(*)' 'Write' 'Edit' \
                      {model_flag}{append_sys_flag}\
                      --output-format stream-json --verbose \
-                     < /dev/null 2>&1 | tee \"$LOG\"",
+                     < /dev/null > \"$LOG\" 2>&1; status=$?; cat \"$LOG\"; exit $status",
                 ))
                 .env("PROMPT", prompt)
                 .env("LOG", &log_path)


### PR DESCRIPTION
## Symptom
On the SPHINCS+ end-to-end run, the verify agent finished its work in ~3 minutes (emitted its final `result` event, `terminal_reason: completed`), but the benchmark stayed blocked for ~35 more minutes until the external `timeout` fired. For an unattended T&E run this wastes the entire (multi-hour) timeout budget on a run that's actually done.

## Root cause
The Claude invocation pipes through `tee`: `claude … | tee "$LOG"`. The agent used the Bash tool with `run_in_background: true` (3×). A backgrounded child **inherits claude's stdout fd**, and `claude -p` does **not** wait for or kill background tasks on exit. So after claude exits, the orphaned child keeps the pipe's write-end open → `tee` never sees EOF → the `claude | tee` pipeline never completes → the Rust `.status()` wait blocks until `timeout`.

## Fix
Redirect claude's stdout/stderr to the log **file** (no pipe), then `cat` the log to stdout afterward so the transcript still reaches the benchmark's captured output (the per-agent log lives in the ephemeral tempdir, so the `cat` is what preserves it). Without a pipe there's no EOF to wait on, so the wrapper returns as soon as claude exits, regardless of any lingering background child. Also add `timeout --kill-after=60s` for a hard SIGKILL if claude ignores SIGTERM at the cap. Applied to both the translate and verify Claude invocations.

## Validation
Shell-level reproduction with a lingering 20s background child:
- redirect-to-file pattern returns in **0.015s**;
- `| tee` pattern blocks the full **20s**.

So the change resolves the exact hang. fmt clean; `translate_agentic` + `verify_fix_agentic` tests pass.

Residual (intentional, out of scope): the orphaned background task still runs after claude exits; it no longer blocks and is bounded by the container lifetime in deployment. Tracked alongside the T&E prep work.