### PR TITLE
Test-repair loop PR 3/3: Repair loop for executables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generate_exec_difftests"
+version = "0.1.0"
+dependencies = [
+ "full_source",
+ "harvest_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1486,7 @@ dependencies = [
  "fix_diff_failures",
  "full_source",
  "generate_difftest_suite",
+ "generate_exec_difftests",
  "harvest_core",
  "libc",
  "load_raw_source",
@@ -1482,6 +1494,7 @@ dependencies = [
  "quantize_rust_spans",
  "raw_source_to_cargo_llm",
  "run_difftest",
+ "run_exec_difftest",
  "serde",
  "serde_json",
  "thiserror",
@@ -2459,6 +2472,20 @@ dependencies = [
  "full_source",
  "generate_difftest_suite",
  "harvest_core",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "run_exec_difftest"
+version = "0.1.0"
+dependencies = [
+ "build_c_artifact",
+ "exec_runner",
+ "full_source",
+ "generate_exec_difftests",
+ "harvest_core",
+ "run_difftest",
  "tempfile",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner", "tools/generate_difftest_suite", "tools/run_difftest", "tools/fix_diff_failures"]
+members = ["benchmark", "core", "tools/full_source", "tools/build_config", "tools/build_project_spec", "tools/emit_build_features", "tools/load_raw_source", "tools/raw_source_to_cargo_llm", "tools/try_cargo_build", "tools/write_output", "translate", "tools/c_ast", "tools/modular_translation_llm", "tools/quantize_rust_spans", "tools/fix_declarations_llm", "tools/translate_agentic", "tools/verify_fix_agentic", "tools/build_c_artifact", "tools/exec_runner", "tools/generate_difftest_suite", "tools/run_difftest", "tools/fix_diff_failures", "tools/generate_exec_difftests", "tools/run_exec_difftest"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -25,6 +25,8 @@ exec_runner = { path = "tools/exec_runner" }
 generate_difftest_suite = { path = "tools/generate_difftest_suite" }
 run_difftest = { path = "tools/run_difftest" }
 fix_diff_failures = { path = "tools/fix_diff_failures" }
+generate_exec_difftests = { path = "tools/generate_exec_difftests" }
+run_exec_difftest = { path = "tools/run_exec_difftest" }
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/tools/generate_exec_difftests/Cargo.toml
+++ b/tools/generate_exec_difftests/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "generate_exec_difftests"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+full_source.workspace = true
+harvest_core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/generate_exec_difftests/src/lib.rs
+++ b/tools/generate_exec_difftests/src/lib.rs
@@ -1,0 +1,133 @@
+use full_source::RawSource;
+use harvest_core::config::unknown_field_warning;
+use harvest_core::llm::{HarvestLLM, LLMConfig, LLMUsageTotals, build_request};
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tracing::info;
+
+const SCHEMA: &str = include_str!("structured_schema_inputs.json");
+const PROMPT: &str = include_str!("system_prompt_inputs.txt");
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// One set of inputs for a single executable invocation.
+#[derive(Serialize, Deserialize)]
+pub struct TestInput {
+    pub argv: Vec<String>,
+    pub stdin: String,
+}
+
+/// LLM-generated test inputs for an executable project.
+pub struct ExecTestInputs {
+    pub cases: Vec<TestInput>,
+}
+
+impl std::fmt::Display for ExecTestInputs {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "ExecTestInputs({} cases)", self.cases.len())
+    }
+}
+
+impl Representation for ExecTestInputs {
+    fn name(&self) -> &'static str {
+        "exec_test_inputs"
+    }
+}
+
+pub struct GenerateExecDifftests;
+
+// ── LLM request/response types ────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct InputFile {
+    path: String,
+    contents: String,
+}
+
+#[derive(Serialize)]
+struct RequestBody {
+    files: Vec<InputFile>,
+}
+
+#[derive(Deserialize)]
+struct LlmResponse {
+    test_cases: Vec<TestInput>,
+}
+
+// ── Tool implementation ───────────────────────────────────────────────────────
+
+impl Tool for GenerateExecDifftests {
+    fn name(&self) -> &'static str {
+        "generate_exec_difftests"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let config = Config::deserialize(
+            context
+                .config
+                .tools
+                .get("generate_exec_difftests")
+                .ok_or("generate_exec_difftests: missing config section")?,
+        )?;
+        config.validate();
+
+        let raw_source = context
+            .ir_snapshot
+            .get::<RawSource>(inputs[0])
+            .ok_or("generate_exec_difftests: no RawSource in IR")?;
+
+        let files = raw_source.dir.files_recursive();
+        let request_files = files
+            .iter()
+            .map(|(path, contents)| InputFile {
+                path: path.to_string_lossy().into_owned(),
+                contents: String::from_utf8_lossy(contents).into_owned(),
+            })
+            .collect();
+
+        let llm = HarvestLLM::build(&config.llm, SCHEMA, PROMPT)?;
+        let request = build_request(
+            "Generate test inputs for this C program:",
+            &RequestBody {
+                files: request_files,
+            },
+        )?;
+
+        let mut usage = LLMUsageTotals::default();
+        let (response, u) = llm.invoke(&request)?;
+        usage.add_usage(u.as_ref());
+        info!("Token usage [exec test input generation] - {usage:?}");
+
+        let parsed: LlmResponse = serde_json::from_str(&response)?;
+        info!(
+            "generate_exec_difftests: generated {} test inputs",
+            parsed.test_cases.len()
+        );
+
+        Ok(Box::new(ExecTestInputs {
+            cases: parsed.test_cases,
+        }))
+    }
+}
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    #[serde(flatten)]
+    pub llm: LLMConfig,
+    #[serde(flatten)]
+    unknown: HashMap<String, serde_json::Value>,
+}
+
+impl Config {
+    pub fn validate(&self) {
+        unknown_field_warning("tools.generate_exec_difftests", &self.unknown);
+    }
+}

--- a/tools/generate_exec_difftests/src/structured_schema_inputs.json
+++ b/tools/generate_exec_difftests/src/structured_schema_inputs.json
@@ -1,0 +1,25 @@
+{
+    "name": "exec_test_inputs",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "test_cases": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "argv": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                        },
+                        "stdin": { "type": "string" }
+                    },
+                    "required": ["argv", "stdin"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["test_cases"],
+        "additionalProperties": false
+    }
+}

--- a/tools/generate_exec_difftests/src/system_prompt_inputs.txt
+++ b/tools/generate_exec_difftests/src/system_prompt_inputs.txt
@@ -1,0 +1,15 @@
+You are a test input generator for C programs. Given C source files, generate a set of interesting test cases that exercise the program's behaviour.
+
+Return a JSON object with one array:
+
+"test_cases" — each entry represents one invocation of the program:
+- argv: array of command-line argument strings passed after the program name (empty array if none)
+- stdin: string of data to feed on standard input (empty string if the program reads no stdin)
+
+Guidelines:
+- Generate between 5 and 20 test cases depending on program complexity
+- Include a baseline case (empty or typical inputs)
+- Include boundary cases: empty input, very short input, longer input, numeric edge cases (0, -1, large numbers), special characters
+- If the program parses command-line flags or subcommands, exercise each one
+- If the program reads lines or records, include single-line, multi-line, and empty inputs
+- Do not include inputs that would cause the program to hang indefinitely

--- a/tools/run_exec_difftest/Cargo.toml
+++ b/tools/run_exec_difftest/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "run_exec_difftest"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+build_c_artifact.workspace = true
+exec_runner.workspace = true
+full_source.workspace = true
+generate_exec_difftests.workspace = true
+harvest_core.workspace = true
+run_difftest.workspace = true
+tempfile.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/tools/run_exec_difftest/src/lib.rs
+++ b/tools/run_exec_difftest/src/lib.rs
@@ -1,0 +1,178 @@
+use build_c_artifact::CArtifact;
+use full_source::CargoPackage;
+use generate_exec_difftests::{ExecTestInputs, TestInput};
+use harvest_core::cargo_utils::CargoToml;
+use harvest_core::tools::{RunContext, Tool};
+use harvest_core::{Id, Representation};
+use run_difftest::DiffTestResult;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+use tracing::info;
+
+const EXEC_TIMEOUT_SECS: u64 = 10;
+
+pub struct RunExecDiffTest;
+
+impl Tool for RunExecDiffTest {
+    fn name(&self) -> &'static str {
+        "run_exec_difftest"
+    }
+
+    fn run(
+        self: Box<Self>,
+        context: RunContext,
+        inputs: Vec<Id>,
+    ) -> Result<Box<dyn Representation>, Box<dyn std::error::Error>> {
+        let exec_test_inputs = context
+            .ir_snapshot
+            .get::<ExecTestInputs>(inputs[0])
+            .ok_or("run_exec_difftest: no ExecTestInputs in IR")?;
+        let c_artifact = context
+            .ir_snapshot
+            .get::<CArtifact>(inputs[1])
+            .ok_or("run_exec_difftest: no CArtifact in IR")?;
+        let cargo_package = context
+            .ir_snapshot
+            .get::<CargoPackage>(inputs[2])
+            .ok_or("run_exec_difftest: no CargoPackage in IR")?;
+
+        let Some(ref c_exe) = c_artifact.exe_path else {
+            info!("run_exec_difftest: project is not an executable; returning empty result");
+            return Ok(empty());
+        };
+        let c_exe = c_exe.clone();
+
+        if exec_test_inputs.cases.is_empty() {
+            info!("run_exec_difftest: no test inputs; returning empty result");
+            return Ok(empty());
+        }
+
+        // Materialize and build the Rust executable.
+        let rust_root = tempfile::tempdir()?;
+        cargo_package.materialize(rust_root.path())?;
+        let mut cargo_toml = CargoToml::open(&rust_root.path().join("Cargo.toml"))?;
+        cargo_toml.add_workspace();
+        cargo_toml.save()?;
+
+        info!("run_exec_difftest: building Rust executable...");
+        let status = Command::new("cargo")
+            .args(["build", "--release"])
+            .current_dir(rust_root.path())
+            .status()
+            .map_err(|e| format!("run_exec_difftest: failed to run cargo build: {e}"))?;
+        if !status.success() {
+            return Err("run_exec_difftest: cargo build --release failed".into());
+        }
+
+        let rust_exe = find_exe_in_dir(&rust_root.path().join("target/release"))
+            .ok_or("run_exec_difftest: no executable found in target/release")?;
+
+        // Run each test case against both binaries and compare outputs.
+        let timeout = Duration::from_secs(EXEC_TIMEOUT_SECS);
+        let mut passed = 0usize;
+        let mut failed = 0usize;
+        let mut failures: Vec<String> = Vec::new();
+
+        for (i, input) in exec_test_inputs.cases.iter().enumerate() {
+            let test_id = format!("T{:03}", i + 1);
+            let stdin = if input.stdin.is_empty() {
+                None
+            } else {
+                Some(input.stdin.as_str())
+            };
+
+            let c_out = match exec_runner::run_with_timeout(&c_exe, &input.argv, stdin, timeout) {
+                Ok(o) => o,
+                Err(e) => {
+                    info!("run_exec_difftest: {test_id} C run failed: {e}; skipping");
+                    continue;
+                }
+            };
+            let rust_out =
+                match exec_runner::run_with_timeout(&rust_exe, &input.argv, stdin, timeout) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        info!("run_exec_difftest: {test_id} Rust run failed: {e}; skipping");
+                        continue;
+                    }
+                };
+
+            let ctx = format_context(input);
+            let mut case_failures: Vec<String> = Vec::new();
+
+            if c_out.stdout != rust_out.stdout {
+                case_failures.push(format!("FAIL exec_{test_id} {ctx} field=stdout"));
+            }
+            if c_out.stderr != rust_out.stderr {
+                case_failures.push(format!("FAIL exec_{test_id} {ctx} field=stderr"));
+            }
+            let c_code = c_out.status.code().unwrap_or(-1);
+            let rust_code = rust_out.status.code().unwrap_or(-1);
+            if c_code != rust_code {
+                case_failures.push(format!(
+                    "FAIL exec_{test_id} {ctx} field=exit_code c={c_code} rust={rust_code}"
+                ));
+            }
+
+            if case_failures.is_empty() {
+                info!("run_exec_difftest: PASS exec_{test_id}");
+                passed += 1;
+            } else {
+                info!(
+                    "run_exec_difftest: FAIL exec_{test_id} ({} field(s))",
+                    case_failures.len()
+                );
+                failed += 1;
+                failures.extend(case_failures);
+            }
+        }
+
+        let total = passed + failed;
+        info!("run_exec_difftest: {passed}/{total} test cases passed");
+
+        Ok(Box::new(DiffTestResult {
+            passed,
+            failed,
+            total,
+            failures,
+        }))
+    }
+}
+
+fn format_context(input: &TestInput) -> String {
+    let argv_str = input.argv.join(",");
+    let stdin_preview: String = input.stdin.chars().take(40).collect();
+    let ellipsis = if input.stdin.chars().count() > 40 {
+        "..."
+    } else {
+        ""
+    };
+    format!("argv=[{argv_str}] stdin=\"{stdin_preview}{ellipsis}\"")
+}
+
+/// Returns the first regular file with the execute bit set and no extension found
+/// directly in `dir` (non-recursive).
+fn find_exe_in_dir(dir: &Path) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.is_file()
+            && path.extension().is_none()
+            && let Ok(meta) = std::fs::metadata(&path)
+            && meta.permissions().mode() & 0o111 != 0
+        {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn empty() -> Box<DiffTestResult> {
+    Box::new(DiffTestResult {
+        passed: 0,
+        failed: 0,
+        total: 0,
+        failures: vec![],
+    })
+}

--- a/translate/Cargo.toml
+++ b/translate/Cargo.toml
@@ -38,6 +38,8 @@ build_c_artifact.workspace = true
 generate_difftest_suite.workspace = true
 run_difftest.workspace = true
 fix_diff_failures.workspace = true
+generate_exec_difftests.workspace = true
+run_exec_difftest.workspace = true
 full_source.workspace = true
 
 [lints]

--- a/translate/default_config.toml
+++ b/translate/default_config.toml
@@ -39,6 +39,12 @@ backend = "ollama"
 model = "codellama:7b"
 max_tokens = 10000
 
+[tools.generate_exec_difftests]
+address = "http://localhost:11434"
+backend = "ollama"
+model = "codellama:7b"
+max_tokens = 10000
+
 [tools.translate_agentic]
 timeout_secs = 7200
 

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -15,6 +15,7 @@ use fix_declarations_llm::FixDeclarationsLlm;
 use fix_diff_failures::FixDiffFailures;
 use full_source::CargoPackage;
 use generate_difftest_suite::GenerateDiffTestSuite;
+use generate_exec_difftests::GenerateExecDifftests;
 use harvest_core::config::Config;
 use harvest_core::tools::Tool;
 use harvest_core::utils::get_version;
@@ -24,6 +25,7 @@ use modular_translation_llm::ModularTranslationLlm;
 use quantize_rust_spans::QuantizeRustSpans;
 use raw_source_to_cargo_llm::RawSourceToCargoLlm;
 use run_difftest::{DiffTestResult, RunDiffTest};
+use run_exec_difftest::RunExecDiffTest;
 use runner::ToolRunner;
 use scheduler::Scheduler;
 use std::sync::Arc;
@@ -101,18 +103,18 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
             }
         }
 
-        // Differential testing: for library projects, generate a C test harness that
-        // exercises the public API through both the original C build and the translated
-        // Rust candidate, and repair candidates that fail. Executable projects are not
-        // yet supported (see generate_exec_difftests / run_exec_difftest).
+        // Differential testing: generate a test harness that exercises the public API (for
+        // library projects) or the program's argv/stdin surface (for executables) through
+        // both the original C build and the translated Rust candidate, and repair
+        // candidates that fail.
         let is_library = matches!(
             ir.get::<ProjectSpec>(project_spec)
                 .ok_or("transpile: no ProjectSpec in IR")?
                 .kind,
             ProjectKind::Library
         );
+        let c_artifact = scheduler.queue_after(BuildCArtifact, &[load_src, project_spec]);
         if is_library {
-            let c_artifact = scheduler.queue_after(BuildCArtifact, &[load_src, project_spec]);
             let (pkg, build) = run_diff_test_and_repair(
                 &mut scheduler,
                 &mut runner,
@@ -124,6 +126,21 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
                 current_build_id,
                 || GenerateDiffTestSuite,
                 || RunDiffTest,
+            )?;
+            current_pkg_id = pkg;
+            current_build_id = build;
+        } else {
+            let (pkg, build) = run_diff_test_and_repair(
+                &mut scheduler,
+                &mut runner,
+                &mut ir,
+                &config,
+                load_src,
+                c_artifact,
+                current_pkg_id,
+                current_build_id,
+                || GenerateExecDifftests,
+                || RunExecDiffTest,
             )?;
             current_pkg_id = pkg;
             current_build_id = build;

--- a/translate/src/lib.rs
+++ b/translate/src/lib.rs
@@ -16,8 +16,9 @@ use fix_diff_failures::FixDiffFailures;
 use full_source::CargoPackage;
 use generate_difftest_suite::GenerateDiffTestSuite;
 use harvest_core::config::Config;
+use harvest_core::tools::Tool;
 use harvest_core::utils::get_version;
-use harvest_core::{HarvestIR, diagnostics};
+use harvest_core::{HarvestIR, Id, diagnostics};
 use load_raw_source::LoadRawSource;
 use modular_translation_llm::ModularTranslationLlm;
 use quantize_rust_spans::QuantizeRustSpans;
@@ -112,68 +113,20 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
         );
         if is_library {
             let c_artifact = scheduler.queue_after(BuildCArtifact, &[load_src, project_spec]);
-            let diff_suite = scheduler.queue_after(GenerateDiffTestSuite, &[load_src]);
-            let mut diff_result_id =
-                scheduler.queue_after(RunDiffTest, &[diff_suite, c_artifact, current_pkg_id]);
-            scheduler.run_all(&mut runner, &mut ir, config.clone())?;
-            let mut best_passed = ir
-                .get::<DiffTestResult>(diff_result_id)
-                .ok_or("transpile: no DiffTestResult in IR")?
-                .passed;
-
-            for _ in 0..config.max_diff_repair_passes {
-                let failed = ir
-                    .get::<DiffTestResult>(diff_result_id)
-                    .ok_or("transpile: no DiffTestResult in IR")?
-                    .failed;
-                if failed == 0 {
-                    break;
-                }
-
-                let fix = scheduler
-                    .queue_after(FixDiffFailures, &[diff_result_id, load_src, current_pkg_id]);
-                scheduler.run_all(&mut runner, &mut ir, config.clone())?;
-
-                // FixDiffFailures can itself hard-error (observed: the LLM returning a file
-                // list with a non-relative path, which RawDir::set_file rejects). If it does,
-                // `fix` never lands in the IR. Queuing TryCargoBuild/RunDiffTest on `fix`
-                // regardless would permanently strand them -- their input can never become
-                // ready -- which the scheduler treats as fatal (run_all errors out) rather
-                // than recoverable. Check first, and treat a missing `fix` as a rejected
-                // attempt, same as a downstream tool failing.
-                if ir.get::<CargoPackage>(fix).is_none() {
-                    continue;
-                }
-
-                let new_build = scheduler.queue_after(TryCargoBuild, &[fix]);
-                let new_diff_result_id =
-                    scheduler.queue_after(RunDiffTest, &[diff_suite, c_artifact, fix]);
-                scheduler.run_all(&mut runner, &mut ir, config.clone())?;
-
-                // RunDiffTest (unlike TryCargoBuild) hard-errors instead of encoding failure
-                // in its result -- e.g. if the LLM's patch doesn't build as a cdylib. The
-                // ToolRunner swallows that error and just never inserts the representation,
-                // so a missing Id here means "this repair attempt failed," not "the pipeline
-                // is broken." Treat it as a rejected candidate and keep iterating from the
-                // last-accepted state.
-                let Some(new_result) = ir.get::<DiffTestResult>(new_diff_result_id) else {
-                    continue;
-                };
-                if new_result.passed > best_passed {
-                    best_passed = new_result.passed;
-                    current_pkg_id = fix;
-                    current_build_id = new_build;
-                    diff_result_id = new_diff_result_id;
-                }
-            }
-
-            let diff_result = ir
-                .get::<DiffTestResult>(diff_result_id)
-                .ok_or("transpile: no DiffTestResult in IR")?;
-            info!(
-                "Diff test: {}/{} passed ({} failed)",
-                diff_result.passed, diff_result.total, diff_result.failed
-            );
+            let (pkg, build) = run_diff_test_and_repair(
+                &mut scheduler,
+                &mut runner,
+                &mut ir,
+                &config,
+                load_src,
+                c_artifact,
+                current_pkg_id,
+                current_build_id,
+                || GenerateDiffTestSuite,
+                || RunDiffTest,
+            )?;
+            current_pkg_id = pkg;
+            current_build_id = build;
         }
 
         scheduler.queue_after(WriteOutput, &[current_build_id]);
@@ -187,6 +140,91 @@ pub fn transpile(config: Arc<Config>) -> Result<HarvestIR, Box<dyn std::error::E
     collector.diagnostics(); // TODO: Return this value (see issue 51)
     result?;
     Ok(ir)
+}
+
+/// Runs one differential-test generate+run pass, then repeats an LLM-based repair loop
+/// (matching the build-repair loop's shape) until the candidate passes or
+/// `config.max_diff_repair_passes` is exhausted. Returns the (possibly updated) package and
+/// build Ids for the caller to use going forward (e.g. for `WriteOutput`).
+///
+/// `make_generate`/`make_run` construct fresh instances of the generate-suite and run-test
+/// tools for this project kind (library vs executable) -- each `queue_after` call needs its
+/// own owned `Tool` value, and the run-test tool is queued multiple times across repair passes.
+#[allow(clippy::too_many_arguments)]
+fn run_diff_test_and_repair<G: Tool, R: Tool>(
+    scheduler: &mut Scheduler,
+    runner: &mut ToolRunner,
+    ir: &mut HarvestIR,
+    config: &Arc<Config>,
+    load_src: Id,
+    c_artifact: Id,
+    mut current_pkg_id: Id,
+    mut current_build_id: Id,
+    make_generate: impl FnOnce() -> G,
+    make_run: impl Fn() -> R,
+) -> Result<(Id, Id), Box<dyn std::error::Error>> {
+    let diff_suite = scheduler.queue_after(make_generate(), &[load_src]);
+    let mut diff_result_id =
+        scheduler.queue_after(make_run(), &[diff_suite, c_artifact, current_pkg_id]);
+    scheduler.run_all(runner, ir, config.clone())?;
+    let mut best_passed = ir
+        .get::<DiffTestResult>(diff_result_id)
+        .ok_or("transpile: no DiffTestResult in IR")?
+        .passed;
+
+    for _ in 0..config.max_diff_repair_passes {
+        let failed = ir
+            .get::<DiffTestResult>(diff_result_id)
+            .ok_or("transpile: no DiffTestResult in IR")?
+            .failed;
+        if failed == 0 {
+            break;
+        }
+
+        let fix =
+            scheduler.queue_after(FixDiffFailures, &[diff_result_id, load_src, current_pkg_id]);
+        scheduler.run_all(runner, ir, config.clone())?;
+
+        // FixDiffFailures can itself hard-error (observed: the LLM returning a file
+        // list with a non-relative path, which RawDir::set_file rejects). If it does,
+        // `fix` never lands in the IR. Queuing TryCargoBuild/RunDiffTest on `fix`
+        // regardless would permanently strand them -- their input can never become
+        // ready -- which the scheduler treats as fatal (run_all errors out) rather
+        // than recoverable. Check first, and treat a missing `fix` as a rejected
+        // attempt, same as a downstream tool failing.
+        if ir.get::<CargoPackage>(fix).is_none() {
+            continue;
+        }
+
+        let new_build = scheduler.queue_after(TryCargoBuild, &[fix]);
+        let new_diff_result_id = scheduler.queue_after(make_run(), &[diff_suite, c_artifact, fix]);
+        scheduler.run_all(runner, ir, config.clone())?;
+
+        // The run-test tool (unlike TryCargoBuild) hard-errors instead of encoding failure
+        // in its result -- e.g. if the LLM's patch doesn't build as a cdylib. The
+        // ToolRunner swallows that error and just never inserts the representation, so a
+        // missing Id here means "this repair attempt failed," not "the pipeline is broken."
+        // Treat it as a rejected candidate and keep iterating from the last-accepted state.
+        let Some(new_result) = ir.get::<DiffTestResult>(new_diff_result_id) else {
+            continue;
+        };
+        if new_result.passed > best_passed {
+            best_passed = new_result.passed;
+            current_pkg_id = fix;
+            current_build_id = new_build;
+            diff_result_id = new_diff_result_id;
+        }
+    }
+
+    let diff_result = ir
+        .get::<DiffTestResult>(diff_result_id)
+        .ok_or("transpile: no DiffTestResult in IR")?;
+    info!(
+        "Diff test: {}/{} passed ({} failed)",
+        diff_result.passed, diff_result.total, diff_result.failed
+    );
+
+    Ok((current_pkg_id, current_build_id))
 }
 
 #[cfg(not(miri))]


### PR DESCRIPTION
This PR takes the work done in #183 and extends it to testing executables. This required:
1. Adding a tool `generate_exec_difftests` that takes as input the C source code, and produces a suite of tests. Each of these tests synthesize `argv` and `stdin` to run the executable under.
2. Integration of this logic into the main difftest-repair loop (very simple, just an if branch on whether the tool is an executable).