### PR TITLE
Test-repair loop PR 1/3: Run library differential tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generate_difftest_suite"
+version = "0.1.0"
+dependencies = [
+ "full_source",
+ "harvest_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,12 +1461,14 @@ dependencies = [
  "emit_build_features",
  "fix_declarations_llm",
  "full_source",
+ "generate_difftest_suite",
  "harvest_core",
  "libc",
  "load_raw_source",
  "modular_translation_llm",
  "quantize_rust_spans",
  "raw_source_to_cargo_llm",
+ "run_difftest",
  "serde",
  "serde_json",
  "thiserror",
@@ -2423,6 +2436,18 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "run_difftest"
+version = "0.1.0"
+dependencies = [
+ "build_c_artifact",
+ "full_source",
+ "generate_difftest_suite",
+ "harvest_core",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner"]
+members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner", "tools/generate_difftest_suite", "tools/run_difftest"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -22,6 +22,8 @@ translate_agentic = { path = "tools/translate_agentic" }
 verify_fix_agentic = { path = "tools/verify_fix_agentic" }
 build_c_artifact = { path = "tools/build_c_artifact" }
 exec_runner = { path = "tools/exec_runner" }
+generate_difftest_suite = { path = "tools/generate_difftest_suite" }
+run_difftest = { path = "tools/run_difftest" }
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/tools/generate_difftest_suite/Cargo.toml
+++ b/tools/generate_difftest_suite/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "generate_difftest_suite"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+full_source.workspace = true
+harvest_core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/generate_difftest_suite/src/generators.rs
+++ b/tools/generate_difftest_suite/src/generators.rs
@@ -1,0 +1,187 @@
+use super::{FnSig, is_string_type};
+use std::collections::HashMap;
+
+/// Map from unqualified struct name → (compound-literal name, fields).
+/// The compound-literal name is the typedef name when one exists (e.g. `Point`),
+/// or `struct Tag` for a plain struct tag.
+pub(super) type StructMap = HashMap<String, (String, Vec<(String, String)>)>;
+
+pub(super) struct TestVector {
+    pub(super) function: String,
+    pub(super) args: Vec<String>,
+}
+
+/// Returns C expression strings representing interesting boundary values for
+/// a C type. Returns an empty vec for unknown/unsupported types.
+pub(super) fn boundary_values(ty: &str, structs: &StructMap) -> Vec<String> {
+    boundary_values_inner(ty, structs, 0)
+}
+
+fn boundary_values_inner(ty: &str, structs: &StructMap, depth: usize) -> Vec<String> {
+    if depth > 4 {
+        return vec![];
+    }
+    let ty = ty.trim();
+
+    // String types (must come before generic pointer check)
+    if is_string_type(ty) {
+        return vec![
+            "NULL".to_string(),
+            r#""""#.to_string(),
+            r#""hello""#.to_string(),
+        ];
+    }
+
+    // Pointer types
+    if let Some(stripped) = ty.strip_suffix('*') {
+        let inner = stripped.trim();
+        let inner_base = inner.trim_start_matches("const").trim();
+
+        if inner_base == "void" {
+            return vec!["NULL".to_string()];
+        }
+
+        // Pointer to known struct
+        let struct_key = inner_base.trim_start_matches("struct").trim();
+        if let Some((compound_name, fields)) = structs.get(struct_key) {
+            let lit = struct_compound_literal(compound_name, fields, structs, depth + 1);
+            return vec![format!("&{lit}"), "NULL".to_string()];
+        }
+
+        // Pointer to known scalar — use compound literal to take address
+        let inner_vals = boundary_values_inner(inner_base, structs, depth + 1);
+        if !inner_vals.is_empty() {
+            let neutral = &inner_vals[0];
+            return vec![format!("&({inner_base}){{{neutral}}}"), "NULL".to_string()];
+        }
+
+        return vec!["NULL".to_string()];
+    }
+
+    // Struct types (by value)
+    let struct_key = ty.trim_start_matches("struct").trim();
+    if let Some((compound_name, fields)) = structs.get(struct_key).or_else(|| structs.get(ty)) {
+        return vec![struct_compound_literal(
+            compound_name,
+            fields,
+            structs,
+            depth + 1,
+        )];
+    }
+
+    // Primitive types
+    match ty {
+        "int" | "signed int" | "signed" => &["0", "1", "-1", "INT_MAX", "INT_MIN"] as &[&str],
+        "unsigned int" | "unsigned" => &["0", "1", "UINT_MAX"],
+        "long" | "signed long" | "long int" => &["0", "1", "-1", "LONG_MAX", "LONG_MIN"],
+        "unsigned long" | "unsigned long int" => &["0", "1", "ULONG_MAX"],
+        "long long" | "signed long long" | "long long int" => {
+            &["0", "1", "-1", "LLONG_MAX", "LLONG_MIN"]
+        }
+        "unsigned long long" | "unsigned long long int" => &["0", "1", "ULLONG_MAX"],
+        "short" | "signed short" | "short int" => &["0", "1", "-1", "SHRT_MAX", "SHRT_MIN"],
+        "unsigned short" | "unsigned short int" => &["0", "1", "USHRT_MAX"],
+        "char" => &["0", "'a'", "CHAR_MAX", "CHAR_MIN"],
+        "signed char" => &["0", "1", "-1", "SCHAR_MAX", "SCHAR_MIN"],
+        "unsigned char" => &["0", "'a'", "UCHAR_MAX"],
+        "float" => &["0.0f", "1.0f", "-1.0f"],
+        "double" => &["0.0", "1.0", "-1.0"],
+        "long double" => &["0.0L", "1.0L", "-1.0L"],
+        "size_t" => &["0", "1", "SIZE_MAX"],
+        "ssize_t" | "ptrdiff_t" | "intptr_t" => &["0", "1", "-1"],
+        "uintptr_t" => &["0", "1"],
+        "bool" | "_Bool" => &["0", "1"],
+        "int8_t" | "int_least8_t" | "int_fast8_t" => &["0", "1", "-1", "INT8_MAX", "INT8_MIN"],
+        "int16_t" | "int_least16_t" | "int_fast16_t" => &["0", "1", "-1", "INT16_MAX", "INT16_MIN"],
+        "int32_t" | "int_least32_t" | "int_fast32_t" => &["0", "1", "-1", "INT32_MAX", "INT32_MIN"],
+        "int64_t" | "int_least64_t" | "int_fast64_t" => &["0", "1", "-1", "INT64_MAX", "INT64_MIN"],
+        "uint8_t" | "uint_least8_t" | "uint_fast8_t" => &["0", "1", "UINT8_MAX"],
+        "uint16_t" | "uint_least16_t" | "uint_fast16_t" => &["0", "1", "UINT16_MAX"],
+        "uint32_t" | "uint_least32_t" | "uint_fast32_t" => &["0", "1", "UINT32_MAX"],
+        "uint64_t" | "uint_least64_t" | "uint_fast64_t" => &["0", "1", "UINT64_MAX"],
+        _ => return vec![],
+    }
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+/// Build a C99 compound literal for a struct, using the neutral (first) boundary
+/// value for each field. Fields with unresolvable types are omitted (C zero-inits them).
+fn struct_compound_literal(
+    compound_name: &str,
+    fields: &[(String, String)],
+    structs: &StructMap,
+    depth: usize,
+) -> String {
+    let inits: Vec<String> = fields
+        .iter()
+        .filter_map(|(fname, ftype)| {
+            boundary_values_inner(ftype, structs, depth)
+                .into_iter()
+                .next()
+                .map(|val| format!(".{fname} = {val}"))
+        })
+        .collect();
+    if inits.is_empty() {
+        format!("({compound_name}){{0}}")
+    } else {
+        format!("({compound_name}){{{}}}", inits.join(", "))
+    }
+}
+
+/// Generate OVAT test vectors for all functions whose parameter types are fully resolvable.
+pub(super) fn generate_test_vectors(
+    sigs: &HashMap<String, FnSig>,
+    structs: &StructMap,
+) -> Vec<TestVector> {
+    let mut fn_names: Vec<&String> = sigs.keys().collect();
+    fn_names.sort();
+
+    let mut tests = Vec::new();
+
+    for fn_name in fn_names {
+        let sig = &sigs[fn_name];
+
+        if sig.param_types.is_empty() {
+            tests.push(TestVector {
+                function: fn_name.clone(),
+                args: vec![],
+            });
+            continue;
+        }
+
+        let value_sets: Vec<Vec<String>> = sig
+            .param_types
+            .iter()
+            .map(|ty| boundary_values(ty, structs))
+            .collect();
+
+        // Skip functions with unresolvable parameter types
+        if value_sets.iter().any(|v| v.is_empty()) {
+            continue;
+        }
+
+        let neutral: Vec<String> = value_sets.iter().map(|v| v[0].clone()).collect();
+
+        // Baseline: all parameters at their neutral value
+        tests.push(TestVector {
+            function: fn_name.clone(),
+            args: neutral.clone(),
+        });
+
+        // OVAT: vary each parameter through its non-neutral values
+        for (i, values) in value_sets.iter().enumerate() {
+            for val in values.iter().skip(1) {
+                let mut args = neutral.clone();
+                args[i] = val.clone();
+                tests.push(TestVector {
+                    function: fn_name.clone(),
+                    args,
+                });
+            }
+        }
+    }
+
+    tests
+}

--- a/tools/generate_difftest_suite/src/lib.rs
+++ b/tools/generate_difftest_suite/src/lib.rs
@@ -1,0 +1,334 @@
+mod generators;
+
+use full_source::RawSource;
+use generators::{StructMap, TestVector, generate_test_vectors};
+use harvest_core::config::unknown_field_warning;
+use harvest_core::llm::{HarvestLLM, LLMConfig, LLMUsageTotals, build_request};
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tracing::info;
+
+const SCHEMA_API: &str = include_str!("structured_schema_api.json");
+const PROMPT_API: &str = include_str!("system_prompt_api.txt");
+
+const TMPL_HEADER: &str = include_str!("templates/header.c");
+const TMPL_PROLOGUE: &str = include_str!("templates/test_prologue.c");
+const TMPL_BODY_SCALAR: &str = include_str!("templates/body_scalar.c");
+const TMPL_BODY_VOID: &str = include_str!("templates/body_void.c");
+const TMPL_BODY_STRING: &str = include_str!("templates/body_string.c");
+const TMPL_BODY_WARN: &str = include_str!("templates/body_warn.c");
+const TMPL_MAIN: &str = include_str!("templates/main.c");
+
+/// A generated C differential test suite that loads both the C and Rust shared libraries via
+/// dlopen and compares their outputs on identical inputs.
+pub struct DiffTestSuite {
+    pub source: String,
+}
+
+impl std::fmt::Display for DiffTestSuite {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&self.source)
+    }
+}
+
+impl Representation for DiffTestSuite {
+    fn name(&self) -> &'static str {
+        "diff_test_suite"
+    }
+}
+
+pub struct GenerateDiffTestSuite;
+
+// ── Internal types ────────────────────────────────────────────────────────────
+
+pub(crate) struct FnSig {
+    pub(crate) return_type: String,
+    pub(crate) param_types: Vec<String>,
+}
+
+// ── API extraction ────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ApiFunction {
+    name: String,
+    return_type: String,
+    param_types: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ApiField {
+    name: String,
+    #[serde(rename = "type")]
+    ty: String,
+}
+
+#[derive(Deserialize)]
+struct ApiStruct {
+    name: String,
+    fields: Vec<ApiField>,
+}
+
+#[derive(Deserialize)]
+struct ApiResponse {
+    functions: Vec<ApiFunction>,
+    structs: Vec<ApiStruct>,
+}
+
+fn extract_c_api(
+    files: &[(PathBuf, &[u8])],
+    config: &Config,
+) -> Result<(HashMap<String, FnSig>, StructMap), Box<dyn std::error::Error>> {
+    #[derive(Serialize)]
+    struct InputFile {
+        path: String,
+        contents: String,
+    }
+
+    #[derive(Serialize)]
+    struct RequestBody {
+        files: Vec<InputFile>,
+    }
+
+    let request_files = files
+        .iter()
+        .map(|(path, contents)| InputFile {
+            path: path.to_string_lossy().into_owned(),
+            contents: String::from_utf8_lossy(contents).into_owned(),
+        })
+        .collect();
+
+    let llm = HarvestLLM::build(&config.llm, SCHEMA_API, PROMPT_API)?;
+    let request = build_request(
+        "Extract the public API from these C source files:",
+        &RequestBody {
+            files: request_files,
+        },
+    )?;
+
+    let mut usage = LLMUsageTotals::default();
+    let (response, u) = llm.invoke(&request)?;
+    usage.add_usage(u.as_ref());
+    info!("Token usage [api extraction] - {usage}");
+
+    let api: ApiResponse = serde_json::from_str(&response)?;
+
+    let sigs = api
+        .functions
+        .into_iter()
+        .map(|f| {
+            (
+                f.name,
+                FnSig {
+                    return_type: f.return_type,
+                    param_types: f.param_types,
+                },
+            )
+        })
+        .collect();
+
+    let structs = api
+        .structs
+        .into_iter()
+        .map(|s| {
+            let key = s.name.trim_start_matches("struct").trim().to_string();
+            let fields = s.fields.into_iter().map(|f| (f.name, f.ty)).collect();
+            (key, (s.name, fields))
+        })
+        .collect();
+
+    Ok((sigs, structs))
+}
+
+// ── C code generation ─────────────────────────────────────────────────────────
+
+fn fill(template: &str, subs: &[(&str, &str)]) -> String {
+    subs.iter().fold(template.to_string(), |s, (k, v)| {
+        s.replace(&format!("{{{k}}}"), v)
+    })
+}
+
+pub(crate) fn is_void_type(ty: &str) -> bool {
+    ty.trim() == "void"
+}
+
+pub(crate) fn is_scalar_type(ty: &str) -> bool {
+    matches!(
+        ty.trim(),
+        "int"
+            | "unsigned int"
+            | "long"
+            | "unsigned long"
+            | "long long"
+            | "unsigned long long"
+            | "short"
+            | "unsigned short"
+            | "char"
+            | "unsigned char"
+            | "signed char"
+            | "float"
+            | "double"
+            | "long double"
+            | "size_t"
+            | "ssize_t"
+            | "int8_t"
+            | "int16_t"
+            | "int32_t"
+            | "int64_t"
+            | "uint8_t"
+            | "uint16_t"
+            | "uint32_t"
+            | "uint64_t"
+            | "ptrdiff_t"
+            | "intptr_t"
+            | "uintptr_t"
+            | "bool"
+            | "_Bool"
+    )
+}
+
+pub(crate) fn is_string_type(ty: &str) -> bool {
+    matches!(
+        ty.trim(),
+        "char *" | "const char *" | "char*" | "const char*"
+    )
+}
+
+fn generate_difftest_c(tests: &[TestVector], sigs: &HashMap<String, FnSig>) -> String {
+    let mut out = TMPL_HEADER.to_string();
+
+    for (i, test) in tests.iter().enumerate() {
+        let test_id = format!("T{:03}", i + 1);
+        let fn_name = &test.function;
+
+        let Some(sig) = sigs.get(fn_name) else {
+            out.push_str(&fill(
+                TMPL_BODY_WARN,
+                &[("TEST_ID", &test_id), ("FN_NAME", fn_name)],
+            ));
+            continue;
+        };
+
+        let ret = sig.return_type.trim();
+        let param_type_str = if sig.param_types.is_empty() {
+            "void".to_string()
+        } else {
+            sig.param_types.join(", ")
+        };
+        let arg_decls = sig
+            .param_types
+            .iter()
+            .enumerate()
+            .map(|(j, ty)| {
+                let val = test.args.get(j).map(String::as_str).unwrap_or("0");
+                format!("    {} arg{j} = {};\n", ty.trim(), val)
+            })
+            .collect::<String>();
+        let args = (0..sig.param_types.len())
+            .map(|j| format!("arg{j}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let subs = &[
+            ("TEST_ID", test_id.as_str()),
+            ("FN_NAME", fn_name.as_str()),
+            ("RET", ret),
+            ("PARAM_TYPES", param_type_str.as_str()),
+            ("ARG_DECLS", arg_decls.as_str()),
+            ("ARGS", args.as_str()),
+        ];
+
+        if is_void_type(ret) || is_scalar_type(ret) || is_string_type(ret) {
+            let body = if is_void_type(ret) {
+                TMPL_BODY_VOID
+            } else if is_scalar_type(ret) {
+                TMPL_BODY_SCALAR
+            } else {
+                TMPL_BODY_STRING
+            };
+            out.push_str(&fill(TMPL_PROLOGUE, subs));
+            out.push_str(&fill(body, subs));
+        } else {
+            out.push_str(&fill(TMPL_BODY_WARN, subs));
+        }
+    }
+
+    let test_calls = (0..tests.len())
+        .map(|i| format!("    diff_T{:03}(&passed, &failed);\n", i + 1))
+        .collect::<String>();
+
+    out.push_str(&fill(TMPL_MAIN, &[("TEST_CALLS", &test_calls)]));
+    out
+}
+
+// ── Tool implementation ───────────────────────────────────────────────────────
+
+impl Tool for GenerateDiffTestSuite {
+    fn name(&self) -> &'static str {
+        "generate_difftest_suite"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let config = Config::deserialize(
+            context
+                .config
+                .tools
+                .get("generate_difftest_suite")
+                .ok_or("generate_difftest_suite: missing config section")?,
+        )?;
+
+        let raw_source = context
+            .ir_snapshot
+            .get::<RawSource>(inputs[0])
+            .ok_or("generate_difftest_suite: no RawSource in IR")?;
+
+        let files = raw_source.dir.files_recursive();
+        let (sigs, structs) = extract_c_api(&files, &config)?;
+        info!(
+            "Extracted {} public functions, {} struct types",
+            sigs.len(),
+            structs.len()
+        );
+
+        let tests = generate_test_vectors(&sigs, &structs);
+        info!(
+            "Generated {} test vectors across {} functions",
+            tests.len(),
+            tests
+                .iter()
+                .map(|t| t.function.as_str())
+                .collect::<std::collections::HashSet<_>>()
+                .len()
+        );
+
+        let source = generate_difftest_c(&tests, &sigs);
+        info!(
+            "Generated difftest_suite.c ({} bytes):\n{}",
+            source.len(),
+            source
+        );
+
+        Ok(Box::new(DiffTestSuite { source }))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    #[serde(flatten)]
+    pub llm: LLMConfig,
+    #[serde(flatten)]
+    unknown: HashMap<String, Value>,
+}
+
+impl Config {
+    pub fn validate(&self) {
+        unknown_field_warning("tools.generate_difftest_suite", &self.unknown);
+    }
+}

--- a/tools/generate_difftest_suite/src/lib.rs
+++ b/tools/generate_difftest_suite/src/lib.rs
@@ -112,7 +112,7 @@ fn extract_c_api(
     let mut usage = LLMUsageTotals::default();
     let (response, u) = llm.invoke(&request)?;
     usage.add_usage(u.as_ref());
-    info!("Token usage [api extraction] - {usage}");
+    info!("Token usage [api extraction] - {usage:?}");
 
     let api: ApiResponse = serde_json::from_str(&response)?;
 

--- a/tools/generate_difftest_suite/src/structured_schema_api.json
+++ b/tools/generate_difftest_suite/src/structured_schema_api.json
@@ -1,0 +1,49 @@
+{
+    "name": "c_api",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "functions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "return_type": { "type": "string" },
+                        "param_types": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                        }
+                    },
+                    "required": ["name", "return_type", "param_types"],
+                    "additionalProperties": false
+                }
+            },
+            "structs": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "fields": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string" },
+                                    "type": { "type": "string" }
+                                },
+                                "required": ["name", "type"],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": ["name", "fields"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["functions", "structs"],
+        "additionalProperties": false
+    }
+}

--- a/tools/generate_difftest_suite/src/system_prompt_api.txt
+++ b/tools/generate_difftest_suite/src/system_prompt_api.txt
@@ -1,0 +1,18 @@
+You are a C API extraction tool. Given C source files, extract the public API.
+
+Return a JSON object with two arrays:
+
+"functions" — every public (non-static) function:
+- name: exact function name as declared
+- return_type: the C return type as a string (e.g. "int", "void", "const char *", "size_t")
+- param_types: array of C type strings for each parameter, in order (empty array for void or zero parameters)
+
+"structs" — every struct or typedef definition:
+- name: the C declaration name — use the typedef name if one exists (e.g. "Point"), or "struct Tag" for a plain struct tag
+- fields: array of {name, type} for each field
+
+Rules:
+- Only include public (non-static) functions
+- Use exact C type strings as declared, including qualifiers and pointer stars (e.g. "const char *", "unsigned long")
+- Do not include static functions, macros, enums, or function-pointer typedefs
+- If there are no structs, return an empty array for "structs"

--- a/tools/generate_difftest_suite/src/templates/body_scalar.c
+++ b/tools/generate_difftest_suite/src/templates/body_scalar.c
@@ -1,0 +1,6 @@
+    {RET} c_result = c_fn({ARGS});
+    {RET} rust_result = rust_fn({ARGS});
+    if (c_result == rust_result) { printf("PASS diff_{TEST_ID} {FN_NAME}\n"); (*passed)++; }
+    else { printf("FAIL diff_{TEST_ID} {FN_NAME} mismatch\n"); (*failed)++; }
+}
+

--- a/tools/generate_difftest_suite/src/templates/body_string.c
+++ b/tools/generate_difftest_suite/src/templates/body_string.c
@@ -1,0 +1,7 @@
+    const char *c_result = (const char *)c_fn({ARGS});
+    const char *rust_result = (const char *)rust_fn({ARGS});
+    if (c_result == NULL && rust_result == NULL) { printf("PASS diff_{TEST_ID} {FN_NAME}\n"); (*passed)++; }
+    else if (c_result != NULL && rust_result != NULL && strcmp(c_result, rust_result) == 0) { printf("PASS diff_{TEST_ID} {FN_NAME}\n"); (*passed)++; }
+    else { printf("FAIL diff_{TEST_ID} {FN_NAME} mismatch\n"); (*failed)++; }
+}
+

--- a/tools/generate_difftest_suite/src/templates/body_void.c
+++ b/tools/generate_difftest_suite/src/templates/body_void.c
@@ -1,0 +1,5 @@
+    c_fn({ARGS});
+    rust_fn({ARGS});
+    printf("PASS diff_{TEST_ID} {FN_NAME}\n"); (*passed)++;
+}
+

--- a/tools/generate_difftest_suite/src/templates/body_warn.c
+++ b/tools/generate_difftest_suite/src/templates/body_warn.c
@@ -1,0 +1,5 @@
+static void diff_{TEST_ID}(int *passed, int *failed) {
+    (void)passed;
+    printf("WARN diff_{TEST_ID} {FN_NAME} unsupported return type\n");
+}
+

--- a/tools/generate_difftest_suite/src/templates/header.c
+++ b/tools/generate_difftest_suite/src/templates/header.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <string.h>
+#include <dlfcn.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+static void *c_lib;
+static void *rust_lib;
+

--- a/tools/generate_difftest_suite/src/templates/main.c
+++ b/tools/generate_difftest_suite/src/templates/main.c
@@ -1,0 +1,9 @@
+int main(int argc, char *argv[]) {
+    if (argc != 3) { fprintf(stderr, "Usage: %s <libc.so> <librust.so>\n", argv[0]); return 1; }
+    c_lib = dlopen(argv[1], RTLD_LOCAL | RTLD_NOW);
+    rust_lib = dlopen(argv[2], RTLD_LOCAL | RTLD_NOW);
+    if (!c_lib || !rust_lib) { fprintf(stderr, "dlopen failed: %s\n", dlerror()); return 1; }
+    int passed = 0, failed = 0;
+{TEST_CALLS}    printf("SUMMARY: %d passed, %d failed out of %d tests\n", passed, failed, passed + failed);
+    return failed > 0 ? 1 : 0;
+}

--- a/tools/generate_difftest_suite/src/templates/test_prologue.c
+++ b/tools/generate_difftest_suite/src/templates/test_prologue.c
@@ -1,0 +1,5 @@
+static void diff_{TEST_ID}(int *passed, int *failed) {
+    {RET} (*c_fn)({PARAM_TYPES}) = dlsym(c_lib, "{FN_NAME}");
+    {RET} (*rust_fn)({PARAM_TYPES}) = dlsym(rust_lib, "{FN_NAME}");
+    if (!c_fn || !rust_fn) { printf("WARN diff_{TEST_ID} {FN_NAME} symbol not found\n"); return; }
+{ARG_DECLS}

--- a/tools/run_difftest/Cargo.toml
+++ b/tools/run_difftest/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "run_difftest"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+build_c_artifact.workspace = true
+full_source.workspace = true
+generate_difftest_suite.workspace = true
+harvest_core.workspace = true
+tempfile.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/run_difftest/src/lib.rs
+++ b/tools/run_difftest/src/lib.rs
@@ -1,0 +1,157 @@
+use build_c_artifact::CArtifact;
+use full_source::CargoPackage;
+use generate_difftest_suite::DiffTestSuite;
+use harvest_core::cargo_utils::CargoToml;
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tracing::info;
+
+/// The results of a differential test run comparing C and Rust library outputs.
+pub struct DiffTestResult {
+    pub passed: usize,
+    pub failed: usize,
+    pub total: usize,
+    /// Raw FAIL and WARN lines from the test run, for use by the fix tool.
+    pub failures: Vec<String>,
+}
+
+impl std::fmt::Display for DiffTestResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln!(f, "DiffTestResult: {}/{} passed", self.passed, self.total)?;
+        for failure in &self.failures {
+            writeln!(f, "  {failure}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Representation for DiffTestResult {
+    fn name(&self) -> &'static str {
+        "diff_test_result"
+    }
+}
+
+pub struct RunDiffTest;
+
+impl Tool for RunDiffTest {
+    fn name(&self) -> &'static str {
+        "run_difftest"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let diff_test_suite = context
+            .ir_snapshot
+            .get::<DiffTestSuite>(inputs[0])
+            .ok_or("run_difftest: no DiffTestSuite in IR")?;
+        let c_library = context
+            .ir_snapshot
+            .get::<CArtifact>(inputs[1])
+            .ok_or("run_difftest: no CArtifact in IR")?;
+        let cargo_package = context
+            .ir_snapshot
+            .get::<CargoPackage>(inputs[2])
+            .ok_or("run_difftest: no CargoPackage in IR")?;
+
+        // Short-circuit for non-library projects.
+        let Some(ref c_so) = c_library.so_path else {
+            info!("run_difftest: project is not a library; returning empty result");
+            return Ok(Box::new(DiffTestResult {
+                passed: 0,
+                failed: 0,
+                total: 0,
+                failures: vec![],
+            }));
+        };
+
+        // Materialize the Rust package with cdylib added, then build it.
+        let rust_root = tempfile::tempdir()?;
+        cargo_package.materialize(rust_root.path())?;
+        let mut cargo_toml = CargoToml::open(&rust_root.path().join("Cargo.toml"))?;
+        cargo_toml.add_workspace();
+        cargo_toml.ensure_cdylib();
+        cargo_toml.save()?;
+
+        info!("Building Rust package as cdylib for diff testing...");
+        let status = Command::new("cargo")
+            .args(["build", "--release", "--lib"])
+            .current_dir(rust_root.path())
+            .status()
+            .map_err(|e| format!("run_difftest: failed to run cargo build: {e}"))?;
+        if !status.success() {
+            return Err("run_difftest: cargo build --release --lib failed".into());
+        }
+
+        let rust_so = find_so_in_dir(&rust_root.path().join("target/release"))
+            .ok_or("run_difftest: no .so found in target/release")?;
+
+        // Write difftest_suite.c and compile it.
+        let difftest_root = tempfile::tempdir()?;
+        let suite_path = difftest_root.path().join("difftest_suite.c");
+        let bin_path = difftest_root.path().join("difftest_bin");
+        std::fs::write(&suite_path, diff_test_suite.source.as_bytes())?;
+
+        info!("Compiling difftest_suite.c...");
+        let status = Command::new("clang")
+            .arg(&suite_path)
+            .arg("-o")
+            .arg(&bin_path)
+            .arg("-ldl")
+            .status()
+            .map_err(|e| format!("run_difftest: failed to run clang: {e}"))?;
+        if !status.success() {
+            return Err("run_difftest: clang failed to compile difftest_suite.c".into());
+        }
+
+        // Run the diff test binary.
+        info!("Running diff test binary...");
+        let output = Command::new(&bin_path)
+            .arg(c_so)
+            .arg(&rust_so)
+            .output()
+            .map_err(|e| format!("run_difftest: failed to run difftest_bin: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(parse_output(&stdout))
+    }
+}
+
+fn parse_output(output: &str) -> Box<DiffTestResult> {
+    let mut passed = 0usize;
+    let mut failures = Vec::new();
+
+    for line in output.lines() {
+        if line.starts_with("PASS ") {
+            passed += 1;
+        } else if line.starts_with("FAIL ") || line.starts_with("WARN ") {
+            failures.push(line.to_string());
+        }
+    }
+
+    let failed = failures.len();
+    let total = passed + failed;
+    info!("Diff test result: {passed}/{total} passed");
+
+    Box::new(DiffTestResult {
+        passed,
+        failed,
+        total,
+        failures,
+    })
+}
+
+/// Returns the first `.so` file found directly in `dir` (non-recursive, skips subdirectories).
+fn find_so_in_dir(dir: &Path) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("so") {
+            return Some(path);
+        }
+    }
+    None
+}

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -35,6 +35,8 @@ raw_source_to_cargo_llm.workspace = true
 translate_agentic.workspace = true
 verify_fix_agentic.workspace = true
 build_c_artifact.workspace = true
+generate_difftest_suite.workspace = true
+run_difftest.workspace = true
 
 [dev-dependencies]
 full_source.workspace = true

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -26,6 +26,12 @@ backend = "ollama"
 model = "codellama:7b"
 max_tokens = 10000
 
+[tools.generate_difftest_suite]
+address = "http://localhost:11434"
+backend = "ollama"
+model = "codellama:7b"
+max_tokens = 10000
+
 [tools.translate_agentic]
 timeout_secs = 7200
 

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -6,11 +6,13 @@ mod runner;
 mod scheduler;
 pub mod util;
 
+use build_c_artifact::BuildCArtifact;
 use build_config::BuildConfig;
-use build_project_spec::BuildProjectSpec;
+use build_project_spec::{BuildProjectSpec, ProjectKind, ProjectSpec};
 use c_ast::ParseToAst;
 use emit_build_features::EmitBuildFeatures;
 use fix_declarations_llm::FixDeclarationsLlm;
+use generate_difftest_suite::GenerateDiffTestSuite;
 use harvest_core::config::Config;
 use harvest_core::utils::get_version;
 use harvest_core::{HarvestIR, diagnostics};
@@ -18,6 +20,7 @@ use load_raw_source::LoadRawSource;
 use modular_translation_llm::ModularTranslationLlm;
 use quantize_rust_spans::QuantizeRustSpans;
 use raw_source_to_cargo_llm::RawSourceToCargoLlm;
+use run_difftest::{DiffTestResult, RunDiffTest};
 use runner::ToolRunner;
 use scheduler::Scheduler;
 use std::sync::Arc;
@@ -93,6 +96,32 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
                 current_pkg_id = fix;
                 current_build_id = new_build;
             }
+        }
+
+        // Differential testing: for library projects, generate a C test harness that
+        // exercises the public API through both the original C build and the translated
+        // Rust candidate, and report how many calls diverge. Not yet wired into a repair
+        // loop, and executable projects are not yet supported (see generate_exec_difftests
+        // / run_exec_difftest).
+        let is_library = matches!(
+            ir.get::<ProjectSpec>(project_spec)
+                .ok_or("transpile: no ProjectSpec in IR")?
+                .kind,
+            ProjectKind::Library
+        );
+        if is_library {
+            let c_artifact = scheduler.queue_after(BuildCArtifact, &[load_src, project_spec]);
+            let diff_suite = scheduler.queue_after(GenerateDiffTestSuite, &[load_src]);
+            let diff_result_id =
+                scheduler.queue_after(RunDiffTest, &[diff_suite, c_artifact, current_pkg_id]);
+            scheduler.run_all(&mut runner, &mut ir, config.clone())?;
+            let diff_result = ir
+                .get::<DiffTestResult>(diff_result_id)
+                .ok_or("transpile: no DiffTestResult in IR")?;
+            info!(
+                "Diff test: {}/{} passed ({} failed)",
+                diff_result.passed, diff_result.total, diff_result.failed
+            );
         }
 
         scheduler.queue_after(WriteOutput, &[current_build_id]);


### PR DESCRIPTION
This PR begins to add support for a full test-repair loop. Future PRs will add support for testing executables (e.g., generating stdin and args) and for iteratively imporving translation based on differential test results (the true test-repair-loop)
In particular, this PR adds 2 new tools, `generate_difftest_suite` and `run_difftest`. The first makes an llm call to infer the type signatures of the C program, and generates a test suite to differentially test a C library against our translated rust library. Example of a generated test:
```C
static void diff_T001(int *passed, int *failed) {
    int (*c_fn)(int, int, int, int, int) = dlsym(c_lib, "encode_quant");
    int (*rust_fn)(int, int, int, int, int) = dlsym(rust_lib, "encode_quant");
    if (!c_fn || !rust_fn) { printf("WARN diff_T001 encode_quant symbol not found\n"); return; }
    int arg0 = 0;
    int arg1 = 0;
    int arg2 = 0;
    int arg3 = 0;
    int arg4 = 0;
    int c_result = c_fn(arg0, arg1, arg2, arg3, arg4);
    int rust_result = rust_fn(arg0, arg1, arg2, arg3, arg4);
    if (c_result == rust_result) { printf("PASS diff_T001 encode_quant\n"); (*passed)++; }
    else { printf("FAIL diff_T001 encode_quant mismatch\n"); (*failed)++; }
}
```
The second tool runs the generated testsuite and reports the resukt (`N/M passed`). 

To test this PR. just translate any library like normal, and harvest will report something along the lines of 
```
2026-07-15T20:33:52.456450Z  INFO generate_difftest_suite: Generated 21 test vectors across 1 functions
2026-07-15T20:33:52.456681Z  INFO generate_difftest_suite: Generated difftest_suite.c (15591 bytes):
...
2026-07-15T20:33:52.708250Z  INFO run_difftest: Compiling difftest_suite.c...
2026-07-15T20:33:52.806419Z  INFO run_difftest: Running diff test binary...
2026-07-15T20:33:52.807806Z  INFO run_difftest: Diff test result: 21/21 passed

```

Important technical note: Currently, we deterministically generate boundary values for inputs (e.g., for an int32_t input, we generate 0, 1, -1, INT_MAX, etc...). My first attempt at doing this generated the input values from an llm call, however the llm was hanging for 10+ minutes, even for simple examples. Probably worth investigating.