### PR TITLE
translate: lock overridable agentic timeout contract for T&E

### DIFF
--- a/translate/src/cli.rs
+++ b/translate/src/cli.rs
@@ -262,4 +262,40 @@ mod tests {
             Some(5400)
         );
     }
+
+    /// A user/deployment config (e.g. the T&E container's config TOML) can raise
+    /// the agentic timeouts above the embedded defaults. This is the supported
+    /// way to give very large codebases a much longer budget without changing
+    /// the reasonable in-repo defaults.
+    #[cfg(not(miri))]
+    #[test]
+    fn agentic_timeouts_are_overridable_by_user_config() {
+        use super::*;
+        use harvest_core::test_util::tempdir;
+        use std::{fs, io::Write as _};
+        let config_dir = tempdir().unwrap();
+        fs::File::create(config_file(config_dir.path()))
+            .unwrap()
+            .write_all(
+                br#"
+                    [tools.translate_agentic]
+                    timeout_secs = 36000
+                    [tools.verify_fix_agentic]
+                    timeout_secs = 28800
+                "#,
+            )
+            .unwrap();
+        let cfg = load_config(
+            &Args::parse_from(["", "a", "--output=/tmp/out"]),
+            config_dir.path(),
+        );
+        assert_eq!(
+            cfg.tools["translate_agentic"]["timeout_secs"].as_u64(),
+            Some(36000)
+        );
+        assert_eq!(
+            cfg.tools["verify_fix_agentic"]["timeout_secs"].as_u64(),
+            Some(28800)
+        );
+    }
 }


### PR DESCRIPTION
## Why

The TRACTOR Test & Evaluation runs against a much larger, unknown codebase (~100 kloc); a ~75 kloc translation (zlib) took ~7 hours. The in-repo agent timeouts are intentionally modest:

- `[tools.translate_agentic].timeout_secs = 7200` (2h)
- `[tools.verify_fix_agentic].timeout_secs = 5400` (90m)

These are already plain config keys, so the T&E container can raise them far above the defaults without changing anything in the repo, via any of the normal config layers:

- `config.toml` in the working directory
- `translate.toml` in the config dir (the same file the container writes its API-key config into)
- `--config tools.translate_agentic.timeout_secs=43200 --config tools.verify_fix_agentic.timeout_secs=28800`

The external `timeout --kill-after=60s {timeout_secs} claude ...` wrapper enforces the value, so bumping the config directly extends the wall-clock budget.

## What

No production change is required. This adds a regression test locking the contract: with no user config the embedded defaults (7200/5400) resolve, and a user config overrides them. This guards against a future change silently making the timeouts non-overridable.