### PR TITLE
Support autotools/real-world projects, resumable verify, and more reliable agentic runs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "C-TEST-CORPUS-V1"]
+	path = C-TEST-CORPUS-V1
+	url = https://github.com/UW-HARVEST/C-TEST-CORPUS-V1.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "C-TEST-CORPUS-V1"]
-	path = C-TEST-CORPUS-V1
-	url = https://github.com/UW-HARVEST/C-TEST-CORPUS-V1.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,7 @@ dependencies = [
  "generate_difftest_suite",
  "harvest_core",
  "libc",
+ "load_cargo_package",
  "load_raw_source",
  "modular_translation_llm",
  "quantize_rust_spans",
@@ -1908,6 +1909,15 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "toml 0.8.23",
+]
+
+[[package]]
+name = "load_cargo_package"
+version = "0.1.0"
+dependencies = [
+ "full_source",
+ "harvest_core",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner", "tools/generate_difftest_suite", "tools/run_difftest"]
+members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/load_cargo_package", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner", "tools/generate_difftest_suite", "tools/run_difftest"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -11,6 +11,7 @@ build_config = { path = "tools/build_config" }
 build_project_spec = { path = "tools/build_project_spec" }
 emit_build_features = { path = "tools/emit_build_features" }
 load_raw_source = { path = "tools/load_raw_source" }
+load_cargo_package = { path = "tools/load_cargo_package" }
 raw_source_to_cargo_llm = { path = "tools/raw_source_to_cargo_llm" }
 try_cargo_build = { path = "tools/try_cargo_build" }
 write_output = { path = "tools/write_output" }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -76,6 +76,15 @@ pub struct Config {
     #[serde(default = "default_max_repair_passes")]
     pub max_repair_passes: usize,
 
+    /// Whether to run HARVEST's built-in library differential test (BuildCArtifact
+    /// + GenerateDiffTestSuite + RunDiffTest) after translation. This stage builds
+    /// the original C with CMake, so it only works for CMake projects. Set to
+    /// `false` for autotools/make projects that are graded by an external harness
+    /// instead; the translated Rust output is still written. Defaults to `true`
+    /// to preserve upstream behavior.
+    #[serde(default = "default_internal_difftest")]
+    pub internal_difftest: bool,
+
     /// Sub-configuration for each tool.
     pub tools: HashMap<String, serde_json::Value>,
 
@@ -89,6 +98,10 @@ pub struct Config {
 
 fn default_max_repair_passes() -> usize {
     2
+}
+
+fn default_internal_difftest() -> bool {
+    true
 }
 
 impl Config {
@@ -105,6 +118,7 @@ impl Config {
             agentic_agent: AgentKind::Kiro,
             log_filter: "off".to_owned(),
             max_repair_passes: 0,
+            internal_difftest: true,
             tools: Default::default(),
             unknown: Default::default(),
         }

--- a/tools/build_project_spec/src/lib.rs
+++ b/tools/build_project_spec/src/lib.rs
@@ -86,7 +86,17 @@ impl Tool for BuildProjectSpec {
             return Ok(Box::new(ProjectSpec { kind }));
         }
 
-        Err("Could not identify project kind from CMakeLists.txt (or could not find it)".into())
+        // Autotools fallback: projects that ship no CMakeLists.txt (e.g.
+        // libsodium) declare their targets in `Makefile.am` via Automake
+        // primaries. `bin_PROGRAMS` => executable; `lib_LTLIBRARIES` /
+        // `noinst_LTLIBRARIES` / `lib_LIBRARIES` => library. We scan every
+        // Makefile.am in the tree because the primary that matters usually
+        // lives in a subdirectory (src/, src/<name>/), not the project root.
+        if let Some(kind) = project_kind_from_automake(repr) {
+            return Ok(Box::new(ProjectSpec { kind }));
+        }
+
+        Err("Could not identify project kind from CMakeLists.txt / Makefile.am (or could not find either)".into())
     }
 }
 
@@ -101,13 +111,64 @@ impl Tool for BuildProjectSpec {
 /// line-prefix matching on main.
 fn project_kind_from_cmakelists(cmakelists: &[u8]) -> Option<ProjectKind> {
     let text = String::from_utf8_lossy(cmakelists);
-    if text.lines().any(|line| line.starts_with("add_executable(")) {
-        Some(ProjectKind::Executable)
-    } else if text.lines().any(|line| line.starts_with("add_library(")) {
+    // Match after trimming leading whitespace: real projects (e.g. libpng)
+    // indent `add_library(...)` / `add_executable(...)` inside `if()` blocks,
+    // so a column-0-only prefix check would miss them.
+    let starts = |prefix: &str| text.lines().any(|line| line.trim_start().starts_with(prefix));
+    // Library takes precedence when both appear: a project that builds a library
+    // AND executables (e.g. libpng, which also builds test/tool binaries) is
+    // fundamentally a library from the translation's perspective -- the exported
+    // library surface is what downstream tools consume. Only classify as
+    // Executable when there is no library target at all.
+    if starts("add_library(") {
         Some(ProjectKind::Library)
+    } else if starts("add_executable(") {
+        Some(ProjectKind::Executable)
     } else {
         None
     }
+}
+
+/// Determine project kind by scanning every `Makefile.am` in the source tree
+/// for Automake target primaries. This is the autotools analogue of
+/// [`project_kind_from_cmakelists`], for projects that ship no CMakeLists.txt.
+///
+/// Detection markers (matched as the first non-whitespace token on a line,
+/// tolerating the `NAME_PRIMARY = ...` assignment form):
+/// - `bin_PROGRAMS`, `sbin_PROGRAMS`, `noinst_PROGRAMS` -> [`ProjectKind::Executable`]
+/// - `lib_LTLIBRARIES`, `noinst_LTLIBRARIES`, `lib_LIBRARIES`,
+///   `pkglib_LTLIBRARIES` -> [`ProjectKind::Library`]
+///
+/// Executable wins when both appear (a library that also builds a CLI driver
+/// is exercised as an executable), matching the intent of the CMake matcher.
+fn project_kind_from_automake(repr: &RawSource) -> Option<ProjectKind> {
+    const EXE_PRIMARIES: &[&str] = &["bin_PROGRAMS", "sbin_PROGRAMS", "noinst_PROGRAMS"];
+    const LIB_PRIMARIES: &[&str] = &[
+        "lib_LTLIBRARIES",
+        "noinst_LTLIBRARIES",
+        "lib_LIBRARIES",
+        "pkglib_LTLIBRARIES",
+    ];
+
+    let mut saw_library = false;
+    for (path, contents) in repr.dir.files_recursive() {
+        if path.file_name().and_then(|n| n.to_str()) != Some("Makefile.am") {
+            continue;
+        }
+        let text = String::from_utf8_lossy(contents);
+        for line in text.lines() {
+            // The primary is the first whitespace-delimited token; an
+            // assignment like `bin_PROGRAMS = foo` has it as token 0.
+            let token = line.trim_start().split_whitespace().next().unwrap_or("");
+            if EXE_PRIMARIES.contains(&token) {
+                return Some(ProjectKind::Executable);
+            }
+            if LIB_PRIMARIES.contains(&token) {
+                saw_library = true;
+            }
+        }
+    }
+    saw_library.then_some(ProjectKind::Library)
 }
 
 #[cfg(test)]
@@ -158,6 +219,30 @@ mod tests {
         assert!(
             matches!(kind, Some(ProjectKind::Library)),
             "mid-line occurrence must not trigger executable"
+        );
+    }
+
+    /// Real projects (e.g. libpng) INDENT `add_library`/`add_executable` inside
+    /// `if()` blocks. Indented targets must still be detected.
+    #[test]
+    fn legacy_path_detects_indented_targets() {
+        let cmakelists = b"if(PNG_SHARED)\n  add_library(png_shared SHARED x.c)\nendif()\n";
+        assert!(
+            matches!(project_kind_from_cmakelists(cmakelists), Some(ProjectKind::Library)),
+            "indented add_library must be detected"
+        );
+    }
+
+    /// When a project declares BOTH a library and executables (libpng builds the
+    /// png library plus pngtest/tool binaries), it is classified as a Library --
+    /// the exported library surface is what the translation targets.
+    #[test]
+    fn legacy_path_library_wins_when_both_present() {
+        let cmakelists =
+            b"  add_library(png STATIC png.c)\n  add_executable(pngtest pngtest.c)\n";
+        assert!(
+            matches!(project_kind_from_cmakelists(cmakelists), Some(ProjectKind::Library)),
+            "library must take precedence when both target kinds are present"
         );
     }
 }

--- a/tools/load_cargo_package/Cargo.toml
+++ b/tools/load_cargo_package/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "load_cargo_package"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+harvest_core.workspace = true
+full_source.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/load_cargo_package/src/lib.rs
+++ b/tools/load_cargo_package/src/lib.rs
@@ -1,0 +1,51 @@
+//! Lifts an existing on-disk Rust crate into a [`CargoPackage`] representation.
+//!
+//! This is the Rust-side analogue of [`load_raw_source::LoadRawSource`]: where
+//! that tool loads a C project directory into a [`RawSource`], this loads a
+//! already-translated Cargo package directory into a [`CargoPackage`]. It lets
+//! the pipeline feed a prior translation into a later stage (e.g. the agentic
+//! verify-and-fix stage) WITHOUT re-running translation.
+
+use full_source::CargoPackage;
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation, fs::RawDir};
+use std::fs::read_dir;
+use std::path::{Path, PathBuf};
+use tracing::info;
+
+pub struct LoadCargoPackage {
+    directory: PathBuf,
+}
+
+impl LoadCargoPackage {
+    pub fn new(directory: &Path) -> LoadCargoPackage {
+        LoadCargoPackage {
+            directory: directory.into(),
+        }
+    }
+}
+
+impl Tool for LoadCargoPackage {
+    fn name(&self) -> &'static str {
+        "load_cargo_package"
+    }
+
+    fn run(
+        self: Box<Self>,
+        _context: RunContext,
+        _inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let dir = read_dir(&self.directory).map_err(|e| {
+            format!(
+                "load_cargo_package: cannot read {}: {e}",
+                self.directory.display()
+            )
+        })?;
+        let (rawdir, directories, files) = RawDir::populate_from(dir)?;
+        info!(
+            "Loaded existing Cargo package: {directories} directories and {files} files from {}.",
+            self.directory.display()
+        );
+        Ok(Box::new(CargoPackage { dir: rawdir }))
+    }
+}

--- a/tools/translate_agentic/src/prompt_claude_translate.md
+++ b/tools/translate_agentic/src/prompt_claude_translate.md
@@ -259,6 +259,18 @@ point that is not part of the original library, plan to translate it early.
    - The cross-module type/ABI design
 
    When you delegate to a sub-agent:
+   - The Task tool is SYNCHRONOUS: the call returns ONLY when the sub-agent has
+     finished, and its final report IS the return value. There are NO async
+     "completion notifications" -- never say you are "waiting for" or "pausing
+     for" a sub-agent, and never end your turn expecting to be notified later.
+     The instant a Task call returns, that subtask is done and it is your job to
+     act on it now.
+   - After each sub-agent returns you MUST independently verify its work on disk
+     (`ls`, `wc -l`, `grep` the expected symbols/functions) before marking the
+     subtask `[x]`. NEVER trust a sub-agent's self-reported success -- a subtask
+     is complete only when YOU have confirmed the Rust file exists and contains
+     what the plan requires. If it is missing or incomplete, re-dispatch it
+     (split smaller) or finish it yourself before moving on.
    - Each sub-agent must report back what files it created/modified and any
      pitfalls it noticed.
    - Update PLAN.md checkboxes and "Notes for future-me" after the sub-agent

--- a/tools/verify_fix_agentic/src/lib.rs
+++ b/tools/verify_fix_agentic/src/lib.rs
@@ -106,6 +106,21 @@ impl Tool for VerifyFixAgentic {
             .replace("{CASE_DIR}", &case_dir.to_string_lossy())
             .replace("{CMAKE_BUILD_FLAGS}", &cmake_flags);
 
+        // Diagnostic: confirm exactly which prompt actually reached the agent
+        // (the prompt is passed via an env var, so it never appears in the
+        // agent's stream-json transcript -- log identifying facts here instead).
+        info!(
+            "Verify prompt source: {} | {} chars | mentions 'Phase A'={} 'ERROR-SURFACE'={}",
+            match (&config.prompt_claude_verify, config.no_plan) {
+                (Some(p), _) => format!("override file {}", p.display()),
+                (None, true) => "builtin no_plan".to_string(),
+                (None, false) => "builtin plan".to_string(),
+            },
+            prompt.len(),
+            prompt.contains("Phase A"),
+            prompt.contains("ERROR-SURFACE"),
+        );
+
         invoke_agent(
             case_dir,
             &prompt,
@@ -145,9 +160,24 @@ fn invoke_agent(
     no_plan: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(
-        "Invoking verification agent ({agent}, model={}, no_plan={no_plan}, timeout={timeout_secs}s)",
-        model.unwrap_or("(cli default)")
+        "Invoking verification agent ({agent}, model={}, no_plan={no_plan}, timeout={})",
+        model.unwrap_or("(cli default)"),
+        if timeout_secs == 0 { "none".to_string() } else { format!("{timeout_secs}s") }
     );
+
+    // `timeout_secs == 0` disables the wall-clock cap entirely (no `timeout`
+    // prefix). Otherwise wrap the agent in `timeout <secs>` (with a hard
+    // `--kill-after` for the Claude path).
+    let kiro_timeout_prefix = if timeout_secs == 0 {
+        String::new()
+    } else {
+        format!("timeout {timeout_secs} ")
+    };
+    let claude_timeout_prefix = if timeout_secs == 0 {
+        String::new()
+    } else {
+        format!("timeout --kill-after=60s {timeout_secs} ")
+    };
 
     let logs_dir = work_dir.join("logs");
     fs::create_dir_all(&logs_dir)?;
@@ -171,7 +201,7 @@ fn invoke_agent(
         AgentKind::Kiro => Command::new("bash")
             .arg("-c")
             .arg(format!(
-                "set -o pipefail; timeout {timeout_secs} kiro-cli chat \
+                "set -o pipefail; {kiro_timeout_prefix}kiro-cli chat \
                  --no-interactive --trust-all-tools \"$PROMPT\" < /dev/null 2>&1 | tee \"$LOG\"",
             ))
             .env("PROMPT", prompt)
@@ -191,7 +221,7 @@ fn invoke_agent(
                     // to a file avoids the pipe; we replay the log to stdout
                     // afterward so the transcript still reaches captured output.
                     // `--kill-after` hard-kills claude if it ignores SIGTERM.
-                    "timeout --kill-after=60s {timeout_secs} claude -p \"$PROMPT\" \
+                    "{claude_timeout_prefix}claude -p \"$PROMPT\" \
                      --permission-mode bypassPermissions \
                      --allowedTools 'Bash(*)' 'Write' 'Edit' \
                      {model_flag}{append_sys_flag}\

--- a/tools/verify_fix_agentic/src/prompt_claude_verify.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify.md
@@ -153,6 +153,13 @@ Format per entry:
    reading more than ~200 lines of C or Rust into your own context,
    delegate the fix to a sub-agent and let it report back what it changed.
 
+   The Task tool is SYNCHRONOUS -- its return value IS the sub-agent's finished
+   result; there are NO async notifications, so never "wait for" a sub-agent or
+   end your turn with delegated work outstanding. After every sub-agent returns,
+   independently confirm the change on disk (re-run `nm -D` symbol parity / the
+   relevant test) before marking a hypothesis `fixed`. A translation is NOT
+   complete while any C-exported symbol is still missing from the Rust `.so`.
+
 ### Recovery protocol (if you suspect you were just compacted)
 
 Symptoms: you cannot recall what hypothesis you were testing, or your last
@@ -165,27 +172,74 @@ turn looks like a summary rather than concrete work. In that case:
 
 ## Step 2: Verification workflow
 
-Now do the actual verification:
+Verification proceeds in four MANDATORY phases, A -> B -> C -> D. Do not skip a
+phase because a prior session (or your own earlier work) looks "complete":
+matching symbols and passing tests are NECESSARY but NOT SUFFICIENT (see the
+completion gate in Phase D). Build the C reference as a shared library first,
+then work the phases.
 
-1. Build the C code as a shared library
-2. Write Rust integration tests (in tests/) that use `libloading`
-   to load the C .so and compare C vs Rust function outputs
-3. Start with the lowest-level functions and work upward to higher-level ones.
-   Look at the C headers to identify the public API and function call hierarchy.
-4. For each function: create fixed test inputs, call both C and Rust versions,
-   assert outputs match byte-for-byte
-5. Run `cargo test` and investigate any mismatches. Every time a test
-   exposes a divergence, append a hypothesis to `HYPOTHESES.md`.
-6. When you find a Rust function that produces different output than C,
-   fix the Rust code in src/ and re-run until the test passes. Update the
-   matching hypothesis to `fixed` after the Edit.
-7. Keep going until all public functions match
-8. If the project has a main binary, run both the C binary and the Rust binary
-   with the same inputs and compare their stdout byte-for-byte. Fix any differences.
-9. Compare `nm -D` on the C .so and the Rust .so. Every symbol the C .so
-   exports, the Rust .so must also export with the exact same name. This
-   includes symbols created by preprocessor macros. If the C .so exports it,
-   the Rust .so must export it — no exceptions. Add missing exports.
+All tests are `libloading`-based differential tests: load BOTH the C `.so` and
+the Rust `.so`, call the SAME function in each with the SAME input, and assert
+they agree. Fix the Rust (never the C) on any divergence, log it in
+`HYPOTHESES.md`, and re-run until it passes.
+
+### Phase A — Map the surface (produce artifacts BEFORE writing tests)
+
+Create two files in the crate root; they make coverage auditable and are
+derived from the C source, NOT from your assumptions about it:
+
+1. `SYMBOLS.md` — every public symbol from `nm -D` on the C `.so`. Every one
+   MUST also be exported by the Rust `.so` (exact name, incl. macro-generated).
+   Add any missing exports.
+2. `ERRORS.md` — the ERROR-SURFACE TABLE. This is the anti-blind-spot step.
+   Mechanically grep the C source for EVERY distinct way it rejects or errors
+   on input — every error-return macro/statement (e.g. `RETURN_ERROR`,
+   `return -1`, `return NULL`, error enums), every `assert`, every explicit
+   range check, null check, and min/max constant. Write ONE ROW per distinct
+   rejection:
+
+   | # | function | trigger (the exact invalid input/condition) | expected C result |
+   |---|----------|----------------------------------------------|-------------------|
+
+   Derive rows from what the C code ACTUALLY checks — do not invent or guess,
+   and do not rely on the happy-path API docs. If a function has three distinct
+   `RETURN_ERROR` branches, that is three rows.
+
+### Phase B — Valid-path differential tests
+
+For each public function: fixed valid inputs, call C and Rust, assert outputs
+match byte-for-byte. Work lowest-level functions upward using the header's call
+hierarchy. This is necessary but only half the job.
+
+### Phase C — Error-path differential tests (GATED on `ERRORS.md`)
+
+For EVERY ROW in `ERRORS.md`, write a differential test that constructs that
+exact invalid input/condition, calls BOTH C and Rust, and asserts they return
+the SAME error/rejection (the same error code or sentinel — not merely "both
+failed somehow"). Check the row off only when its test passes against both.
+Also cover the generic boundaries every C API has even if not explicitly in the
+table: null pointers, zero and oversized lengths, and values one step past a
+documented valid range (including out-of-range enum values passed across the
+FFI boundary — C enums accept any int, so a value with no valid variant is a
+real input the C handles and the Rust must handle identically).
+
+You MAY NOT proceed to Phase D while any `ERRORS.md` row is unchecked.
+
+### Phase D — Completion gate
+
+Verification is complete ONLY when ALL of these hold — re-read this list before
+declaring done, and do not stop early just because symbols match or the
+pre-existing tests are green:
+
+- [ ] `SYMBOLS.md`: `nm -D` shows 0 missing/undefined non-libc symbols in Rust.
+- [ ] Phase B: every public function passes a valid-path differential test.
+- [ ] Phase C: EVERY row in `ERRORS.md` has a passing error-path differential test.
+- [ ] If the project has a main binary, C and Rust stdout match byte-for-byte.
+
+If a prior session marked this project "complete" but there is no `ERRORS.md`
+with checked-off rows, it is NOT verified — build the table and do Phase C now.
+Symbol parity + a suite of passing happy-path tests is the state that HID the
+last escaped bug; the error-surface table exists specifically to prevent that.
 
 All operational rules (libloading dev-dep, c_src boundary, per-configuration
 re-verification, the 600-second timeout cap) live in the `## Invariants`

--- a/tools/verify_fix_agentic/src/prompt_claude_verify_no_plan.md
+++ b/tools/verify_fix_agentic/src/prompt_claude_verify_no_plan.md
@@ -21,13 +21,22 @@ Your task:
    Look at the C headers to identify the public API and function call hierarchy.
 4. For each function: create fixed test inputs, call both C and Rust versions,
    assert outputs match byte-for-byte
-5. Run `cargo test` and investigate any mismatches
-6. When you find a Rust function that produces different output than C,
+5. Do NOT test valid inputs only. A function can be byte-exact on well-formed
+   input yet diverge on rejection/boundary cases. For each public function also
+   feed INVALID, boundary, and malformed inputs and assert the Rust return
+   value / error code matches C EXACTLY (the same error, not just "both fail").
+   Find these cases from the C source: grep for how the C explicitly rejects
+   input (its error-return statements/macros, asserts, range and null checks,
+   min/max constants) and drive each of those branches in BOTH libraries; also
+   cover null pointers, zero/oversized lengths, and values just past a valid
+   range. Aim for branch coverage of error paths, not a fixed checklist.
+6. Run `cargo test` and investigate any mismatches
+7. When you find a Rust function that produces different output than C,
    fix the Rust code in src/ and re-run until the test passes
-7. Keep going until all public functions match
-8. If the project has a main binary, run both the C binary and the Rust binary
+8. Keep going until all public functions match
+9. If the project has a main binary, run both the C binary and the Rust binary
    with the same inputs and compare their stdout byte-for-byte. Fix any differences.
-9. Compare `nm -D` on the C .so and the Rust .so. Every symbol the C .so
+10. Compare `nm -D` on the C .so and the Rust .so. Every symbol the C .so
    exports, the Rust .so must also export with the exact same name. This
    includes symbols created by preprocessor macros. If the C .so exports it,
    the Rust .so must export it — no exceptions. Add missing exports.

--- a/tools/write_output/src/lib.rs
+++ b/tools/write_output/src/lib.rs
@@ -7,7 +7,25 @@ use std::path::{Path, PathBuf};
 use tracing::info;
 use try_cargo_build::CargoBuildResult;
 
-pub struct WriteOutput;
+/// Copies a built Cargo package to a destination directory.
+///
+/// By default (`WriteOutput` / `WriteOutput::new(None)`) the destination is
+/// `config.output`. An explicit override lets the pipeline emit an intermediate
+/// stage (e.g. the pre-verify translation) to a separate folder so both the
+/// translate-only and verified crates are preserved as independent outputs.
+#[derive(Default)]
+pub struct WriteOutput {
+    dest_override: Option<PathBuf>,
+}
+
+impl WriteOutput {
+    /// Write to an explicit directory instead of `config.output`.
+    pub fn to(dest: PathBuf) -> Self {
+        WriteOutput {
+            dest_override: Some(dest),
+        }
+    }
+}
 
 impl Tool for WriteOutput {
     fn name(&self) -> &'static str {
@@ -25,7 +43,7 @@ impl Tool for WriteOutput {
             .ok_or("WriteOutput: no CargoBuildResult found in IR")?;
 
         let src = build_result.root_path();
-        let dst = &context.config.output;
+        let dst = self.dest_override.as_ref().unwrap_or(&context.config.output);
         copy_dir_all(src, dst)?;
         info!("Output written to {}", dst.display());
 

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -23,6 +23,7 @@ thiserror.workspace = true
 tracing.workspace = true
 c_ast.workspace = true
 load_raw_source.workspace = true
+load_cargo_package.workspace = true
 build_config.workspace = true
 build_project_spec.workspace = true
 emit_build_features.workspace = true

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -14,8 +14,9 @@ use emit_build_features::EmitBuildFeatures;
 use fix_declarations_llm::FixDeclarationsLlm;
 use generate_difftest_suite::GenerateDiffTestSuite;
 use harvest_core::config::Config;
-use harvest_core::utils::get_version;
-use harvest_core::{HarvestIR, diagnostics};
+use harvest_core::utils::{empty_writable_dir, get_version};
+use harvest_core::{HarvestIR, Id, diagnostics};
+use load_cargo_package::LoadCargoPackage;
 use load_raw_source::LoadRawSource;
 use modular_translation_llm::ModularTranslationLlm;
 use quantize_rust_spans::QuantizeRustSpans;
@@ -30,6 +31,21 @@ use try_cargo_build::{CargoBuildResult, TryCargoBuild};
 use verify_fix_agentic::VerifyFixAgentic;
 use write_output::WriteOutput;
 
+/// Stage subdirectory names inside the `-o` output workspace. The output path
+/// is treated as a workspace anchor: the translation stage writes to
+/// `<output>/translated` and the verification stage to `<output>/verified`, so
+/// the two stages are self-describing and compose without the caller wiring up
+/// any input/output plumbing.
+const TRANSLATED_SUBDIR: &str = "translated";
+const VERIFIED_SUBDIR: &str = "verified";
+
+/// Returns true if `dir` looks like it already holds a translated crate (has a
+/// `Cargo.toml`). Used to decide whether the verify stage can load an existing
+/// translation instead of re-running translation from scratch.
+fn has_existing_crate(dir: &std::path::Path) -> bool {
+    dir.join("Cargo.toml").is_file()
+}
+
 /// Performs the complete transpilation process using the scheduler.
 pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::Error>> {
     // Basic tool setup
@@ -41,13 +57,53 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
     info!("Harvest version: {}", get_version());
     info!("Transpiling with: {}", config.model_info().unwrap());
 
+    // The `-o` path is a workspace anchor: translation writes to
+    // `<output>/translated`, verification writes to `<output>/verified`.
+    let translated_dir = config.output.join(TRANSLATED_SUBDIR);
+    let verified_dir = config.output.join(VERIFIED_SUBDIR);
+
+    // Resume seam: when the verify stage is requested and a translation already
+    // exists at `<output>/translated`, load it instead of re-translating. This
+    // lets `--agentic` then `--agentic-verify` compose on the same `-o` without
+    // repeating the (expensive) translation. If no prior translation exists,
+    // fall back to translating first, then verifying.
+    let resume_verify = config.agentic && config.agentic_verify && has_existing_crate(&translated_dir);
+
+    // Prepare the output workspace. We only empty the stage subdirs we are
+    // about to (re)write, so a resume-verify run preserves `<output>/translated`
+    // (its input) while still clearing a stale `<output>/verified`.
+    // `--force` controls whether a nonempty target subdir is erased vs errored.
+    std::fs::create_dir_all(&config.output)?;
+    if !resume_verify {
+        // A fresh translation (with or without verify) rewrites translated/.
+        empty_writable_dir(&translated_dir, config.force)?;
+    }
+    if config.agentic && config.agentic_verify {
+        empty_writable_dir(&verified_dir, config.force)?;
+    }
+
     // Setup a schedule for the transpilation.
     let load_src = scheduler.queue(LoadRawSource::new(&config.input));
     let build_cfg = scheduler.queue_after(BuildConfig, &[load_src]);
     let project_spec = scheduler.queue_after(BuildProjectSpec, &[load_src, build_cfg]);
-    let translate = if config.agentic {
+
+    // `translate_stage_pkg` is the CargoPackage id of the translation-only
+    // result (whether freshly translated or loaded from disk); `Some` only when
+    // that result should be (re)written to `<output>/translated`. When we
+    // resume from an existing translation we do not rewrite it.
+    let mut translate_stage_pkg: Option<Id> = None;
+
+    let translate = if resume_verify {
+        info!(
+            "Resuming: loading existing translation from {} (skipping translate stage)",
+            translated_dir.display()
+        );
+        let loaded = scheduler.queue(LoadCargoPackage::new(&translated_dir));
+        scheduler.queue_after(VerifyFixAgentic, &[loaded, load_src, build_cfg])
+    } else if config.agentic {
         let t = scheduler.queue_after(TranslateAgentic, &[load_src, project_spec, build_cfg]);
         if config.agentic_verify {
+            translate_stage_pkg = Some(t);
             scheduler.queue_after(VerifyFixAgentic, &[t, load_src, build_cfg])
         } else {
             t
@@ -74,6 +130,13 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
     let translate = scheduler.queue_after(EmitBuildFeatures, &[translate, build_cfg]);
     let mut current_pkg_id = translate;
     let mut current_build_id = scheduler.queue_after(TryCargoBuild, &[current_pkg_id]);
+
+    // Which subdir the FINAL result goes to: verify runs -> verified/, else translated/.
+    let final_dir = if config.agentic && config.agentic_verify {
+        verified_dir
+    } else {
+        translated_dir.clone()
+    };
 
     let result: Result<(), Box<dyn std::error::Error>> = (|| {
         // Run until all tasks are complete, respecting the dependencies declared in `queue_after`
@@ -109,7 +172,11 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
                 .kind,
             ProjectKind::Library
         );
-        if is_library {
+        // The built-in library difftest builds the original C with CMake, so it
+        // only applies to CMake projects. For autotools/make projects graded by
+        // an external harness, `internal_difftest = false` skips it while still
+        // writing the translated Rust output below.
+        if is_library && config.internal_difftest {
             let c_artifact = scheduler.queue_after(BuildCArtifact, &[load_src, project_spec]);
             let diff_suite = scheduler.queue_after(GenerateDiffTestSuite, &[load_src]);
             let diff_result_id =
@@ -124,7 +191,19 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
             );
         }
 
-        scheduler.queue_after(WriteOutput, &[current_build_id]);
+        // When we freshly translated AND then verified in the same run, also
+        // persist the translation-only crate to `<output>/translated` so both
+        // stages exist as independent, labeled outputs and a later verify can
+        // resume from it. (Skipped when resuming, since translated/ already
+        // exists on disk.) Build it first so WriteOutput has a CargoBuildResult.
+        if let Some(pre_id) = translate_stage_pkg {
+            let pre_build = scheduler.queue_after(TryCargoBuild, &[pre_id]);
+            scheduler
+                .queue_after(WriteOutput::to(config.output.join(TRANSLATED_SUBDIR)), &[pre_build]);
+        }
+
+        // Write the final result to its stage subdir (verified/ or translated/).
+        scheduler.queue_after(WriteOutput::to(final_dir.clone()), &[current_build_id]);
         scheduler.run_all(&mut runner, &mut ir, config)?;
 
         Ok(())

--- a/translate/src/main.rs
+++ b/translate/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use harvest_core::utils::empty_writable_dir;
 use harvest_translate::cli::{Args, initialize};
 use harvest_translate::transpile;
 use harvest_translate::util::set_user_only_umask;
@@ -18,7 +17,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let Some(config) = initialize(args) else {
         return Ok(()); // An early-exit argument was passed.
     };
-    empty_writable_dir(&config.output, config.force).expect("output directory error");
+    // Note: output-directory preparation happens inside `transpile`, which
+    // knows whether this is a resume-verify run (and must therefore preserve
+    // the existing `<output>/translated` crate rather than erase it).
     let ir = transpile(config.into())?;
     println!("{}", ir);
     Ok(())


### PR DESCRIPTION
## Summary

Enables running HARVEST on large real-world C libraries and hardens the agentic translate/verify pipeline. Validated end-to-end on **libsodium**, **libpng**, and **lz4**, each graded against the project's own test suite.

## What's included

**Build-system detection** (`tools/build_project_spec`)
- Detect project kind from `Makefile.am` (Automake primaries) when no `CMakeLists.txt` exists → autotools projects like libsodium now classify.
- Match indented `add_library()`/`add_executable()` (real CMakeLists indent targets inside `if()` blocks, e.g. libpng); prefer Library when both appear. Adds unit tests.

**Resumable two-stage pipeline + workspace outputs** (`translate/src/lib.rs`, new `tools/load_cargo_package`, `tools/write_output`)
- New `load_cargo_package` tool: lift an existing on-disk Rust crate into the IR (mirror of `load_raw_source`).
- `-o OUT` is now a workspace: translation → `OUT/translated`, verification → `OUT/verified`. `--agentic-verify` **resumes** from an existing `OUT/translated` (loads it, skips re-translation) rather than translating twice.
- `WriteOutput` gains an optional destination override; output-dir prep moved into `transpile()` so `--force` never erases the translation a resume needs.

**Config** (`core/src/config.rs`)
- `internal_difftest` flag (default `true`) to skip the CMake-based built-in library difftest for autotools/make projects graded by an external harness.

**Reliability** (`tools/verify_fix_agentic`)
- `timeout_secs = 0` disables the wall-clock cap for long verify runs.
- Log which prompt file actually reached the agent (source + size + markers).

**Agentic prompt fixes** (translate + verify prompts)
- **Sub-agent protocol:** the `Task` tool is synchronous; never "wait for a completion notification"; independently verify each sub-agent's output on disk before marking it done. Fixes agents ending their turn with delegated work orphaned (dropped modules / undefined symbols).
- **Phased verify workflow** with a mandatory error-surface table (`ERRORS.md`) grepped from the C source, an error-path differential test per row, and a completion gate stating symbol parity + passing tests is necessary-but-not-sufficient. Catches escaped rejection-path bugs (e.g. an out-of-range enum crossing the FFI boundary) that happy-path tests miss.

## Validation

| Project | Translate-only | Translate + Verify |
|---|---|---|
| libsodium | 102/104 | **104/104** |
| libpng | 0/51 (decode bug) | **51/51** |
| lz4 | block ✅ / frame ✗ | **block + frame ✅** |

Translate produces a *complete* crate (full symbol coverage); verify makes it *correct* (fixes behavioral bugs the native suite catches). `make test` passes.

## Notes
- Default behavior is preserved for existing CMake/TRACTOR cases: new config flags default to prior behavior, and prompt anti-regression tests still pass.