### PR TITLE
Test-repair loop PR 2/3: Repair loop logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fix_diff_failures"
+version = "0.1.0"
+dependencies = [
+ "full_source",
+ "harvest_core",
+ "run_difftest",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1472,7 @@ dependencies = [
  "directories",
  "emit_build_features",
  "fix_declarations_llm",
+ "fix_diff_failures",
  "full_source",
  "generate_difftest_suite",
  "harvest_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner", "tools/generate_difftest_suite", "tools/run_difftest"]
+members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner", "tools/generate_difftest_suite", "tools/run_difftest", "tools/fix_diff_failures"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -24,6 +24,7 @@ build_c_artifact = { path = "tools/build_c_artifact" }
 exec_runner = { path = "tools/exec_runner" }
 generate_difftest_suite = { path = "tools/generate_difftest_suite" }
 run_difftest = { path = "tools/run_difftest" }
+fix_diff_failures = { path = "tools/fix_diff_failures" }
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -100,6 +100,7 @@ pub fn translate_c_directory_to_rust_project(
         agentic_verify,
         agentic_agent: None,
         repair_passes,
+        diff_repair_passes: 0,
     }
     .into();
     let mut config = harvest_translate::cli::initialize(args).expect("Failed to generate config");

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -76,6 +76,10 @@ pub struct Config {
     #[serde(default = "default_max_repair_passes")]
     pub max_repair_passes: usize,
 
+    /// Maximum number of LLM-based repair passes to attempt after a failed differential test.
+    #[serde(default = "default_max_diff_repair_passes")]
+    pub max_diff_repair_passes: usize,
+
     /// Sub-configuration for each tool.
     pub tools: HashMap<String, serde_json::Value>,
 
@@ -89,6 +93,10 @@ pub struct Config {
 
 fn default_max_repair_passes() -> usize {
     2
+}
+
+fn default_max_diff_repair_passes() -> usize {
+    0
 }
 
 impl Config {
@@ -105,6 +113,7 @@ impl Config {
             agentic_agent: AgentKind::Kiro,
             log_filter: "off".to_owned(),
             max_repair_passes: 0,
+            max_diff_repair_passes: 0,
             tools: Default::default(),
             unknown: Default::default(),
         }

--- a/tools/fix_diff_failures/Cargo.toml
+++ b/tools/fix_diff_failures/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fix_diff_failures"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+full_source.workspace = true
+harvest_core.workspace = true
+run_difftest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/fix_diff_failures/src/lib.rs
+++ b/tools/fix_diff_failures/src/lib.rs
@@ -1,6 +1,5 @@
 use full_source::{CargoPackage, RawSource};
 use harvest_core::config::unknown_field_warning;
-use harvest_core::fs::RawDir;
 use harvest_core::llm::{HarvestLLM, LLMConfig, LLMUsageTotals, build_request};
 use harvest_core::tools::{RunContext, Tool};
 use harvest_core::{Id, Representation};
@@ -110,9 +109,21 @@ impl Tool for FixDiffFailures {
         let files: OutputFiles = serde_json::from_str(&response)?;
         info!("LLM returned {} files", files.files.len());
 
-        let mut out_dir = RawDir::default();
+        // Clone the existing package and overlay only the files the LLM returned, rather than
+        // rebuilding from scratch -- this preserves Cargo.toml and any files the LLM omits
+        // (see the updated system prompt, which now asks for changed files only). set_file
+        // errors if the file already exists, so overwrite in place when it does and only fall
+        // back to inserting a new file when it doesn't.
+        let mut out_dir = cargo_package.dir.clone();
         for file in files.files {
-            out_dir.set_file(&file.path, file.contents.into())?;
+            let contents: Vec<u8> = file.contents.into();
+            match out_dir.get_file_mut(&file.path) {
+                Ok(existing) => *existing = contents,
+                Err(harvest_core::fs::GetFileError::DoesNotExist) => {
+                    out_dir.set_file(&file.path, contents)?;
+                }
+                Err(e) => return Err(e.into()),
+            }
         }
 
         info!("Token usage [total] - {usage_totals:?}");

--- a/tools/fix_diff_failures/src/lib.rs
+++ b/tools/fix_diff_failures/src/lib.rs
@@ -1,0 +1,136 @@
+use full_source::{CargoPackage, RawSource};
+use harvest_core::config::unknown_field_warning;
+use harvest_core::fs::RawDir;
+use harvest_core::llm::{HarvestLLM, LLMConfig, LLMUsageTotals, build_request};
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use run_difftest::DiffTestResult;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tracing::info;
+
+const STRUCTURED_OUTPUT_SCHEMA: &str = include_str!("structured_schema.json");
+const SYSTEM_PROMPT: &str = include_str!("system_prompt.txt");
+
+pub struct FixDiffFailures;
+
+impl Tool for FixDiffFailures {
+    fn name(&self) -> &'static str {
+        "fix_diff_failures"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let config = Config::deserialize(
+            context
+                .config
+                .tools
+                .get("fix_diff_failures")
+                .ok_or("fix_diff_failures: missing config section")?,
+        )?;
+        config.validate();
+
+        let diff_result = context
+            .ir_snapshot
+            .get::<DiffTestResult>(inputs[0])
+            .ok_or("fix_diff_failures: no DiffTestResult in IR")?;
+        let raw_source = context
+            .ir_snapshot
+            .get::<RawSource>(inputs[1])
+            .ok_or("fix_diff_failures: no RawSource in IR")?;
+        let cargo_package = context
+            .ir_snapshot
+            .get::<CargoPackage>(inputs[2])
+            .ok_or("fix_diff_failures: no CargoPackage in IR")?;
+
+        let llm = HarvestLLM::build(&config.llm, STRUCTURED_OUTPUT_SCHEMA, SYSTEM_PROMPT)?;
+
+        #[derive(Serialize)]
+        struct SourceFile {
+            path: String,
+            contents: String,
+        }
+
+        #[derive(Serialize)]
+        struct RequestBody {
+            c_source_files: Vec<SourceFile>,
+            rust_source_files: Vec<SourceFile>,
+            failures: Vec<String>,
+        }
+
+        let c_source_files = raw_source
+            .dir
+            .files_recursive()
+            .into_iter()
+            .map(|(path, contents)| SourceFile {
+                path: path.to_string_lossy().into_owned(),
+                contents: String::from_utf8_lossy(contents).into_owned(),
+            })
+            .collect();
+
+        let rust_source_files = cargo_package
+            .dir
+            .files_recursive()
+            .into_iter()
+            .map(|(path, contents)| SourceFile {
+                path: path.to_string_lossy().into_owned(),
+                contents: String::from_utf8_lossy(contents).into_owned(),
+            })
+            .collect();
+
+        let request = build_request(
+            "Fix the Rust code to match C behavior for the following failures:",
+            &RequestBody {
+                c_source_files,
+                rust_source_files,
+                failures: diff_result.failures.clone(),
+            },
+        )?;
+
+        let mut usage_totals = LLMUsageTotals::default();
+        let (response, usage) = llm.invoke(&request)?;
+        usage_totals.add_usage(usage.as_ref());
+
+        #[derive(Deserialize)]
+        struct OutputFiles {
+            files: Vec<OutputFile>,
+        }
+
+        #[derive(Deserialize)]
+        struct OutputFile {
+            path: PathBuf,
+            contents: String,
+        }
+
+        let files: OutputFiles = serde_json::from_str(&response)?;
+        info!("LLM returned {} files", files.files.len());
+
+        let mut out_dir = RawDir::default();
+        for file in files.files {
+            out_dir.set_file(&file.path, file.contents.into())?;
+        }
+
+        info!("Token usage [total] - {usage_totals:?}");
+
+        Ok(Box::new(CargoPackage { dir: out_dir }))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    #[serde(flatten)]
+    pub llm: LLMConfig,
+    #[serde(flatten)]
+    unknown: HashMap<String, Value>,
+}
+
+impl Config {
+    pub fn validate(&self) {
+        unknown_field_warning("tools.fix_diff_failures", &self.unknown);
+    }
+}

--- a/tools/fix_diff_failures/src/structured_schema.json
+++ b/tools/fix_diff_failures/src/structured_schema.json
@@ -1,0 +1,20 @@
+{
+    "name": "file",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "files": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string" },
+                        "contents": { "type": "string" }
+                    },
+                    "required": ["path", "contents"]
+                }
+            }
+        },
+        "required": ["files"]
+    }
+}

--- a/tools/fix_diff_failures/src/system_prompt.txt
+++ b/tools/fix_diff_failures/src/system_prompt.txt
@@ -6,7 +6,9 @@ Rules:
 - Be surgical: change only the lines that are wrong. Do not rewrite working functions.
 - Do not change the public API or function signatures.
 - Do not add comments.
-- Return ALL Rust source files in the "files" list, including unchanged ones.
+- Return only the files you changed in the "files" list, using their path relative to the
+  project root (e.g. "src/lib.rs"). Do not return unchanged files, and do not use absolute
+  paths.
 
 Library failure lines (FAIL diff_* / WARN diff_*):
 - FAIL names the test ID and the function whose return value differed between C and Rust.

--- a/tools/fix_diff_failures/src/system_prompt.txt
+++ b/tools/fix_diff_failures/src/system_prompt.txt
@@ -1,0 +1,20 @@
+You are a Rust repair tool. The Rust code is a translation of a C program. Differential tests show that the Rust code produces different outputs than the C code for some inputs.
+
+Your task: fix the Rust source files so their outputs match the C source for the failing tests.
+
+Rules:
+- Be surgical: change only the lines that are wrong. Do not rewrite working functions.
+- Do not change the public API or function signatures.
+- Do not add comments.
+- Return ALL Rust source files in the "files" list, including unchanged ones.
+
+Library failure lines (FAIL diff_* / WARN diff_*):
+- FAIL names the test ID and the function whose return value differed between C and Rust.
+- WARN means the Rust symbol was not found in the shared library (missing or unexported function).
+- Common causes: wrong arithmetic, incorrect array indexing, inverted condition, missing operation, wrong type conversion.
+
+Executable failure lines (FAIL exec_* / WARN exec_*):
+- FAIL includes the test ID, the argv and stdin used, and which output field differed: stdout, stderr, or exit_code.
+- For exit_code mismatches the line includes c=N rust=M showing both values.
+- For stdout/stderr mismatches the outputs are not shown inline — read the C source to understand the expected output.
+- Common causes: wrong output formatting, missing or extra newline, incorrect error handling, wrong exit code on error paths.

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -38,8 +38,6 @@ build_c_artifact.workspace = true
 generate_difftest_suite.workspace = true
 run_difftest.workspace = true
 fix_diff_failures.workspace = true
-
-[dev-dependencies]
 full_source.workspace = true
 
 [lints]

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -37,6 +37,7 @@ verify_fix_agentic.workspace = true
 build_c_artifact.workspace = true
 generate_difftest_suite.workspace = true
 run_difftest.workspace = true
+fix_diff_failures.workspace = true
 
 [dev-dependencies]
 full_source.workspace = true

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -7,6 +7,7 @@ agentic = false
 agentic_verify = false
 agentic_agent = "kiro"
 max_repair_passes = 2
+max_diff_repair_passes = 0
 
 [tools.raw_source_to_cargo_llm]
 address = "http://localhost:11434"
@@ -27,6 +28,12 @@ model = "codellama:7b"
 max_tokens = 10000
 
 [tools.generate_difftest_suite]
+address = "http://localhost:11434"
+backend = "ollama"
+model = "codellama:7b"
+max_tokens = 10000
+
+[tools.fix_diff_failures]
 address = "http://localhost:11434"
 backend = "ollama"
 model = "codellama:7b"

--- a/translate/src/cli.rs
+++ b/translate/src/cli.rs
@@ -46,6 +46,10 @@ pub struct Args {
     #[arg(long, default_value = "2")]
     pub repair_passes: usize,
 
+    /// Number of LLM-based repair passes to attempt after a failed differential test.
+    #[arg(long, default_value = "0")]
+    pub diff_repair_passes: usize,
+
     /// Prints out the location of the config file.
     #[arg(long)]
     pub print_config_path: bool,
@@ -133,6 +137,10 @@ fn load_config(args: &Args, config_dir: &Path) -> Config {
 
     settings = settings
         .set_override("max_repair_passes", args.repair_passes as i64)
+        .expect("settings override failed");
+
+    settings = settings
+        .set_override("max_diff_repair_passes", args.diff_repair_passes as i64)
         .expect("settings override failed");
 
     // We need to set an override so that deserializing the config does not error.

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -12,6 +12,8 @@ use build_project_spec::{BuildProjectSpec, ProjectKind, ProjectSpec};
 use c_ast::ParseToAst;
 use emit_build_features::EmitBuildFeatures;
 use fix_declarations_llm::FixDeclarationsLlm;
+use fix_diff_failures::FixDiffFailures;
+use full_source::CargoPackage;
 use generate_difftest_suite::GenerateDiffTestSuite;
 use harvest_core::config::Config;
 use harvest_core::utils::get_version;
@@ -100,9 +102,8 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
 
         // Differential testing: for library projects, generate a C test harness that
         // exercises the public API through both the original C build and the translated
-        // Rust candidate, and report how many calls diverge. Not yet wired into a repair
-        // loop, and executable projects are not yet supported (see generate_exec_difftests
-        // / run_exec_difftest).
+        // Rust candidate, and repair candidates that fail. Executable projects are not
+        // yet supported (see generate_exec_difftests / run_exec_difftest).
         let is_library = matches!(
             ir.get::<ProjectSpec>(project_spec)
                 .ok_or("transpile: no ProjectSpec in IR")?
@@ -112,9 +113,60 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
         if is_library {
             let c_artifact = scheduler.queue_after(BuildCArtifact, &[load_src, project_spec]);
             let diff_suite = scheduler.queue_after(GenerateDiffTestSuite, &[load_src]);
-            let diff_result_id =
+            let mut diff_result_id =
                 scheduler.queue_after(RunDiffTest, &[diff_suite, c_artifact, current_pkg_id]);
             scheduler.run_all(&mut runner, &mut ir, config.clone())?;
+            let mut best_passed = ir
+                .get::<DiffTestResult>(diff_result_id)
+                .ok_or("transpile: no DiffTestResult in IR")?
+                .passed;
+
+            for _ in 0..config.max_diff_repair_passes {
+                let failed = ir
+                    .get::<DiffTestResult>(diff_result_id)
+                    .ok_or("transpile: no DiffTestResult in IR")?
+                    .failed;
+                if failed == 0 {
+                    break;
+                }
+
+                let fix = scheduler
+                    .queue_after(FixDiffFailures, &[diff_result_id, load_src, current_pkg_id]);
+                scheduler.run_all(&mut runner, &mut ir, config.clone())?;
+
+                // FixDiffFailures can itself hard-error (observed: the LLM returning a file
+                // list with a non-relative path, which RawDir::set_file rejects). If it does,
+                // `fix` never lands in the IR. Queuing TryCargoBuild/RunDiffTest on `fix`
+                // regardless would permanently strand them -- their input can never become
+                // ready -- which the scheduler treats as fatal (run_all errors out) rather
+                // than recoverable. Check first, and treat a missing `fix` as a rejected
+                // attempt, same as a downstream tool failing.
+                if ir.get::<CargoPackage>(fix).is_none() {
+                    continue;
+                }
+
+                let new_build = scheduler.queue_after(TryCargoBuild, &[fix]);
+                let new_diff_result_id =
+                    scheduler.queue_after(RunDiffTest, &[diff_suite, c_artifact, fix]);
+                scheduler.run_all(&mut runner, &mut ir, config.clone())?;
+
+                // RunDiffTest (unlike TryCargoBuild) hard-errors instead of encoding failure
+                // in its result -- e.g. if the LLM's patch doesn't build as a cdylib. The
+                // ToolRunner swallows that error and just never inserts the representation,
+                // so a missing Id here means "this repair attempt failed," not "the pipeline
+                // is broken." Treat it as a rejected candidate and keep iterating from the
+                // last-accepted state.
+                let Some(new_result) = ir.get::<DiffTestResult>(new_diff_result_id) else {
+                    continue;
+                };
+                if new_result.passed > best_passed {
+                    best_passed = new_result.passed;
+                    current_pkg_id = fix;
+                    current_build_id = new_build;
+                    diff_result_id = new_diff_result_id;
+                }
+            }
+
             let diff_result = ir
                 .get::<DiffTestResult>(diff_result_id)
                 .ok_or("transpile: no DiffTestResult in IR")?;


### PR DESCRIPTION
This PR takes the work done in #180 to generate and run differential tests, and integrates it into a repair loop that generates differential test -> run to find discrepancies -> send results to LLM to repair -> generate differential test  -> ...

Specifically, this PR adds:
1. A new tool `fix_diff_failures` that submits the C source, generated rust source, and differential test results to an LLM. The LLM generates a patch intended to fix any errors in the differential test results.
2. A new config option `--diff-repair-passes` for easily changing the max number of repair passes. This setting can also be set in the harvest config file. Currently defaults to 0.
3. The integration of the above options/tools into the main translation loop. This loop first translates, then repairs. Each intermediate repair is stored in a `tmp/` directory, and the best performing version is ultimately copied to the harvest output directory.