### PR TITLE
Add tool to build C artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_c_artifact"
+version = "0.1.0"
+dependencies = [
+ "build_project_spec",
+ "full_source",
+ "harvest_core",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "build_config"
 version = "0.1.0"
 dependencies = [
@@ -1421,6 +1432,7 @@ dependencies = [
 name = "harvest_translate"
 version = "0.1.0"
 dependencies = [
+ "build_c_artifact",
  "build_config",
  "build_project_spec",
  "c_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic"]
+members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -20,6 +20,7 @@ quantize_rust_spans = { path = "tools/quantize_rust_spans" }
 fix_declarations_llm = { path = "tools/fix_declarations_llm" }
 translate_agentic = { path = "tools/translate_agentic" }
 verify_fix_agentic = { path = "tools/verify_fix_agentic" }
+build_c_artifact = { path = "tools/build_c_artifact" }
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/tools/build_c_artifact/Cargo.toml
+++ b/tools/build_c_artifact/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "build_c_artifact"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+build_project_spec.workspace = true
+full_source.workspace = true
+harvest_core.workspace = true
+tempfile.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/build_c_artifact/src/lib.rs
+++ b/tools/build_c_artifact/src/lib.rs
@@ -1,0 +1,155 @@
+use build_project_spec::{ProjectKind, ProjectSpec};
+use full_source::RawSource;
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tracing::info;
+
+/// The compiled C artifact produced by running CMake on the C source.
+///
+/// Exactly one of `so_path` or `exe_path` is `Some` depending on the project kind.
+pub struct CArtifact {
+    pub so_path: Option<PathBuf>,
+    pub exe_path: Option<PathBuf>,
+    _root: Option<Arc<TempDir>>,
+}
+
+impl std::fmt::Display for CArtifact {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match (&self.so_path, &self.exe_path) {
+            (Some(p), _) => write!(f, "CArtifact(so={})", p.display()),
+            (_, Some(p)) => write!(f, "CArtifact(exe={})", p.display()),
+            _ => write!(f, "CArtifact(not applicable)"),
+        }
+    }
+}
+
+impl Representation for CArtifact {
+    fn name(&self) -> &'static str {
+        "c_artifact"
+    }
+
+    fn materialize(&self, _path: &Path) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+pub struct BuildCArtifact;
+
+impl Tool for BuildCArtifact {
+    fn name(&self) -> &'static str {
+        "build_c_artifact"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let raw_source = context
+            .ir_snapshot
+            .get::<RawSource>(inputs[0])
+            .ok_or("build_c_artifact: no RawSource in IR")?;
+        let project_spec = context
+            .ir_snapshot
+            .get::<ProjectSpec>(inputs[1])
+            .ok_or("build_c_artifact: no ProjectSpec in IR")?;
+
+        let root = Arc::new(tempfile::tempdir()?);
+        let src_dir = root.path().join("src");
+        let build_dir = root.path().join("build");
+        std::fs::create_dir_all(&src_dir)?;
+        std::fs::create_dir_all(&build_dir)?;
+
+        raw_source.dir.materialize(&src_dir)?;
+
+        info!("Running cmake configure in {}", build_dir.display());
+        let status = Command::new("cmake")
+            .arg("-S")
+            .arg(&src_dir)
+            .arg("-B")
+            .arg(&build_dir)
+            .status()
+            .map_err(|e| format!("build_c_artifact: failed to run cmake: {e}"))?;
+        if !status.success() {
+            return Err("build_c_artifact: cmake configure failed".into());
+        }
+
+        info!("Running cmake --build in {}", build_dir.display());
+        let status = Command::new("cmake")
+            .arg("--build")
+            .arg(&build_dir)
+            .status()
+            .map_err(|e| format!("build_c_artifact: failed to run cmake --build: {e}"))?;
+        if !status.success() {
+            return Err("build_c_artifact: cmake build failed".into());
+        }
+
+        match project_spec.kind {
+            ProjectKind::Library => {
+                let so_path = find_shared_lib(&build_dir)
+                    .ok_or("build_c_artifact: no .so found in build directory")?;
+                info!("Found shared library: {}", so_path.display());
+                Ok(Box::new(CArtifact {
+                    so_path: Some(so_path),
+                    exe_path: None,
+                    _root: Some(root),
+                }))
+            }
+            ProjectKind::Executable => {
+                let exe_path = find_executable(&build_dir)
+                    .ok_or("build_c_artifact: no executable found in build directory")?;
+                info!("Found executable: {}", exe_path.display());
+                Ok(Box::new(CArtifact {
+                    so_path: None,
+                    exe_path: Some(exe_path),
+                    _root: Some(root),
+                }))
+            }
+        }
+    }
+}
+
+/// Recursively walks `dir` and returns the first file whose extension is exactly `so`.
+/// Matches unversioned symlinks (`libfoo.so`) rather than versioned files (`libfoo.so.1.0.0`).
+fn find_shared_lib(dir: &Path) -> Option<PathBuf> {
+    let read_dir = std::fs::read_dir(dir).ok()?;
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(found) = find_shared_lib(&path) {
+                return Some(found);
+            }
+        } else if path.extension().and_then(|e| e.to_str()) == Some("so") {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Recursively walks `dir` and returns the first regular file that has the execute bit set
+/// and no file extension. Skips `CMakeFiles` directories to avoid cmake build artifacts.
+fn find_executable(dir: &Path) -> Option<PathBuf> {
+    let read_dir = std::fs::read_dir(dir).ok()?;
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if path.file_name().and_then(|n| n.to_str()) == Some("CMakeFiles") {
+                continue;
+            }
+            if let Some(found) = find_executable(&path) {
+                return Some(found);
+            }
+        } else if path.extension().is_none()
+            && let Ok(meta) = std::fs::metadata(&path)
+            && meta.permissions().mode() & 0o111 != 0
+        {
+            return Some(path);
+        }
+    }
+    None
+}

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -34,6 +34,7 @@ fix_declarations_llm.workspace = true
 raw_source_to_cargo_llm.workspace = true
 translate_agentic.workspace = true
 verify_fix_agentic.workspace = true
+build_c_artifact.workspace = true
 
 [dev-dependencies]
 full_source.workspace = true


### PR DESCRIPTION
This PR adds `build_c_artifact`, a tool that runs cmake to build a C project.
This is a stepping stone to building a differential fuzzing harness between projects translated by Harvest, and the original source code.