### PR TITLE
Move runner utility into a separate tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "exec_runner"
+version = "0.1.0"
+dependencies = [
+ "wait-timeout",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1405,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "csv",
+ "exec_runner",
  "full_source",
  "harvest_core",
  "harvest_translate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact"]
+members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -21,6 +21,7 @@ fix_declarations_llm = { path = "tools/fix_declarations_llm" }
 translate_agentic = { path = "tools/translate_agentic" }
 verify_fix_agentic = { path = "tools/verify_fix_agentic" }
 build_c_artifact = { path = "tools/build_c_artifact" }
+exec_runner = { path = "tools/exec_runner" }
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { workspace = true }
 toml_edit = { workspace = true }
 try_cargo_build = { version = "0.1.0", path = "../tools/try_cargo_build" }
 write_output = { workspace = true }
+exec_runner = { workspace = true }
 wait-timeout = "0.2"
 walkdir = "2.0"
 

--- a/benchmark/src/runner.rs
+++ b/benchmark/src/runner.rs
@@ -1,103 +1,19 @@
 use crate::error::HarvestResult;
-use std::io::Write;
+use crate::harness::TestCase;
 use std::path::Path;
-use std::process::{Child, Command, Output, Stdio};
+use std::process::Output;
 use std::time::Duration;
 
-use crate::harness::TestCase;
-
-/// Runs a binary with test case inputs and enforces a timeout
+/// Runs a binary with test case inputs and enforces a timeout.
 pub fn run_binary_with_timeout(
     binary_path: &Path,
     test_case: &TestCase,
     timeout: Duration,
 ) -> HarvestResult<Output> {
-    let mut child = spawn_process_with_args(binary_path, test_case)?;
-    write_stdin_to_process(&mut child, test_case.stdin.as_deref(), binary_path)?;
-    wait_for_process_with_timeout(child, timeout)
-}
-
-/// Spawns a process with the appropriate command line arguments and stdio configuration
-fn spawn_process_with_args(binary_path: &Path, test_case: &TestCase) -> HarvestResult<Child> {
-    let mut cmd = Command::new(binary_path);
-    cmd.args(&test_case.argv[..]);
-
-    // Configure stdio pipes
-    cmd.stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    // Start the process
-    cmd.spawn().map_err(|e| -> Box<dyn std::error::Error> {
-        format!("Failed to spawn process: {}: {}", binary_path.display(), e).into()
-    })
-}
-
-/// Writes stdin data to the child process
-fn write_stdin_to_process(
-    child: &mut Child,
-    stdin_data: Option<&str>,
-    binary_path: &Path,
-) -> HarvestResult<()> {
-    // Early return if no stdin data - just close the pipe
-    let Some(data) = stdin_data else {
-        if let Some(stdin) = child.stdin.take() {
-            drop(stdin);
-        }
-        return Ok(());
-    };
-
-    // Get stdin handle or return error
-    let mut stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| -> Box<dyn std::error::Error> {
-            format!(
-                "Failed to open stdin for process: {}",
-                binary_path.display()
-            )
-            .into()
-        })?;
-
-    // Write data to stdin
-    stdin
-        .write_all(data.as_bytes())
-        .map_err(|e| -> Box<dyn std::error::Error> {
-            format!("Failed to write to stdin: {}", e).into()
-        })?;
-
-    // stdin is automatically closed when dropped
-    Ok(())
-}
-
-/// Waits for the process to complete within the timeout, handling cleanup on timeout or error
-fn wait_for_process_with_timeout(mut child: Child, timeout: Duration) -> HarvestResult<Output> {
-    use wait_timeout::ChildExt;
-
-    match child.wait_timeout(timeout) {
-        Ok(Some(_status)) => {
-            // Process completed within timeout, get the output
-            child
-                .wait_with_output()
-                .map_err(|e| -> Box<dyn std::error::Error> {
-                    format!("Failed to read process output: {}", e).into()
-                })
-        }
-        Ok(None) => {
-            // Timeout occurred - clean up and return error
-            cleanup_process(&mut child);
-            Err(format!("Process timed out after {} seconds", timeout.as_secs()).into())
-        }
-        Err(e) => {
-            // Error waiting for process - clean up and return error
-            cleanup_process(&mut child);
-            Err(format!("Error waiting for process: {}", e).into())
-        }
-    }
-}
-
-/// Kills and waits for a process, ignoring any errors during cleanup
-fn cleanup_process(child: &mut Child) {
-    let _ = child.kill();
-    let _ = child.wait();
+    exec_runner::run_with_timeout(
+        binary_path,
+        &test_case.argv,
+        test_case.stdin.as_deref(),
+        timeout,
+    )
 }

--- a/tools/exec_runner/Cargo.toml
+++ b/tools/exec_runner/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "exec_runner"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+wait-timeout = "0.2"
+
+[lints]
+workspace = true

--- a/tools/exec_runner/src/lib.rs
+++ b/tools/exec_runner/src/lib.rs
@@ -1,0 +1,59 @@
+use std::io::Write;
+use std::path::Path;
+use std::process::{Child, Command, Output, Stdio};
+use std::time::Duration;
+use wait_timeout::ChildExt;
+
+/// Runs a binary with the given arguments and optional stdin, enforcing a timeout.
+/// Returns the full `Output` (stdout, stderr, exit status) on success.
+pub fn run_with_timeout(
+    binary: &Path,
+    argv: &[String],
+    stdin: Option<&str>,
+    timeout: Duration,
+) -> Result<Output, Box<dyn std::error::Error>> {
+    let mut child = spawn(binary, argv)?;
+    write_stdin(&mut child, stdin, binary)?;
+    finish(child, timeout)
+}
+
+fn spawn(binary: &Path, argv: &[String]) -> Result<Child, Box<dyn std::error::Error>> {
+    Command::new(binary)
+        .args(argv)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("exec_runner: failed to spawn {}: {e}", binary.display()).into())
+}
+
+fn write_stdin(
+    child: &mut Child,
+    data: Option<&str>,
+    binary: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(data) = data else {
+        drop(child.stdin.take());
+        return Ok(());
+    };
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| format!("exec_runner: could not open stdin for {}", binary.display()))?;
+    stdin
+        .write_all(data.as_bytes())
+        .map_err(|e| format!("exec_runner: stdin write failed: {e}").into())
+}
+
+fn finish(mut child: Child, timeout: Duration) -> Result<Output, Box<dyn std::error::Error>> {
+    match child.wait_timeout(timeout)? {
+        Some(_) => child
+            .wait_with_output()
+            .map_err(|e| format!("exec_runner: failed to read output: {e}").into()),
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(format!("exec_runner: timed out after {}s", timeout.as_secs()).into())
+        }
+    }
+}


### PR DESCRIPTION
This PR moves our utility in `benchmark` for running executables into a separate tool so that we can then use it as a component in our differential testing harness.